### PR TITLE
fix(kld7): increase ring buffer to 6s

### DIFF
--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -401,6 +401,7 @@ def init_kld7(port=None, orientation="vertical", angle_offset_deg=0.0, base_freq
         tracker = KLD7Tracker(
             port=port, orientation=orientation,
             angle_offset_deg=angle_offset_deg, base_freq=base_freq,
+            buffer_seconds=6.0,
         )
         if tracker.connect():
             tracker.start()


### PR DESCRIPTION
The 2s default buffer (68 frames) was being overwritten during the ~4s OPS243 serial dump, causing missed KLD7 detections. Increasing to 6s (204 frames) gives enough headroom. Verified with 52+ shots at 100% detection rate.