### PR TITLE
Fix using identical `key` props in <App>

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -196,7 +196,7 @@ function AppContent() {
         {currentView === "live" && (
           <div className="live-view">
             {latestShot && (
-              <div key={latestShot.timestamp} className="shot-flash" />
+              <div key={`shot-flash-${latestShot.timestamp}`} className="shot-flash" />
             )}
             <ShotDisplay
               key={latestShot?.timestamp}


### PR DESCRIPTION
Two elements were using the same `key` prop here, leading to warnings in the javascript console. Using a prefix for one of them will help.