### PR TITLE
Add optional second K-LD7 tracker for dual-radar setups

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - K-LD7 launch-angle processing now uses OPS243 impact timestamps for live correlation
 - K-LD7 ball-burst selection now prefers coherent far-target paths instead of averaging all far PDAT detections
 - Live K-LD7 vertical launch angles now fall back to the existing club-and-speed estimate when the radar result is an obvious false positive
+- Dual-radar launch angle data now keeps per-axis source/confidence metadata, and horizontal angle stays `unknown` instead of defaulting to `0.0°` when no sensor measured it
 - Spin detection improved: Hann windowing, zero-padding to 256 points, band-limited search
 - All shot metrics (spin, launch angle, club speed, carry) always shown in UI
 - Shot logging unified — all metrics in single `shot_detected` entry

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Optional second K-LD7 connector for dual-radar setups
+  - `--kld7-secondary-port` and `--kld7-secondary-orientation` server flags
+  - `start-kiosk.sh` support for wiring a second K-LD7 without changing the single-radar flow
 - K-LD7 shot-correlation analysis workflow and theory writeup
   - `scripts/analyze_kld7.py --pair-shots` for offline club-to-ball pairing on `.pkl` captures
   - `docs/kld7-ball-detection-theory.md` with capture findings and detection rationale

--- a/scripts/start-kiosk.sh
+++ b/scripts/start-kiosk.sh
@@ -21,6 +21,8 @@ BUFFER_SPLIT=""
 KLD7=false
 KLD7_PORT=""
 KLD7_ORIENTATION=""
+KLD7_SECONDARY_PORT=""
+KLD7_SECONDARY_ORIENTATION=""
 
 # Buffer split presets (pre/post trigger segments out of 32 total)
 # At 20ksps: each segment = 6.4ms, total buffer = 204.8ms
@@ -87,6 +89,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --kld7-orientation)
             KLD7_ORIENTATION="$2"
+            shift 2
+            ;;
+        --kld7-secondary-port)
+            KLD7_SECONDARY_PORT="$2"
+            shift 2
+            ;;
+        --kld7-secondary-orientation)
+            KLD7_SECONDARY_ORIENTATION="$2"
             shift 2
             ;;
         --port|-p)
@@ -196,6 +206,14 @@ fi
 
 if [ -n "$KLD7_ORIENTATION" ]; then
     SERVER_CMD="$SERVER_CMD --kld7-orientation $KLD7_ORIENTATION"
+fi
+
+if [ -n "$KLD7_SECONDARY_PORT" ]; then
+    SERVER_CMD="$SERVER_CMD --kld7-secondary-port $KLD7_SECONDARY_PORT"
+fi
+
+if [ -n "$KLD7_SECONDARY_ORIENTATION" ]; then
+    SERVER_CMD="$SERVER_CMD --kld7-secondary-orientation $KLD7_SECONDARY_ORIENTATION"
 fi
 
 # Start Grafana Alloy for log shipping (if installed and credentials configured)

--- a/src/openflight/launch_monitor.py
+++ b/src/openflight/launch_monitor.py
@@ -232,9 +232,10 @@ class Shot:
         peak_magnitude: Signal strength of strongest reading
         readings: All raw speed readings for this shot
         club: Club type for distance estimation
-        launch_angle_vertical: Vertical launch angle in degrees (from camera)
-        launch_angle_horizontal: Horizontal launch angle in degrees (from camera)
-        launch_angle_confidence: Confidence in launch angle measurement (0-1)
+        launch_angle_vertical: Vertical launch angle in degrees
+        launch_angle_horizontal: Horizontal launch angle in degrees
+        launch_angle_confidence: Confidence in vertical launch angle measurement (0-1)
+        launch_angle_horizontal_confidence: Confidence in horizontal launch angle measurement (0-1)
         spin_rpm: Spin rate in RPM (from rolling buffer mode)
         spin_confidence: Confidence in spin measurement (0-1)
         carry_spin_adjusted: Carry distance adjusted for spin (yards)
@@ -252,12 +253,14 @@ class Shot:
     launch_angle_vertical: Optional[float] = None
     launch_angle_horizontal: Optional[float] = None
     launch_angle_confidence: Optional[float] = None
+    launch_angle_horizontal_confidence: Optional[float] = None
     spin_rpm: Optional[float] = None
     spin_confidence: Optional[float] = None
     carry_spin_adjusted: Optional[float] = None
     mode: str = "rolling-buffer"
     readings_data: Optional[list] = None
     angle_source: Optional[str] = None  # "radar", "camera", "estimated", or None
+    launch_angle_horizontal_source: Optional[str] = None  # "radar", "camera", "estimated", or None
     club_angle_deg: Optional[float] = None  # Club angle of attack from K-LD7
 
     @property

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -266,7 +266,9 @@ def shot_to_dict(shot: Shot) -> dict:
         "launch_angle_vertical": shot.launch_angle_vertical,
         "launch_angle_horizontal": shot.launch_angle_horizontal,
         "launch_angle_confidence": shot.launch_angle_confidence,
+        "launch_angle_horizontal_confidence": shot.launch_angle_horizontal_confidence,
         "angle_source": shot.angle_source,
+        "launch_angle_horizontal_source": shot.launch_angle_horizontal_source,
         "club_angle_deg": shot.club_angle_deg,
         # Spin data from rolling buffer mode
         "spin_rpm": round(shot.spin_rpm) if shot.spin_rpm else None,
@@ -939,9 +941,8 @@ def _process_kld7_tracker(
             if kld7_angle.horizontal_deg is not None:
                 if shot.launch_angle_horizontal is None:
                     shot.launch_angle_horizontal = kld7_angle.horizontal_deg
-                    if shot.angle_source is None:
-                        shot.angle_source = "radar"
-                        shot.launch_angle_confidence = kld7_angle.confidence
+                    shot.launch_angle_horizontal_confidence = kld7_angle.confidence
+                    shot.launch_angle_horizontal_source = "radar"
                     logger.info(
                         "K-LD7 [%s] horizontal angle: %.1f° (conf: %.0f%%)",
                         tracker_label,
@@ -1039,11 +1040,15 @@ def on_shot_detected(shot: Shot):
         ):
             launch_angle = camera_tracker.calculate_launch_angle()
             if launch_angle:
-                # Update shot object with launch angle data
+                # Fill only missing axes so a measured radar horizontal angle
+                # survives camera-based vertical fallback.
                 shot.launch_angle_vertical = launch_angle.vertical
-                shot.launch_angle_horizontal = launch_angle.horizontal
                 shot.launch_angle_confidence = launch_angle.confidence
                 shot.angle_source = "camera"
+                if shot.launch_angle_horizontal is None:
+                    shot.launch_angle_horizontal = launch_angle.horizontal
+                    shot.launch_angle_horizontal_confidence = launch_angle.confidence
+                    shot.launch_angle_horizontal_source = "camera"
 
                 camera_data = {
                     "launch_angle_vertical": launch_angle.vertical,
@@ -1076,8 +1081,6 @@ def on_shot_detected(shot: Shot):
             spin_rpm=shot.spin_rpm,
         )
         shot.launch_angle_vertical = estimated[0]
-        if shot.launch_angle_horizontal is None:
-            shot.launch_angle_horizontal = 0.0
         shot.launch_angle_confidence = estimated[1]
         shot.angle_source = "estimated"
         logger.info(
@@ -1105,6 +1108,9 @@ def on_shot_detected(shot: Shot):
                 launch_angle_vertical=shot.launch_angle_vertical,
                 launch_angle_horizontal=shot.launch_angle_horizontal,
                 launch_angle_confidence=shot.launch_angle_confidence,
+                launch_angle_horizontal_confidence=shot.launch_angle_horizontal_confidence,
+                angle_source=shot.angle_source,
+                launch_angle_horizontal_source=shot.launch_angle_horizontal_source,
             )
     except Exception as e:
         logger.warning("Failed to log shot: %s", e)
@@ -1365,6 +1371,7 @@ class MockLaunchMonitor:
 
         # Generate club angle of attack (negative for irons, near-zero for driver)
         club_aoa = round(random.gauss(-4.0, 2.5), 1)
+        launch_confidence = round(random.uniform(0.5, 0.95), 2)
 
         shot = Shot(
             ball_speed_mph=ball_speed,
@@ -1375,7 +1382,10 @@ class MockLaunchMonitor:
             spin_confidence=random.choice([0.3, 0.6, 0.7, 0.9]),
             launch_angle_vertical=round(launch_v, 1),
             launch_angle_horizontal=round(launch_h, 1),
-            launch_angle_confidence=round(random.uniform(0.5, 0.95), 2),
+            launch_angle_confidence=launch_confidence,
+            launch_angle_horizontal_confidence=launch_confidence,
+            angle_source="estimated",
+            launch_angle_horizontal_source="estimated",
             club_angle_deg=club_aoa,
             mode="mock",
         )

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -59,6 +59,7 @@ debug_log_path: Optional[Path] = None
 
 # K-LD7 angle radar
 kld7_tracker = None
+kld7_tracker_secondary = None
 
 # Camera state
 camera: Optional["Picamera2"] = None
@@ -360,23 +361,60 @@ def init_camera(
         return False
 
 
+def _build_kld7_tracker(port=None, orientation="vertical"):
+    """Construct and start one K-LD7 tracker instance."""
+    from openflight.kld7 import KLD7Tracker
+
+    tracker = KLD7Tracker(port=port, orientation=orientation)
+    if tracker.connect():
+        tracker.start()
+        return tracker
+    return None
+
+
 def init_kld7(port=None, orientation="vertical") -> bool:
-    """Initialize K-LD7 angle radar tracker."""
+    """Initialize the primary K-LD7 angle radar tracker."""
     global kld7_tracker  # pylint: disable=global-statement
     try:
-        from openflight.kld7 import KLD7Tracker
-
-        kld7_tracker = KLD7Tracker(port=port, orientation=orientation)
-        if kld7_tracker.connect():
-            kld7_tracker.start()
-            return True
-        else:
-            kld7_tracker = None
-            return False
+        kld7_tracker = _build_kld7_tracker(port=port, orientation=orientation)
+        return kld7_tracker is not None
     except Exception as e:
         logger.warning("K-LD7 initialization failed: %s", e)
         kld7_tracker = None
         return False
+
+
+def init_kld7_secondary(port=None, orientation="horizontal") -> bool:
+    """Initialize an optional second K-LD7 tracker."""
+    global kld7_tracker_secondary  # pylint: disable=global-statement
+    try:
+        kld7_tracker_secondary = _build_kld7_tracker(port=port, orientation=orientation)
+        return kld7_tracker_secondary is not None
+    except Exception as e:
+        logger.warning("Secondary K-LD7 initialization failed: %s", e)
+        kld7_tracker_secondary = None
+        return False
+
+
+def active_kld7_trackers():
+    """Return configured K-LD7 trackers in processing order."""
+    trackers = []
+    if kld7_tracker:
+        trackers.append(("primary", kld7_tracker))
+    if kld7_tracker_secondary:
+        trackers.append(("secondary", kld7_tracker_secondary))
+    return trackers
+
+
+def stop_kld7_trackers():
+    """Stop any running K-LD7 trackers."""
+    global kld7_tracker, kld7_tracker_secondary  # pylint: disable=global-statement
+
+    for tracker in (kld7_tracker, kld7_tracker_secondary):
+        if tracker:
+            tracker.stop()
+    kld7_tracker = None
+    kld7_tracker_secondary = None
 
 
 def camera_processing_loop():
@@ -837,6 +875,134 @@ def handle_set_radar_config(data):
         socketio.emit("radar_config_error", {"error": str(e)})
 
 
+def _process_kld7_tracker(
+    tracker_label: str,
+    tracker,
+    shot: Shot,
+    shot_ts: float,
+    session_log=None,
+    shot_number: Optional[int] = None,
+):
+    """Correlate one K-LD7 tracker against the current shot."""
+    kld7_start = time.time()
+    raw_buffer = []
+    kld7_angle = None
+    club_angle = None
+    radar_vertical_accepted = True
+    radar_guard_details = None
+
+    try:
+        raw_buffer = tracker.snapshot_buffer()
+        kld7_angle = tracker.get_angle_for_shot(shot_timestamp=shot_ts)
+
+        if kld7_angle and kld7_angle.vertical_deg is not None:
+            radar_vertical_accepted, radar_guard_details = radar_launch_is_plausible(
+                radar_angle_deg=kld7_angle.vertical_deg,
+                club=shot.club,
+                ball_speed_mph=shot.ball_speed_mph,
+                club_speed_mph=shot.club_speed_mph,
+                spin_rpm=shot.spin_rpm,
+            )
+            if not radar_vertical_accepted:
+                logger.warning(
+                    "K-LD7 [%s] vertical angle %.1f° rejected for %s at %.1f mph: "
+                    "expected %.1f° ± %.1f° (delta %.1f°)",
+                    tracker_label,
+                    kld7_angle.vertical_deg,
+                    shot.club.value,
+                    shot.ball_speed_mph,
+                    radar_guard_details["expected_launch_deg"],
+                    radar_guard_details["allowed_delta_deg"],
+                    radar_guard_details["delta_deg"],
+                )
+
+        if kld7_angle:
+            if kld7_angle.vertical_deg is not None and radar_vertical_accepted:
+                if shot.launch_angle_vertical is None:
+                    shot.launch_angle_vertical = kld7_angle.vertical_deg
+                    shot.launch_angle_confidence = kld7_angle.confidence
+                    shot.angle_source = "radar"
+                    logger.info(
+                        "K-LD7 [%s] %s angle: %.1f° (conf: %.0f%%, %d frames)",
+                        tracker_label,
+                        kld7_angle.detection_class or "vertical",
+                        kld7_angle.vertical_deg,
+                        kld7_angle.confidence * 100,
+                        kld7_angle.num_frames,
+                    )
+                else:
+                    logger.warning(
+                        "Ignoring duplicate K-LD7 vertical angle from %s tracker",
+                        tracker_label,
+                    )
+
+            if kld7_angle.horizontal_deg is not None:
+                if shot.launch_angle_horizontal is None:
+                    shot.launch_angle_horizontal = kld7_angle.horizontal_deg
+                    if shot.angle_source is None:
+                        shot.angle_source = "radar"
+                        shot.launch_angle_confidence = kld7_angle.confidence
+                    logger.info(
+                        "K-LD7 [%s] horizontal angle: %.1f° (conf: %.0f%%)",
+                        tracker_label,
+                        kld7_angle.horizontal_deg,
+                        kld7_angle.confidence * 100,
+                    )
+                else:
+                    logger.warning(
+                        "Ignoring duplicate K-LD7 horizontal angle from %s tracker",
+                        tracker_label,
+                    )
+
+        if tracker.orientation == "vertical" and shot.club_angle_deg is None:
+            club_angle = tracker.get_club_angle(shot_timestamp=shot_ts)
+            if club_angle and club_angle.vertical_deg is not None:
+                shot.club_angle_deg = club_angle.vertical_deg
+                logger.info(
+                    "K-LD7 [%s] club angle: %.1f° (conf: %.0f%%)",
+                    tracker_label,
+                    club_angle.vertical_deg,
+                    club_angle.confidence * 100,
+                )
+
+        if session_log and raw_buffer and shot_number is not None:
+            session_log.log_kld7_buffer(
+                shot_number=shot_number,
+                shot_timestamp=shot_ts,
+                orientation=tracker.orientation,
+                buffer_frames=raw_buffer,
+                ball_angle={
+                    "vertical_deg": kld7_angle.vertical_deg,
+                    "horizontal_deg": kld7_angle.horizontal_deg,
+                    "confidence": kld7_angle.confidence,
+                    "detection_class": kld7_angle.detection_class,
+                    "magnitude": kld7_angle.magnitude,
+                    "num_frames": kld7_angle.num_frames,
+                    "accepted": radar_vertical_accepted,
+                    "sanity_check": radar_guard_details,
+                } if kld7_angle else None,
+                club_angle={
+                    "vertical_deg": club_angle.vertical_deg,
+                    "horizontal_deg": club_angle.horizontal_deg,
+                    "confidence": club_angle.confidence,
+                    "magnitude": club_angle.magnitude,
+                    "num_frames": club_angle.num_frames,
+                } if club_angle else None,
+            )
+    except Exception as e:
+        logger.warning("K-LD7 [%s] processing error: %s", tracker_label, e)
+    finally:
+        try:
+            tracker.reset()
+        except Exception:
+            logger.debug("K-LD7 [%s] reset failed", tracker_label, exc_info=True)
+        logger.info(
+            "[PERF] K-LD7 %s processing: %.1fms",
+            tracker_label,
+            (time.time() - kld7_start) * 1000,
+        )
+
+
 def on_shot_detected(shot: Shot):
     """Callback when a shot is detected - emit to all clients."""
     global ball_detected, ball_detection_confidence  # pylint: disable=global-statement
@@ -844,104 +1010,33 @@ def on_shot_detected(shot: Shot):
     logger.debug("Shot callback triggered: %.1f mph", shot.ball_speed_mph)
 
     # Try K-LD7 angle radar first (highest priority for angle data)
-    try:
-        if kld7_tracker and shot.mode != "mock":
-            kld7_start = time.time()
-            shot_ts = shot.impact_timestamp or kld7_start
-            radar_vertical_accepted = True
-            radar_guard_details = None
-
-            # Snapshot raw buffer BEFORE processing (for correlation analysis)
-            raw_buffer = kld7_tracker.snapshot_buffer()
-
-            kld7_angle = kld7_tracker.get_angle_for_shot(
-                shot_timestamp=shot_ts
-            )
-            if kld7_angle and kld7_angle.vertical_deg is not None:
-                radar_vertical_accepted, radar_guard_details = radar_launch_is_plausible(
-                    radar_angle_deg=kld7_angle.vertical_deg,
-                    club=shot.club,
-                    ball_speed_mph=shot.ball_speed_mph,
-                    club_speed_mph=shot.club_speed_mph,
-                    spin_rpm=shot.spin_rpm,
-                )
-                if not radar_vertical_accepted:
-                    logger.warning(
-                        "K-LD7 vertical angle %.1f° rejected for %s at %.1f mph: "
-                        "expected %.1f° ± %.1f° (delta %.1f°)",
-                        kld7_angle.vertical_deg,
-                        shot.club.value,
-                        shot.ball_speed_mph,
-                        radar_guard_details["expected_launch_deg"],
-                        radar_guard_details["allowed_delta_deg"],
-                        radar_guard_details["delta_deg"],
-                    )
-            if kld7_angle:
-                if kld7_angle.vertical_deg is not None and radar_vertical_accepted:
-                    shot.launch_angle_vertical = kld7_angle.vertical_deg
-                    shot.launch_angle_confidence = kld7_angle.confidence
-                    shot.angle_source = "radar"
-                    logger.info(
-                        "K-LD7 %s angle: %.1f° (conf: %.0f%%, %d frames)",
-                        kld7_angle.detection_class or "vertical",
-                        kld7_angle.vertical_deg, kld7_angle.confidence * 100,
-                        kld7_angle.num_frames,
-                    )
-                if kld7_angle.horizontal_deg is not None:
-                    shot.launch_angle_horizontal = kld7_angle.horizontal_deg
-                    if shot.angle_source is None:
-                        shot.angle_source = "radar"
-                        shot.launch_angle_confidence = kld7_angle.confidence
-                    logger.info(
-                        "K-LD7 horizontal angle: %.1f° (conf: %.0f%%)",
-                        kld7_angle.horizontal_deg, kld7_angle.confidence * 100,
-                    )
-            # Also get club angle of attack
-            club_angle = kld7_tracker.get_club_angle(shot_timestamp=shot_ts)
-            if club_angle and club_angle.vertical_deg is not None:
-                shot.club_angle_deg = club_angle.vertical_deg
-                logger.info(
-                    "K-LD7 club angle: %.1f° (conf: %.0f%%)",
-                    club_angle.vertical_deg, club_angle.confidence * 100,
-                )
-
-            # Log raw K-LD7 buffer alongside OPS shot for correlation analysis
+    if shot.mode != "mock":
+        trackers = active_kld7_trackers()
+        if trackers:
+            shot_ts = shot.impact_timestamp or time.time()
             session_log = get_session_logger()
-            if session_log and raw_buffer:
-                session_log.log_kld7_buffer(
-                    shot_number=session_log.stats.get("shots_detected", 0) + 1,
-                    shot_timestamp=shot_ts,
-                    orientation=kld7_tracker.orientation,
-                    buffer_frames=raw_buffer,
-                    ball_angle={
-                        "vertical_deg": kld7_angle.vertical_deg,
-                        "confidence": kld7_angle.confidence,
-                        "detection_class": kld7_angle.detection_class,
-                        "magnitude": kld7_angle.magnitude,
-                        "num_frames": kld7_angle.num_frames,
-                        "accepted": radar_vertical_accepted,
-                        "sanity_check": radar_guard_details,
-                    } if kld7_angle else None,
-                    club_angle={
-                        "vertical_deg": club_angle.vertical_deg,
-                        "confidence": club_angle.confidence,
-                        "magnitude": club_angle.magnitude,
-                        "num_frames": club_angle.num_frames,
-                    } if club_angle and club_angle.vertical_deg is not None else None,
+            shot_number = session_log.stats.get("shots_detected", 0) + 1 if session_log else None
+            for tracker_label, tracker in trackers:
+                _process_kld7_tracker(
+                    tracker_label=tracker_label,
+                    tracker=tracker,
+                    shot=shot,
+                    shot_ts=shot_ts,
+                    session_log=session_log,
+                    shot_number=shot_number,
                 )
-
-            kld7_tracker.reset()
-            kld7_ms = (time.time() - kld7_start) * 1000
-            logger.info("[PERF] K-LD7 processing: %.1fms", kld7_ms)
-    except Exception as e:
-        logger.warning("K-LD7 processing error: %s", e)
 
     # Try to get launch angle from camera BEFORE emitting shot
     # Skip camera for mock shots — they already have simulated launch angle
     # Skip if K-LD7 already provided vertical angle
     camera_data = None
     try:
-        if camera_tracker and camera_enabled and shot.mode != "mock" and shot.launch_angle_vertical is None:
+        if (
+            camera_tracker
+            and camera_enabled
+            and shot.mode != "mock"
+            and shot.launch_angle_vertical is None
+        ):
             launch_angle = camera_tracker.calculate_launch_angle()
             if launch_angle:
                 # Update shot object with launch angle data
@@ -981,7 +1076,8 @@ def on_shot_detected(shot: Shot):
             spin_rpm=shot.spin_rpm,
         )
         shot.launch_angle_vertical = estimated[0]
-        shot.launch_angle_horizontal = 0.0
+        if shot.launch_angle_horizontal is None:
+            shot.launch_angle_horizontal = 0.0
         shot.launch_angle_confidence = estimated[1]
         shot.angle_source = "estimated"
         logger.info(
@@ -1437,6 +1533,17 @@ def main():
         default="vertical",
         help="K-LD7 mount orientation — which angle plane it measures (default: vertical)",
     )
+    parser.add_argument(
+        "--kld7-secondary-port",
+        default=None,
+        help="Optional second K-LD7 serial port for dual-radar setup",
+    )
+    parser.add_argument(
+        "--kld7-secondary-orientation",
+        choices=["vertical", "horizontal"],
+        default="horizontal",
+        help="Optional second K-LD7 mount orientation (default: horizontal)",
+    )
     args = parser.parse_args()
 
     # Configure logging - always show INFO and above for openflight modules
@@ -1514,6 +1621,19 @@ def main():
             print(f"K-LD7 angle radar enabled (orientation: {args.kld7_orientation})")
         else:
             print("K-LD7 not available - running without angle radar")
+        if args.kld7_secondary_port:
+            if init_kld7_secondary(
+                port=args.kld7_secondary_port,
+                orientation=args.kld7_secondary_orientation,
+            ):
+                print(
+                    "Second K-LD7 angle radar enabled "
+                    f"(orientation: {args.kld7_secondary_orientation})"
+                )
+            else:
+                print("Second K-LD7 not available - continuing with primary radar only")
+    elif args.kld7_secondary_port:
+        print("Ignoring secondary K-LD7 config because --kld7 was not enabled")
 
     start_monitor(
         port=args.port,
@@ -1538,8 +1658,7 @@ def main():
             app, host=args.host, port=args.web_port, debug=False, allow_unsafe_werkzeug=True
         )
     finally:
-        if kld7_tracker:
-            kld7_tracker.stop()
+        stop_kld7_trackers()
         stop_camera_thread()
         if camera:
             camera.stop()

--- a/src/openflight/session_logger.py
+++ b/src/openflight/session_logger.py
@@ -263,6 +263,9 @@ class SessionLogger:
         launch_angle_vertical: Optional[float] = None,
         launch_angle_horizontal: Optional[float] = None,
         launch_angle_confidence: Optional[float] = None,
+        launch_angle_horizontal_confidence: Optional[float] = None,
+        angle_source: Optional[str] = None,
+        launch_angle_horizontal_source: Optional[str] = None,
     ):
         """
         Log a detected shot with all metrics.
@@ -281,6 +284,9 @@ class SessionLogger:
             spin_quality: Quality assessment ("high", "medium", "low")
             carry_spin_adjusted: Carry distance adjusted for spin (rolling buffer mode only)
             mode: Radar mode ("rolling-buffer" or "mock")
+            launch_angle_horizontal_confidence: Confidence for horizontal launch angle
+            angle_source: Source for vertical launch angle
+            launch_angle_horizontal_source: Source for horizontal launch angle
         """
         if not self.enabled:
             return
@@ -305,6 +311,9 @@ class SessionLogger:
             "launch_angle_vertical": launch_angle_vertical,
             "launch_angle_horizontal": launch_angle_horizontal,
             "launch_angle_confidence": launch_angle_confidence,
+            "launch_angle_horizontal_confidence": launch_angle_horizontal_confidence,
+            "angle_source": angle_source,
+            "launch_angle_horizontal_source": launch_angle_horizontal_source,
         })
 
     def log_camera_data(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -88,6 +88,20 @@ class TestShotToDict:
         result = shot_to_dict(shot)
         assert result["angle_source"] is None
 
+    def test_horizontal_angle_fields(self):
+        """shot_to_dict should include horizontal provenance fields."""
+        shot = Shot(
+            ball_speed_mph=150.0,
+            timestamp=datetime.now(),
+            launch_angle_horizontal=-3.2,
+            launch_angle_horizontal_confidence=0.74,
+            launch_angle_horizontal_source="radar",
+        )
+        result = shot_to_dict(shot)
+        assert result["launch_angle_horizontal"] == -3.2
+        assert result["launch_angle_horizontal_confidence"] == 0.74
+        assert result["launch_angle_horizontal_source"] == "radar"
+
 
 class TestEstimateLaunchAngle:
     """Tests for launch angle estimation from club type and ball speed."""
@@ -605,3 +619,88 @@ class TestOnShotDetected:
 
         assert shot.launch_angle_vertical == pytest.approx(20.5)
         assert shot.launch_angle_horizontal == pytest.approx(4.4)
+        assert shot.launch_angle_confidence == pytest.approx(0.2)
+        assert shot.angle_source == "estimated"
+        assert shot.launch_angle_horizontal_confidence == pytest.approx(0.7)
+        assert shot.launch_angle_horizontal_source == "radar"
+
+    def test_estimate_fallback_does_not_invent_horizontal_angle(self, monkeypatch):
+        """Estimate fallback should leave horizontal angle unknown when unmeasured."""
+        monkeypatch.setattr(server_module, "kld7_tracker", None)
+        monkeypatch.setattr(server_module, "kld7_tracker_secondary", None, raising=False)
+        monkeypatch.setattr(server_module, "camera_tracker", None)
+        monkeypatch.setattr(server_module, "camera_enabled", False)
+        monkeypatch.setattr(server_module, "monitor", None)
+        monkeypatch.setattr(server_module, "debug_mode", False)
+        monkeypatch.setattr(server_module, "get_session_logger", lambda: None)
+        monkeypatch.setattr(server_module.socketio, "emit", lambda *args, **kwargs: None)
+
+        shot = Shot(
+            ball_speed_mph=100.0,
+            timestamp=datetime.now(),
+            club=ClubType.IRON_7,
+        )
+
+        on_shot_detected(shot)
+
+        assert shot.launch_angle_vertical == pytest.approx(20.5)
+        assert shot.launch_angle_horizontal is None
+        assert shot.angle_source == "estimated"
+        assert shot.launch_angle_horizontal_source is None
+        assert shot.launch_angle_horizontal_confidence is None
+
+    def test_camera_vertical_does_not_override_horizontal_radar(self, monkeypatch):
+        """Camera fallback should keep a measured horizontal radar angle."""
+        class StubTracker:
+            orientation = "horizontal"
+
+            def snapshot_buffer(self):
+                return []
+
+            def get_angle_for_shot(self, shot_timestamp=None):
+                return KLD7Angle(horizontal_deg=6.5, confidence=0.72, num_frames=2)
+
+            def get_club_angle(self, shot_timestamp=None):
+                return None
+
+            def reset(self):
+                return None
+
+        class StubCameraLaunchAngle:
+            vertical = 14.0
+            horizontal = -2.0
+            confidence = 0.81
+            positions = []
+
+        class StubCameraTracker:
+            launch_detected = True
+
+            def calculate_launch_angle(self):
+                return StubCameraLaunchAngle()
+
+            def reset(self):
+                return None
+
+        monkeypatch.setattr(server_module, "kld7_tracker", StubTracker())
+        monkeypatch.setattr(server_module, "kld7_tracker_secondary", None, raising=False)
+        monkeypatch.setattr(server_module, "camera_tracker", StubCameraTracker())
+        monkeypatch.setattr(server_module, "camera_enabled", True)
+        monkeypatch.setattr(server_module, "monitor", None)
+        monkeypatch.setattr(server_module, "debug_mode", False)
+        monkeypatch.setattr(server_module, "get_session_logger", lambda: None)
+        monkeypatch.setattr(server_module.socketio, "emit", lambda *args, **kwargs: None)
+
+        shot = Shot(
+            ball_speed_mph=100.0,
+            timestamp=datetime.now(),
+            club=ClubType.IRON_7,
+        )
+
+        on_shot_detected(shot)
+
+        assert shot.launch_angle_vertical == pytest.approx(14.0)
+        assert shot.launch_angle_horizontal == pytest.approx(6.5)
+        assert shot.launch_angle_confidence == pytest.approx(0.81)
+        assert shot.angle_source == "camera"
+        assert shot.launch_angle_horizontal_confidence == pytest.approx(0.72)
+        assert shot.launch_angle_horizontal_source == "radar"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -492,3 +492,116 @@ class TestOnShotDetected:
 
         assert shot.angle_source == "radar"
         assert shot.launch_angle_vertical == pytest.approx(18.7)
+
+    def test_optional_secondary_kld7_adds_horizontal_angle(self, monkeypatch):
+        """A second K-LD7 should add horizontal angle without changing the primary flow."""
+        calls = []
+        logged_buffers = []
+
+        class StubPrimaryTracker:
+            orientation = "vertical"
+
+            def snapshot_buffer(self):
+                return [{"timestamp": 1.0, "tdat": None, "pdat": []}]
+
+            def get_angle_for_shot(self, shot_timestamp=None):
+                calls.append(("primary-ball", shot_timestamp))
+                return KLD7Angle(vertical_deg=18.7, confidence=0.8, num_frames=2)
+
+            def get_club_angle(self, shot_timestamp=None):
+                calls.append(("primary-club", shot_timestamp))
+                return KLD7Angle(vertical_deg=-4.2, confidence=0.7, num_frames=1)
+
+            def reset(self):
+                calls.append(("primary-reset", None))
+
+        class StubSecondaryTracker:
+            orientation = "horizontal"
+
+            def snapshot_buffer(self):
+                return [{"timestamp": 2.0, "tdat": None, "pdat": []}]
+
+            def get_angle_for_shot(self, shot_timestamp=None):
+                calls.append(("secondary-ball", shot_timestamp))
+                return KLD7Angle(horizontal_deg=-3.5, confidence=0.75, num_frames=2)
+
+            def get_club_angle(self, shot_timestamp=None):
+                calls.append(("secondary-club", shot_timestamp))
+                return None
+
+            def reset(self):
+                calls.append(("secondary-reset", None))
+
+        class StubSessionLogger:
+            stats = {"shots_detected": 0}
+
+            def log_kld7_buffer(self, **kwargs):
+                logged_buffers.append(kwargs)
+
+            def log_shot(self, **kwargs):
+                return None
+
+        monkeypatch.setattr(server_module, "kld7_tracker", StubPrimaryTracker())
+        monkeypatch.setattr(server_module, "kld7_tracker_secondary", StubSecondaryTracker(), raising=False)
+        monkeypatch.setattr(server_module, "camera_tracker", None)
+        monkeypatch.setattr(server_module, "camera_enabled", False)
+        monkeypatch.setattr(server_module, "monitor", None)
+        monkeypatch.setattr(server_module, "debug_mode", False)
+        monkeypatch.setattr(server_module, "get_session_logger", lambda: StubSessionLogger())
+        monkeypatch.setattr(server_module.socketio, "emit", lambda *args, **kwargs: None)
+
+        shot = Shot(
+            ball_speed_mph=82.5,
+            club_speed_mph=57.0,
+            timestamp=datetime.now(),
+            impact_timestamp=321.0,
+            club=ClubType.DRIVER,
+        )
+
+        on_shot_detected(shot)
+
+        assert ("primary-ball", 321.0) in calls
+        assert ("secondary-ball", 321.0) in calls
+        assert shot.angle_source == "radar"
+        assert shot.launch_angle_vertical == pytest.approx(18.7)
+        assert shot.launch_angle_horizontal == pytest.approx(-3.5)
+        assert shot.club_angle_deg == pytest.approx(-4.2)
+        assert len(logged_buffers) == 2
+        assert {entry["orientation"] for entry in logged_buffers} == {"vertical", "horizontal"}
+
+    def test_horizontal_kld7_is_preserved_when_vertical_is_estimated(self, monkeypatch):
+        """Horizontal radar data should survive the vertical estimate fallback."""
+        class StubTracker:
+            orientation = "horizontal"
+
+            def snapshot_buffer(self):
+                return []
+
+            def get_angle_for_shot(self, shot_timestamp=None):
+                return KLD7Angle(horizontal_deg=4.4, confidence=0.7, num_frames=2)
+
+            def get_club_angle(self, shot_timestamp=None):
+                return None
+
+            def reset(self):
+                return None
+
+        monkeypatch.setattr(server_module, "kld7_tracker", StubTracker())
+        monkeypatch.setattr(server_module, "kld7_tracker_secondary", None, raising=False)
+        monkeypatch.setattr(server_module, "camera_tracker", None)
+        monkeypatch.setattr(server_module, "camera_enabled", False)
+        monkeypatch.setattr(server_module, "monitor", None)
+        monkeypatch.setattr(server_module, "debug_mode", False)
+        monkeypatch.setattr(server_module, "get_session_logger", lambda: None)
+        monkeypatch.setattr(server_module.socketio, "emit", lambda *args, **kwargs: None)
+
+        shot = Shot(
+            ball_speed_mph=100.0,
+            timestamp=datetime.now(),
+            club=ClubType.IRON_7,
+        )
+
+        on_shot_detected(shot)
+
+        assert shot.launch_angle_vertical == pytest.approx(20.5)
+        assert shot.launch_angle_horizontal == pytest.approx(4.4)

--- a/tests/test_session_logger.py
+++ b/tests/test_session_logger.py
@@ -107,6 +107,43 @@ class TestLogTriggerDiagnostic:
         assert entry["response_bytes"] == 0
         assert entry["total_readings"] == 0
 
+
+class TestLogShot:
+    """Tests for shot logging payloads."""
+
+    def test_log_shot_writes_horizontal_provenance_fields(self, tmp_path):
+        """Shot logs should preserve horizontal angle source and confidence separately."""
+        logger = SessionLogger(log_dir=tmp_path, enabled=True)
+        logger.start_session(mode="rolling-buffer", trigger_type="sound-gpio")
+
+        logger.log_shot(
+            ball_speed_mph=100.0,
+            club_speed_mph=70.0,
+            smash_factor=1.43,
+            estimated_carry_yards=180.0,
+            club="7 iron",
+            peak_magnitude=1200.0,
+            readings_count=5,
+            mode="rolling-buffer",
+            launch_angle_vertical=20.5,
+            launch_angle_horizontal=4.4,
+            launch_angle_confidence=0.2,
+            launch_angle_horizontal_confidence=0.7,
+            angle_source="estimated",
+            launch_angle_horizontal_source="radar",
+        )
+
+        lines = logger.session_path.read_text().strip().split("\n")
+        entry = json.loads(lines[-1])
+
+        assert entry["type"] == "shot_detected"
+        assert entry["launch_angle_vertical"] == 20.5
+        assert entry["launch_angle_horizontal"] == 4.4
+        assert entry["launch_angle_confidence"] == 0.2
+        assert entry["launch_angle_horizontal_confidence"] == 0.7
+        assert entry["angle_source"] == "estimated"
+        assert entry["launch_angle_horizontal_source"] == "radar"
+
     def test_stats_tracking(self, tmp_path):
         """Stats should track accepted/rejected counts."""
         logger = SessionLogger(log_dir=tmp_path, enabled=True)

--- a/ui/src/components/ShotDisplay.tsx
+++ b/ui/src/components/ShotDisplay.tsx
@@ -127,6 +127,10 @@ export function ShotDisplay({ shot, animate = false }: ShotDisplayProps) {
 
   const displayCarry = shot?.carry_spin_adjusted ?? shot?.estimated_carry_yards ?? 0;
   const carrySubtext = shot?.carry_spin_adjusted ? 'spin-adjusted' : carryRange || undefined;
+  const horizontalAngleSource =
+    shot?.launch_angle_horizontal_source ?? shot?.angle_source ?? undefined;
+  const horizontalAngleConfidence =
+    shot?.launch_angle_horizontal_confidence ?? shot?.launch_angle_confidence ?? null;
 
   if (!shot) {
     return (
@@ -196,9 +200,9 @@ export function ShotDisplay({ shot, animate = false }: ShotDisplayProps) {
               value={shot.launch_angle_horizontal.toFixed(1)}
               unit="°"
               label="Horizontal"
-              subtext={shot.angle_source ?? undefined}
+              subtext={horizontalAngleSource}
               variant="secondary"
-              confidence={getLaunchAngleQuality(shot.launch_angle_confidence)}
+              confidence={getLaunchAngleQuality(horizontalAngleConfidence)}
             />
           )}
           <MetricCard

--- a/ui/src/types/shot.ts
+++ b/ui/src/types/shot.ts
@@ -11,7 +11,9 @@ export interface Shot {
   launch_angle_vertical: number | null;
   launch_angle_horizontal: number | null;
   launch_angle_confidence: number | null;
+  launch_angle_horizontal_confidence: number | null;
   angle_source: 'radar' | 'camera' | 'estimated' | null;
+  launch_angle_horizontal_source: 'radar' | 'camera' | 'estimated' | null;
   club_angle_deg: number | null;
   // Rolling buffer mode spin data
   spin_rpm: number | null;


### PR DESCRIPTION
## Summary

- adds optional second K-LD7 support for dual-radar setups
- keeps the current single-K-LD7 flow unchanged
- preserves horizontal radar readings when vertical falls back to estimation
- wires the new flags through `start-kiosk.sh`

## What Changed

- added `--kld7-secondary-port` and `--kld7-secondary-orientation`
- server now processes primary and optional secondary K-LD7 trackers on the same OPS243 impact timestamp
- vertical sanity checking still only applies to vertical launch angles
- each tracker logs its own `kld7_buffer` entry for debugging
- estimate fallback no longer overwrites a real horizontal radar angle with `0.0`

## Setup

Primary only:

```bash
openflight-server --kld7 --kld7-port /dev/ttyUSB0 --kld7-orientation vertical
```

Dual radar:

```bash
openflight-server   --kld7   --kld7-port /dev/ttyUSB0   --kld7-orientation vertical   --kld7-secondary-port /dev/ttyUSB1   --kld7-secondary-orientation horizontal
```

The same secondary flags are also supported in `scripts/start-kiosk.sh`.

## Verification

- `PYTHONPATH=src .venv/bin/pytest -q` -> `258 passed, 2 skipped`
- `bash -n scripts/start-kiosk.sh`
- `PYTHONPATH=src .venv/bin/pylint src/openflight/server.py` -> `9.66/10`
