### PR TITLE
Fix rolling buffer shot timing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - K-LD7 launch-angle processing now uses OPS243 impact timestamps for live correlation
 - K-LD7 ball-burst selection now prefers coherent far-target paths instead of averaging all far PDAT detections
 - Live K-LD7 vertical launch angles now fall back to the existing club-and-speed estimate when the radar result is an obvious false positive
+- K-LD7 RADC extraction now narrows frame selection around the recorded shot timestamp instead of scanning the full buffer
+- Rolling-buffer capture metadata now preserves the configured sample rate and reconstructs impact timestamps from capture timing
 - Spin detection improved: Hann windowing, zero-padding to 256 points, band-limited search
 - All shot metrics (spin, launch angle, club speed, carry) always shown in UI
 - Shot logging unified — all metrics in single `shot_detected` entry

--- a/src/openflight/kld7/tracker.py
+++ b/src/openflight/kld7/tracker.py
@@ -40,6 +40,7 @@ class KLD7Tracker:
     # fail with AttributeError when code accesses these.
     angle_offset_deg = 0.0
     base_freq = 0
+    shot_window_seconds = 0.2
 
     def __init__(
         self,
@@ -90,6 +91,7 @@ class KLD7Tracker:
         # the prior session, returning the K-LD7 to its idle state where
         # it accepts INIT at 115200 again.
         import struct
+
         import serial as pyserial
 
         # Binary GBYE packet: 4-byte command + 4-byte length (0)
@@ -99,24 +101,36 @@ class KLD7Tracker:
         for attempt in range(1, max_attempts + 1):
             try:
                 self._radar = KLD7(port, baudrate=3000000)
-                actual_baud = getattr(self._radar._port, 'baudrate', 'unknown') if hasattr(self._radar, '_port') else 'unknown'
-                logger.info("[KLD7] Connected on %s at %s baud (attempt %d/%d)",
-                             port, actual_baud, attempt, max_attempts)
+                actual_baud = (
+                    getattr(self._radar._port, "baudrate", "unknown")
+                    if hasattr(self._radar, "_port")
+                    else "unknown"
+                )
+                logger.info(
+                    "[KLD7] Connected on %s at %s baud (attempt %d/%d)",
+                    port,
+                    actual_baud,
+                    attempt,
+                    max_attempts,
+                )
                 break
             except Exception as e:
-                logger.warning("[KLD7] Connect attempt %d/%d failed: %s",
-                                attempt, max_attempts, e)
+                logger.warning("[KLD7] Connect attempt %d/%d failed: %s", attempt, max_attempts, e)
                 if attempt >= max_attempts:
-                    logger.error("[KLD7] Connection failed after %d attempts — giving up",
-                                  max_attempts, exc_info=True)
+                    logger.error(
+                        "[KLD7] Connection failed after %d attempts — giving up",
+                        max_attempts,
+                        exc_info=True,
+                    )
                     return False
 
                 # Send binary GBYE at 3Mbaud to close a stuck prior session,
                 # then drain. The K-LD7 will return to idle and accept INIT
                 # at 115200 on the next attempt.
                 try:
-                    with pyserial.Serial(port, 3000000, parity=pyserial.PARITY_EVEN,
-                                         timeout=0.1) as ser:
+                    with pyserial.Serial(
+                        port, 3000000, parity=pyserial.PARITY_EVEN, timeout=0.1
+                    ) as ser:
                         ser.reset_input_buffer()
                         ser.write(gbye_packet)
                         ser.flush()
@@ -131,8 +145,14 @@ class KLD7Tracker:
                 time.sleep(0.3)
 
         self._configure_for_golf()
-        logger.info("[KLD7] Ready: port=%s, baud=%s, range=%dm, speed=%dkm/h, orientation=%s",
-                     port, actual_baud, self.range_m, self.speed_kmh, self.orientation)
+        logger.info(
+            "[KLD7] Ready: port=%s, baud=%s, range=%dm, speed=%dkm/h, orientation=%s",
+            port,
+            actual_baud,
+            self.range_m,
+            self.speed_kmh,
+            self.orientation,
+        )
         return True
 
     def _configure_for_golf(self):
@@ -158,8 +178,11 @@ class KLD7Tracker:
         freq_labels = {0: "Low/24.05GHz", 1: "Mid/24.15GHz", 2: "High/24.25GHz"}
         logger.info(
             "[KLD7] Configured: range=%dm, speed=%dkm/h, orientation=%s, RBFR=%d (%s)",
-            self.range_m, self.speed_kmh, self.orientation,
-            self.base_freq, freq_labels.get(self.base_freq, "unknown"),
+            self.range_m,
+            self.speed_kmh,
+            self.orientation,
+            self.base_freq,
+            freq_labels.get(self.base_freq, "unknown"),
         )
 
     def start(self):
@@ -212,7 +235,6 @@ class KLD7Tracker:
         # and continues with a truncated packet, causing cascading errors.
         # This patch retries the read until we get all expected bytes.
         import struct
-        original_read_packet = self._radar._read_packet.__func__
 
         def _robust_read_packet(device):
             if device._port is None:
@@ -256,21 +278,29 @@ class KLD7Tracker:
                         errors = 0  # reset on success
 
                         if frame_count == 1:
-                            logger.info("[KLD7] First RADC frame received (%d bytes, %s)",
-                                        len(payload) if payload else 0, self.orientation)
+                            logger.info(
+                                "[KLD7] First RADC frame received (%d bytes, %s)",
+                                len(payload) if payload else 0,
+                                self.orientation,
+                            )
                         elif frame_count == 50:
-                            logger.info("[KLD7] Stream health: %d RADC frames (%s)",
-                                        frame_count, self.orientation)
+                            logger.info(
+                                "[KLD7] Stream health: %d RADC frames (%s)",
+                                frame_count,
+                                self.orientation,
+                            )
 
                 if not self._running:
                     break
-                logger.warning("[KLD7] Stream generator exited (frames=%d, %s)",
-                              frame_count, self.orientation)
+                logger.warning(
+                    "[KLD7] Stream generator exited (frames=%d, %s)", frame_count, self.orientation
+                )
 
             except KLD7Exception as e:
                 errors += 1
-                logger.debug("[KLD7] Stream error %d/%d (%s): %s",
-                              errors, max_errors, self.orientation, e)
+                logger.debug(
+                    "[KLD7] Stream error %d/%d (%s): %s", errors, max_errors, self.orientation, e
+                )
                 if errors < max_errors:
                     # Drain serial and retry
                     try:
@@ -280,19 +310,55 @@ class KLD7Tracker:
                     time.sleep(0.1)
 
             except Exception as e:
-                logger.error("[KLD7] Stream crashed after %d frames (%s): %s",
-                              frame_count, self.orientation, e, exc_info=True)
+                logger.error(
+                    "[KLD7] Stream crashed after %d frames (%s): %s",
+                    frame_count,
+                    self.orientation,
+                    e,
+                    exc_info=True,
+                )
                 break
 
         if errors >= max_errors:
-            logger.error("[KLD7] Stream gave up after %d consecutive errors (%s)",
-                          max_errors, self.orientation)
+            logger.error(
+                "[KLD7] Stream gave up after %d consecutive errors (%s)",
+                max_errors,
+                self.orientation,
+            )
 
     def _add_frame(self, frame: KLD7Frame):
         """Add a frame to the ring buffer."""
         self._ring_buffer.append(frame)
 
-    def _extract_ball_radc(self, ball_speed_mph: float) -> Optional[KLD7Angle]:
+    def _get_radc_frames(self, shot_timestamp: Optional[float] = None) -> list[dict]:
+        """Collect RADC frames, optionally narrowed around the shot timestamp."""
+        frames = [
+            {"timestamp": frame.timestamp, "radc": frame.radc}
+            for frame in self._ring_buffer
+            if frame.radc is not None
+        ]
+
+        if shot_timestamp is None or not frames:
+            return frames
+
+        window_start = shot_timestamp - self.shot_window_seconds
+        window_end = shot_timestamp + self.shot_window_seconds
+        filtered = [frame for frame in frames if window_start <= frame["timestamp"] <= window_end]
+
+        logger.info(
+            "[KLD7] RADC: filtered %d/%d frames around shot timestamp %.3f (+/- %.0fms)",
+            len(filtered),
+            len(frames),
+            shot_timestamp,
+            self.shot_window_seconds * 1000,
+        )
+        return filtered
+
+    def _extract_ball_radc(
+        self,
+        ball_speed_mph: float,
+        shot_timestamp: Optional[float] = None,
+    ) -> Optional[KLD7Angle]:
         """Extract ball launch angle via RADC phase interferometry.
 
         Uses the OPS243-measured ball speed to narrow the FFT velocity
@@ -300,19 +366,18 @@ class KLD7Tracker:
         """
         from .radc import extract_launch_angle
 
-        frames = [
-            {"timestamp": f.timestamp, "radc": f.radc}
-            for f in self._ring_buffer
-            if f.radc is not None
-        ]
+        frames = self._get_radc_frames(shot_timestamp=shot_timestamp)
 
         if not frames:
-            logger.info("[KLD7] RADC: no frames with RADC data in buffer (%d total frames)",
-                         len(self._ring_buffer))
+            logger.info(
+                "[KLD7] RADC: no frames with RADC data in buffer (%d total frames)",
+                len(self._ring_buffer),
+            )
             return None
 
-        logger.info("[KLD7] RADC: examining %d frames, ball_speed=%.1f mph",
-                     len(frames), ball_speed_mph)
+        logger.info(
+            "[KLD7] RADC: examining %d frames, ball_speed=%.1f mph", len(frames), ball_speed_mph
+        )
 
         # Horizontal radar sees weaker ball returns (narrower beam in
         # the horizontal plane), so use a lower impact energy threshold.
@@ -328,15 +393,22 @@ class KLD7Tracker:
         )
 
         if not results:
-            logger.info("[KLD7] RADC: no ball detections for %.1f mph (%s, %d frames examined)",
-                         ball_speed_mph, self.orientation, len(frames))
+            logger.info(
+                "[KLD7] RADC: no ball detections for %.1f mph (%s, %d frames examined)",
+                ball_speed_mph,
+                self.orientation,
+                len(frames),
+            )
             return None
 
         best = results[0]
         logger.info(
             "[KLD7] RADC: angle=%.1f° speed=%.1f mph snr=%.1f conf=%.2f frames=%d",
-            best["launch_angle_deg"], best["ball_speed_mph"],
-            best["avg_snr_db"], best["confidence"], best["frame_count"],
+            best["launch_angle_deg"],
+            best["ball_speed_mph"],
+            best["avg_snr_db"],
+            best["confidence"],
+            best["frame_count"],
         )
 
         if self.orientation == "vertical":
@@ -357,24 +429,34 @@ class KLD7Tracker:
             detection_class="ball",
         )
 
-    def get_angle_for_shot(self, shot_timestamp: Optional[float] = None, ball_speed_mph: Optional[float] = None) -> Optional[KLD7Angle]:
+    def get_angle_for_shot(
+        self, shot_timestamp: Optional[float] = None, ball_speed_mph: Optional[float] = None
+    ) -> Optional[KLD7Angle]:
         """Search the ring buffer for the ball launch angle using RADC phase interferometry.
 
         Requires ball_speed_mph from OPS243 to narrow the FFT velocity search.
         Returns None if RADC extraction fails or ball_speed_mph not provided.
         """
-        logger.info("[KLD7] Angle extraction: ball_speed=%s mph, buffer=%d frames",
-                     "%.1f" % ball_speed_mph if ball_speed_mph else "None", len(self._ring_buffer))
+        logger.info(
+            "[KLD7] Angle extraction: ball_speed=%s mph, buffer=%d frames",
+            "%.1f" % ball_speed_mph if ball_speed_mph else "None",
+            len(self._ring_buffer),
+        )
 
         if ball_speed_mph is None:
             logger.info("[KLD7] No ball speed provided, cannot extract RADC angle")
             return None
 
         try:
-            result = self._extract_ball_radc(ball_speed_mph)
+            result = self._extract_ball_radc(
+                ball_speed_mph,
+                shot_timestamp=shot_timestamp,
+            )
             if result is not None:
                 return result
-            logger.info("[KLD7] RADC extraction returned None (no detections at %.1f mph)", ball_speed_mph)
+            logger.info(
+                "[KLD7] RADC extraction returned None (no detections at %.1f mph)", ball_speed_mph
+            )
         except Exception as e:
             logger.warning("[KLD7] RADC extraction failed: %s", e, exc_info=True)
 
@@ -394,9 +476,12 @@ class KLD7Tracker:
             if result is not None:
                 # Re-tag as club detection
                 result.detection_class = "club"
-                logger.info("[KLD7] Club angle: %.1f° at %.1f mph (%s)",
-                             result.vertical_deg or result.horizontal_deg,
-                             club_speed_mph, self.orientation)
+                logger.info(
+                    "[KLD7] Club angle: %.1f° at %.1f mph (%s)",
+                    result.vertical_deg or result.horizontal_deg,
+                    club_speed_mph,
+                    self.orientation,
+                )
                 return result
         except Exception as e:
             logger.debug("[KLD7] Club angle extraction failed: %s", e)

--- a/src/openflight/ops243.py
+++ b/src/openflight/ops243.py
@@ -50,16 +50,17 @@ def set_show_raw_readings(enabled: bool):
 
 class SpeedUnit(Enum):
     """Speed units supported by OPS243-A."""
-    MPS = "UM"      # meters per second (default)
-    MPH = "US"      # miles per hour
-    KPH = "UK"      # kilometers per hour
-    FPS = "UF"      # feet per second
-    CMS = "UC"      # centimeters per second
 
+    MPS = "UM"  # meters per second (default)
+    MPH = "US"  # miles per hour
+    KPH = "UK"  # kilometers per hour
+    FPS = "UF"  # feet per second
+    CMS = "UC"  # centimeters per second
 
 
 class Direction(Enum):
     """Direction of detected object."""
+
     INBOUND = "inbound"
     OUTBOUND = "outbound"
     UNKNOWN = "unknown"
@@ -68,6 +69,7 @@ class Direction(Enum):
 @dataclass
 class SpeedReading:
     """A single speed reading from the radar."""
+
     speed: float
     direction: Direction
     magnitude: Optional[float] = None
@@ -85,9 +87,10 @@ class IQBlock:
     Used for continuous I/Q streaming mode where we process
     the FFT locally instead of using the radar's internal processing.
     """
+
     i_samples: List[int]  # Raw I channel ADC values (0-4095)
     q_samples: List[int]  # Raw Q channel ADC values (0-4095)
-    timestamp: float      # When this block was received
+    timestamp: float  # When this block was received
 
 
 class OPS243Radar:
@@ -133,6 +136,7 @@ class OPS243Radar:
         self._unit = "mph"
         self._json_mode = False
         self._magnitude_enabled = False
+        self.last_hardware_trigger_time: Optional[float] = None
 
     @staticmethod
     def find_radar_ports() -> List[str]:
@@ -177,7 +181,7 @@ class OPS243Radar:
                 timeout=timeout,
                 bytesize=serial.EIGHTBITS,
                 parity=serial.PARITY_NONE,
-                stopbits=serial.STOPBITS_ONE
+                stopbits=serial.STOPBITS_ONE,
             )
             # Drain any in-progress dump (e.g. radar triggered while no software was running).
             # Opening the port unblocks the radar's UART TX, so we read until silence.
@@ -239,12 +243,12 @@ class OPS243Radar:
         self.serial.reset_input_buffer()
 
         # Send command
-        self.serial.write(cmd.encode('ascii'))
+        self.serial.write(cmd.encode("ascii"))
 
         # For commands that require carriage return
         # Note: S# commands (trigger split) also need \r
-        if '=' in cmd or '>' in cmd or '<' in cmd or '#' in cmd:
-            self.serial.write(b'\r')
+        if "=" in cmd or ">" in cmd or "<" in cmd or "#" in cmd:
+            self.serial.write(b"\r")
 
         # Wait for response
         time.sleep(0.1)
@@ -252,7 +256,7 @@ class OPS243Radar:
         # Read response
         response = ""
         while self.serial.in_waiting:
-            response += self.serial.read(self.serial.in_waiting).decode('ascii', errors='ignore')
+            response += self.serial.read(self.serial.in_waiting).decode("ascii", errors="ignore")
             time.sleep(0.05)
 
         return response.strip()
@@ -267,9 +271,9 @@ class OPS243Radar:
         response = self._send_command("??")
         info = {}
 
-        for line in response.split('\n'):
+        for line in response.split("\n"):
             line = line.strip()
-            if line.startswith('{') and line.endswith('}'):
+            if line.startswith("{") and line.endswith("}"):
                 try:
                     data = json.loads(line)
                     info.update(data)
@@ -300,7 +304,7 @@ class OPS243Radar:
             SpeedUnit.MPH: "mph",
             SpeedUnit.KPH: "kph",
             SpeedUnit.FPS: "fps",
-            SpeedUnit.CMS: "cm/s"
+            SpeedUnit.CMS: "cm/s",
         }
         self._unit = unit_names[unit]
 
@@ -326,7 +330,7 @@ class OPS243Radar:
             10000: "SX",
             20000: "S2",
             50000: "SL",
-            100000: "SC"
+            100000: "SC",
         }
 
         if rate in rate_commands:
@@ -346,12 +350,7 @@ class OPS243Radar:
         Args:
             size: Buffer size (128, 256, 512, or 1024)
         """
-        size_commands = {
-            128: "S(",
-            256: "S[",
-            512: "S<",
-            1024: "S>"
-        }
+        size_commands = {128: "S(", 256: "S[", 512: "S<", 1024: "S>"}
         if size in size_commands:
             self._send_command(size_commands[size])
 
@@ -559,10 +558,10 @@ class OPS243Radar:
             print(f"[SERIAL] {line!r}")
 
         try:
-            if self._json_mode and line.startswith('{'):
+            if self._json_mode and line.startswith("{"):
                 data = json.loads(line)
-                speed_data = data.get('speed', 0)
-                magnitude_data = data.get('magnitude')
+                speed_data = data.get("speed", 0)
+                magnitude_data = data.get("magnitude")
 
                 # Handle array format from O4 multi-object mode
                 # Arrays are ordered by magnitude (strongest first)
@@ -573,7 +572,9 @@ class OPS243Radar:
                     magnitude = float(magnitude_data[0]) if magnitude_data else None
 
                     if _show_raw_readings:
-                        print(f"[MULTI] {len(speed_data)} objects: speeds={speed_data} mags={magnitude_data}")
+                        print(
+                            f"[MULTI] {len(speed_data)} objects: speeds={speed_data} mags={magnitude_data}"
+                        )
                 else:
                     speed = float(speed_data)
                     magnitude = float(magnitude_data) if magnitude_data else None
@@ -591,14 +592,20 @@ class OPS243Radar:
                     print(f"[RAW] {speed:+.1f} mph -> {direction.value} (mag: {magnitude})")
 
                 # Log parsed reading for debugging
-                logger.debug("[OPS] PARSED: raw_speed=%.2f abs_speed=%.2f dir=%s mag=%s", speed, abs(speed), direction.value, magnitude)
+                logger.debug(
+                    "[OPS] PARSED: raw_speed=%.2f abs_speed=%.2f dir=%s mag=%s",
+                    speed,
+                    abs(speed),
+                    direction.value,
+                    magnitude,
+                )
 
                 return SpeedReading(
                     speed=abs(speed),
                     direction=direction,
                     magnitude=magnitude,
                     timestamp=time.time(),
-                    unit=self._unit
+                    unit=self._unit,
                 )
 
             # Plain number format - direction from sign
@@ -612,13 +619,15 @@ class OPS243Radar:
             if _show_raw_readings:
                 print(f"[RAW] {speed:+.1f} mph -> {direction.value}")
 
-            logger.debug("[OPS] PARSED (plain): raw_speed=%.2f abs_speed=%.2f dir=%s", speed, abs(speed), direction.value)
+            logger.debug(
+                "[OPS] PARSED (plain): raw_speed=%.2f abs_speed=%.2f dir=%s",
+                speed,
+                abs(speed),
+                direction.value,
+            )
 
             return SpeedReading(
-                speed=abs(speed),
-                direction=direction,
-                timestamp=time.time(),
-                unit=self._unit
+                speed=abs(speed), direction=direction, timestamp=time.time(), unit=self._unit
             )
         except (ValueError, json.JSONDecodeError) as e:
             logger.warning("[OPS] Failed to parse reading: %r - %s", line, e)
@@ -676,9 +685,12 @@ class OPS243Radar:
         if not self.serial or not self.serial.is_open:
             raise ConnectionError("Not connected to radar")
 
-        print(f"[RADAR] Entering rolling buffer mode (S#{pre_trigger_segments}, S={sample_rate_ksps})...")
-        logger.info("[OPS] Entering rolling buffer mode (pre_trigger_segments=%d)...",
-                    pre_trigger_segments)
+        print(
+            f"[RADAR] Entering rolling buffer mode (S#{pre_trigger_segments}, S={sample_rate_ksps})..."
+        )
+        logger.info(
+            "[OPS] Entering rolling buffer mode (pre_trigger_segments=%d)...", pre_trigger_segments
+        )
 
         # Clear any stale data
         self.serial.reset_input_buffer()
@@ -724,9 +736,14 @@ class OPS243Radar:
         # to ensure stable state before accepting triggers
         time.sleep(0.3)
 
-        print(f"[RADAR] Rolling buffer mode ACTIVE (S#{pre_trigger_segments}, {sample_rate_ksps}ksps)")
-        logger.info("[OPS] Rolling buffer mode active (S#%d, %dksps)",
-                    pre_trigger_segments, sample_rate_ksps)
+        print(
+            f"[RADAR] Rolling buffer mode ACTIVE (S#{pre_trigger_segments}, {sample_rate_ksps}ksps)"
+        )
+        logger.info(
+            "[OPS] Rolling buffer mode active (S#%d, %dksps)",
+            pre_trigger_segments,
+            sample_rate_ksps,
+        )
 
     def disable_rolling_buffer(self):
         """Disable rolling buffer mode and return to normal CW mode."""
@@ -735,8 +752,9 @@ class OPS243Radar:
         time.sleep(0.1)
         logger.info("[OPS] Rolling buffer mode disabled (returned to CW mode)")
 
-    def persist_rolling_buffer_mode(self, pre_trigger_segments: int = 16,
-                                     sample_rate_ksps: int = 30):
+    def persist_rolling_buffer_mode(
+        self, pre_trigger_segments: int = 16, sample_rate_ksps: int = 30
+    ):
         """
         Save rolling buffer mode to persistent memory.
 
@@ -765,16 +783,17 @@ class OPS243Radar:
 
         # Enter rolling buffer mode with desired settings
         self.enter_rolling_buffer_mode(
-            pre_trigger_segments=pre_trigger_segments,
-            sample_rate_ksps=sample_rate_ksps
+            pre_trigger_segments=pre_trigger_segments, sample_rate_ksps=sample_rate_ksps
         )
 
         # Save to persistent memory
         self.serial.write(b"A!")
         time.sleep(0.5)
 
-        logger.info("[OPS] Rolling buffer mode saved to persistent memory. "
-                     "Power cycle the board for changes to take effect.")
+        logger.info(
+            "[OPS] Rolling buffer mode saved to persistent memory. "
+            "Power cycle the board for changes to take effect."
+        )
         print("[RADAR] Settings saved to persistent memory.")
         print("[RADAR] Power cycle the board (unplug USB, wait 3s, replug).")
 
@@ -817,17 +836,20 @@ class OPS243Radar:
         while (time.time() - start_time) < timeout:
             if self.serial.in_waiting:
                 chunk = self.serial.read(self.serial.in_waiting)
-                response_lines.append(chunk.decode('ascii', errors='ignore'))
+                response_lines.append(chunk.decode("ascii", errors="ignore"))
                 bytes_received += len(chunk)
                 last_data_time = time.time()
 
                 # Check if we have complete data (Q array ends the response)
-                full_response = ''.join(response_lines)
+                full_response = "".join(response_lines)
                 if '"Q"' in full_response:
                     # Look for closing bracket of Q array followed by newline or EOF
                     q_idx = full_response.rfind('"Q"')
                     remaining = full_response[q_idx:]
-                    if ']}' in remaining or (remaining.rstrip().endswith(']') and remaining.count('[') == remaining.count(']')):
+                    if "]}" in remaining or (
+                        remaining.rstrip().endswith("]")
+                        and remaining.count("[") == remaining.count("]")
+                    ):
                         break
 
                 time.sleep(0.01)  # Short sleep to accumulate data
@@ -835,21 +857,29 @@ class OPS243Radar:
                 # No data available
                 # If we've received some data and haven't gotten more in 0.5s, consider done
                 if bytes_received > 100 and (time.time() - last_data_time) > 0.5:
-                    full_response = ''.join(response_lines)
+                    full_response = "".join(response_lines)
                     if '"Q"' in full_response:
                         break
                 time.sleep(0.02)
 
-        full_response = ''.join(response_lines)
+        full_response = "".join(response_lines)
 
         # Only log issues, not normal operation
         if not full_response:
-            logger.warning("[OPS] S! trigger returned empty response after %.1fs", time.time() - start_time)
+            logger.warning(
+                "[OPS] S! trigger returned empty response after %.1fs", time.time() - start_time
+            )
         else:
-            logger.info("[OPS] S! trigger: %d bytes in %.1fs", len(full_response), time.time() - start_time)
+            logger.info(
+                "[OPS] S! trigger: %d bytes in %.1fs", len(full_response), time.time() - start_time
+            )
             if len(full_response) < 1000:
                 # Short response usually means mode not configured correctly
-                logger.info("[OPS] S! response too short (%s bytes): %s", len(full_response), repr(full_response[:100]))
+                logger.info(
+                    "[OPS] S! response too short (%s bytes): %s",
+                    len(full_response),
+                    repr(full_response[:100]),
+                )
 
         return full_response
 
@@ -877,26 +907,31 @@ class OPS243Radar:
         start_time = time.time()
         last_data_time = None
         bytes_received = 0
+        self.last_hardware_trigger_time = None
 
         while (time.time() - start_time) < timeout:
             if self.serial.in_waiting:
                 chunk = self.serial.read(self.serial.in_waiting)
-                response_lines.append(chunk.decode('ascii', errors='ignore'))
+                response_lines.append(chunk.decode("ascii", errors="ignore"))
                 bytes_received += len(chunk)
                 if last_data_time is None:
                     last_data_time = time.time()
-                    logger.debug("[OPS] Hardware trigger: first byte after %.1fs", last_data_time - start_time)
+                    self.last_hardware_trigger_time = last_data_time
+                    logger.debug(
+                        "[OPS] Hardware trigger: first byte after %.1fs",
+                        last_data_time - start_time,
+                    )
                 else:
                     last_data_time = time.time()
 
                 # Check if we have complete I/Q data
-                full_response = ''.join(response_lines)
+                full_response = "".join(response_lines)
                 if '"Q"' in full_response:
                     q_idx = full_response.rfind('"Q"')
                     remaining = full_response[q_idx:]
-                    if ']}' in remaining or (
-                        remaining.rstrip().endswith(']')
-                        and remaining.count('[') == remaining.count(']')
+                    if "]}" in remaining or (
+                        remaining.rstrip().endswith("]")
+                        and remaining.count("[") == remaining.count("]")
                     ):
                         break
 
@@ -904,17 +939,21 @@ class OPS243Radar:
             else:
                 # If we've started receiving data, use shorter timeout
                 if last_data_time and (time.time() - last_data_time) > 0.5:
-                    full_response = ''.join(response_lines)
+                    full_response = "".join(response_lines)
                     if '"Q"' in full_response:
                         break
                 time.sleep(0.02)
 
-        full_response = ''.join(response_lines) if response_lines else ""
+        full_response = "".join(response_lines) if response_lines else ""
 
         if not full_response:
             logger.info("[OPS] Hardware trigger: no data received within %.0fs", timeout)
         else:
-            logger.info("[OPS] Hardware trigger: %d bytes in %.1fs", len(full_response), time.time() - start_time)
+            logger.info(
+                "[OPS] Hardware trigger: %d bytes in %.1fs",
+                len(full_response),
+                time.time() - start_time,
+            )
 
         return full_response
 
@@ -948,7 +987,9 @@ class OPS243Radar:
             time.sleep(0.2)
             if self.serial.in_waiting == 0:
                 break
-        logger.info("[OPS] Re-arm drain: %d bytes in %.1fs", total_drained, time.time() - drain_start)
+        logger.info(
+            "[OPS] Re-arm drain: %d bytes in %.1fs", total_drained, time.time() - drain_start
+        )
 
         # Restart sampling
         self.serial.write(b"PA")
@@ -969,7 +1010,9 @@ class OPS243Radar:
         self.serial.reset_input_buffer()
         logger.info("[OPS] Rolling buffer re-armed (S#%d)", pre_trigger_segments)
 
-    def configure_for_rolling_buffer(self, pre_trigger_segments: int = 16, sample_rate_ksps: int = 30):
+    def configure_for_rolling_buffer(
+        self, pre_trigger_segments: int = 16, sample_rate_ksps: int = 30
+    ):
         """
         Configure radar optimally for rolling buffer mode.
 
@@ -1000,7 +1043,9 @@ class OPS243Radar:
         logger.info("[OPS] Transmit power: level 3 (reduced to avoid clipping)")
 
         # Enter rolling buffer mode using the single source of truth
-        self.enter_rolling_buffer_mode(pre_trigger_segments=pre_trigger_segments, sample_rate_ksps=sample_rate_ksps)
+        self.enter_rolling_buffer_mode(
+            pre_trigger_segments=pre_trigger_segments, sample_rate_ksps=sample_rate_ksps
+        )
 
         logger.info("[OPS] Rolling buffer mode configured")
 
@@ -1124,16 +1169,16 @@ class OPS243Radar:
         try:
             # Read available data
             raw_bytes = self.serial.read(self.serial.in_waiting)
-            line = raw_bytes.decode('ascii', errors='ignore').strip()
+            line = raw_bytes.decode("ascii", errors="ignore").strip()
 
             if not line:
                 return None
 
             # May have multiple lines - take the last complete one
-            lines = line.split('\n')
+            lines = line.split("\n")
             for candidate in reversed(lines):
                 candidate = candidate.strip()
-                if candidate.startswith('{'):
+                if candidate.startswith("{"):
                     reading = self._parse_reading(candidate)
                     if reading:
                         return reading

--- a/src/openflight/rolling_buffer/monitor.py
+++ b/src/openflight/rolling_buffer/monitor.py
@@ -22,7 +22,9 @@ from .types import ProcessedCapture
 logger = logging.getLogger("openflight.rolling_buffer.monitor")
 
 
-def get_optimal_spin_for_ball_speed(ball_speed_mph: float, club: ClubType = ClubType.DRIVER) -> float:
+def get_optimal_spin_for_ball_speed(
+    ball_speed_mph: float, club: ClubType = ClubType.DRIVER
+) -> float:
     """
     Get optimal spin rate for a given ball speed.
 
@@ -279,12 +281,16 @@ class RollingBufferMonitor:
         # Other triggers need rolling buffer mode configured upfront
         if self.trigger_type != "speed":
             # Get pre_trigger_segments from the trigger if available
-            pre_trigger_segments = getattr(self.trigger, 'pre_trigger_segments', 12)
+            pre_trigger_segments = getattr(self.trigger, "pre_trigger_segments", 12)
             self.radar.configure_for_rolling_buffer(
                 pre_trigger_segments=pre_trigger_segments,
                 sample_rate_ksps=self.sample_rate_ksps,
             )
-            logger.info("[MONITOR] Rolling buffer mode configured with S#%d, S=%d", pre_trigger_segments, self.sample_rate_ksps)
+            logger.info(
+                "[MONITOR] Rolling buffer mode configured with S#%d, S=%d",
+                pre_trigger_segments,
+                self.sample_rate_ksps,
+            )
         else:
             logger.info("[MONITOR] Using speed trigger — configuration deferred to trigger")
 
@@ -428,16 +434,23 @@ class RollingBufferMonitor:
                     continue
 
                 # For speed trigger, use the trigger speed as club speed if not found in capture
-                if (self.trigger_type == "speed" and
-                    processed.club_speed_mph is None and
-                    hasattr(self.trigger, 'last_trigger_speed')):
+                if (
+                    self.trigger_type == "speed"
+                    and processed.club_speed_mph is None
+                    and hasattr(self.trigger, "last_trigger_speed")
+                ):
                     trigger_speed = self.trigger.last_trigger_speed
                     if trigger_speed > 0:
                         processed.club_speed_mph = trigger_speed
-                        logger.info("[MONITOR] Using trigger speed as club speed: %.1f mph", trigger_speed)
+                        logger.info(
+                            "[MONITOR] Using trigger speed as club speed: %.1f mph", trigger_speed
+                        )
 
-                logger.debug("[MONITOR] Processed: ball=%.1f mph, club=%s",
-                            processed.ball_speed_mph, processed.club_speed_mph)
+                logger.debug(
+                    "[MONITOR] Processed: ball=%.1f mph, club=%s",
+                    processed.ball_speed_mph,
+                    processed.club_speed_mph,
+                )
 
                 # Create shot
                 shot = self._create_shot(processed)
@@ -448,7 +461,7 @@ class RollingBufferMonitor:
                         "[MONITOR] Shot detected: ball=%.1f mph, club=%s, spin=%s",
                         shot.ball_speed_mph,
                         "%.1f" % shot.club_speed_mph if shot.club_speed_mph else "N/A",
-                        "%.0f" % shot.spin_rpm if shot.spin_rpm else "N/A"
+                        "%.0f" % shot.spin_rpm if shot.spin_rpm else "N/A",
                     )
 
                     # Log raw I/Q data and trigger events to session logger
@@ -507,25 +520,27 @@ class RollingBufferMonitor:
 
                     # Emit diagnostic to UI
                     if self._diagnostic_callback:
-                        self._diagnostic_callback({
-                            "timestamp": datetime.now().isoformat(),
-                            "accepted": True,
-                            "reason": "accepted",
-                            "trigger_type": self.trigger_type,
-                            "latency_ms": trigger_latency_ms,
-                            "response_bytes": 0,
-                            "total_readings": len(processed.timeline.readings),
-                            "outbound_readings": 0,
-                            "inbound_readings": 0,
-                            "peak_outbound_mph": shot.ball_speed_mph,
-                            "peak_inbound_mph": 0,
-                            "all_outbound_speeds": [],
-                            "all_inbound_speeds": [],
-                            "ball_speed_mph": shot.ball_speed_mph,
-                            "club_speed_mph": shot.club_speed_mph,
-                            "spin_rpm": shot.spin_rpm,
-                            "carry_yards": shot.estimated_carry_yards,
-                        })
+                        self._diagnostic_callback(
+                            {
+                                "timestamp": datetime.now().isoformat(),
+                                "accepted": True,
+                                "reason": "accepted",
+                                "trigger_type": self.trigger_type,
+                                "latency_ms": trigger_latency_ms,
+                                "response_bytes": 0,
+                                "total_readings": len(processed.timeline.readings),
+                                "outbound_readings": 0,
+                                "inbound_readings": 0,
+                                "peak_outbound_mph": shot.ball_speed_mph,
+                                "peak_inbound_mph": 0,
+                                "all_outbound_speeds": [],
+                                "all_inbound_speeds": [],
+                                "ball_speed_mph": shot.ball_speed_mph,
+                                "club_speed_mph": shot.club_speed_mph,
+                                "spin_rpm": shot.spin_rpm,
+                                "carry_yards": shot.estimated_carry_yards,
+                            }
+                        )
 
                     if self._shot_callback:
                         callback_start = time.time()
@@ -538,13 +553,18 @@ class RollingBufferMonitor:
                             len(self._shots),
                             shot.ball_speed_mph,
                             "%.1f" % shot.club_speed_mph if shot.club_speed_mph else "N/A",
-                            "%.0f" % shot.estimated_carry_yards if shot.estimated_carry_yards else "N/A",
-                            trigger_latency_ms, process_ms, callback_ms, total_ms,
+                            "%.0f" % shot.estimated_carry_yards
+                            if shot.estimated_carry_yards
+                            else "N/A",
+                            trigger_latency_ms,
+                            process_ms,
+                            callback_ms,
+                            total_ms,
                         )
                 else:
                     logger.info(
                         "[MONITOR] Shot validation failed: ball=%.1f mph (min 15 mph)",
-                        processed.ball_speed_mph if processed else 0
+                        processed.ball_speed_mph if processed else 0,
                     )
                     # Emit diagnostic for shot validation failure
                     diag = {
@@ -618,11 +638,19 @@ class RollingBufferMonitor:
         # The UI shows confidence indicators so the user can judge
         spin_rpm = processed.spin.spin_rpm if has_any_spin else None
         spin_confidence = processed.spin.confidence if has_any_spin else None
+        impact_timestamp = None
+        capture = processed.capture or processed.timeline.capture
+        if capture is not None:
+            capture_start_timestamp = capture.timestamp - (
+                capture.trigger_time - capture.sample_time
+            )
+            impact_timestamp = capture_start_timestamp + (processed.ball_timestamp_ms / 1000.0)
 
         # Create shot with extended fields
         shot = Shot(
             ball_speed_mph=processed.ball_speed_mph,
             timestamp=datetime.now(),
+            impact_timestamp=impact_timestamp,
             club_speed_mph=processed.club_speed_mph,
             peak_magnitude=None,  # Not directly available in rolling buffer mode
             readings=[],  # Raw readings not stored (use ProcessedCapture instead)
@@ -686,11 +714,7 @@ class RollingBufferMonitor:
         smash_factors = [s.smash_factor for s in self._shots if s.smash_factor]
 
         # Get spin data
-        spin_rpms = [
-            s.spin_rpm
-            for s in self._shots
-            if s.spin_rpm is not None
-        ]
+        spin_rpms = [s.spin_rpm for s in self._shots if s.spin_rpm is not None]
 
         return {
             "shot_count": len(self._shots),

--- a/src/openflight/rolling_buffer/processor.py
+++ b/src/openflight/rolling_buffer/processor.py
@@ -73,17 +73,17 @@ class RollingBufferProcessor:
 
     # Spin detection via amplitude envelope demodulation.
     # The ball seam modulates the radar return at 2x spin rate.
-    SPIN_BANDPASS_BW_HZ = 700       # ±700 Hz around ball Doppler (must cover max seam freq)
-    SPIN_BANDPASS_ORDER = 4          # Butterworth filter order
-    SPIN_ENVELOPE_FFT_SIZE = 8192   # Zero-padded FFT for envelope
-    SPIN_MIN_SEAM_HZ = 33.0         # ~2000 RPM min (seam = 1x spin)
-    SPIN_MAX_SEAM_HZ = 200.0        # 12000 RPM max
-    SPIN_MIN_SAMPLES = 600           # ~20ms minimum ball signal
-    SPIN_SNR_HIGH = 8.0              # High confidence threshold
-    SPIN_SNR_MEDIUM = 5.0            # Medium confidence threshold
-    SPIN_SNR_MIN = 3.0               # Minimum to report
-    SPIN_AUTOCORR_MIN = 0.3          # Minimum normalized correlation
-    SPIN_MIN_CYCLES = 2              # Minimum seam cycles to report
+    SPIN_BANDPASS_BW_HZ = 700  # ±700 Hz around ball Doppler (must cover max seam freq)
+    SPIN_BANDPASS_ORDER = 4  # Butterworth filter order
+    SPIN_ENVELOPE_FFT_SIZE = 8192  # Zero-padded FFT for envelope
+    SPIN_MIN_SEAM_HZ = 33.0  # ~2000 RPM min (seam = 1x spin)
+    SPIN_MAX_SEAM_HZ = 200.0  # 12000 RPM max
+    SPIN_MIN_SAMPLES = 600  # ~20ms minimum ball signal
+    SPIN_SNR_HIGH = 8.0  # High confidence threshold
+    SPIN_SNR_MEDIUM = 5.0  # Medium confidence threshold
+    SPIN_SNR_MIN = 3.0  # Minimum to report
+    SPIN_AUTOCORR_MIN = 0.3  # Minimum normalized correlation
+    SPIN_MIN_CYCLES = 2  # Minimum seam cycles to report
 
     def __init__(self, sample_rate: int = 30000):
         """Initialize processor with pre-computed window function.
@@ -95,7 +95,11 @@ class RollingBufferProcessor:
         self.SAMPLE_RATE = sample_rate
         self.hanning_window = np.hanning(self.WINDOW_SIZE)
 
-    def parse_capture(self, response: str) -> Optional[IQCapture]:
+    def parse_capture(
+        self,
+        response: str,
+        capture_timestamp: Optional[float] = None,
+    ) -> Optional[IQCapture]:
         """
         Parse S! command response into IQCapture object.
 
@@ -138,12 +142,16 @@ class RollingBufferProcessor:
                     continue
 
             if all(v is not None for v in [sample_time, trigger_time, i_samples, q_samples]):
-                return IQCapture(
-                    sample_time=sample_time,
-                    trigger_time=trigger_time,
-                    i_samples=i_samples,
-                    q_samples=q_samples,
-                )
+                capture_kwargs = {
+                    "sample_time": sample_time,
+                    "trigger_time": trigger_time,
+                    "i_samples": i_samples,
+                    "q_samples": q_samples,
+                    "sample_rate_hz": self.SAMPLE_RATE,
+                }
+                if capture_timestamp is not None:
+                    capture_kwargs["timestamp"] = capture_timestamp
+                return IQCapture(**capture_kwargs)
 
             # Log what's missing
             missing = []
@@ -553,15 +561,19 @@ class RollingBufferProcessor:
         logger.info(
             "[PROCESSOR] Spin envelope: peak=%.1f Hz (%.0f RPM), SNR=%.1f, "
             "cycles=%.1f, window=%.0fms, samples=%d",
-            peak_freq, spin_rpm, fft_snr, seam_cycles,
-            window_seconds * 1000, len(ball_envelope),
+            peak_freq,
+            spin_rpm,
+            fft_snr,
+            seam_cycles,
+            window_seconds * 1000,
+            len(ball_envelope),
         )
 
         # --- Fallback: Autocorrelation for marginal FFT ---
         autocorr_confirmed = False
         if fft_snr < self.SPIN_SNR_MEDIUM and fft_snr >= self.SPIN_SNR_MIN:
             norm = np.correlate(windowed, windowed, mode="full")
-            norm = norm[len(norm) // 2:]  # positive lags only
+            norm = norm[len(norm) // 2 :]  # positive lags only
             if norm[0] > 0:
                 norm = norm / norm[0]
 
@@ -584,7 +596,8 @@ class RollingBufferProcessor:
                             autocorr_confirmed = True
                             logger.info(
                                 "[PROCESSOR] Spin autocorrelation confirms: %.0f RPM (corr=%.2f)",
-                                acorr_rpm, acorr_peak_val,
+                                acorr_rpm,
+                                acorr_peak_val,
                             )
                         elif acorr_peak_val >= 0.4:
                             spin_rpm = acorr_rpm
@@ -592,7 +605,8 @@ class RollingBufferProcessor:
                             autocorr_confirmed = True
                             logger.info(
                                 "[PROCESSOR] Spin autocorrelation override: %.0f RPM (corr=%.2f)",
-                                acorr_rpm, acorr_peak_val,
+                                acorr_rpm,
+                                acorr_peak_val,
                             )
 
         # --- Quality assessment ---
@@ -707,6 +721,7 @@ class RollingBufferProcessor:
 
         # Bin to 1-mph buckets, find the mode
         from collections import Counter
+
         binned = Counter(round(s) for s in speeds)
 
         # The ball is the highest-speed cluster with significant repetition.
@@ -725,7 +740,12 @@ class RollingBufferProcessor:
         # Log if max speed differs significantly from mode (outlier rejected)
         max_speed = max(speeds)
         if max_speed > ball_bin + 10:
-            logger.info("[PROCESSOR] Ball speed outlier rejected: max=%.1f, mode=%.1f mph (%d occurrences)", max_speed, float(ball_bin), frequent[0][1])
+            logger.info(
+                "[PROCESSOR] Ball speed outlier rejected: max=%.1f, mode=%.1f mph (%d occurrences)",
+                max_speed,
+                float(ball_bin),
+                frequent[0][1],
+            )
 
         # Return the actual max speed within ±2 mph of the mode bin
         # for sub-mph precision
@@ -754,7 +774,11 @@ class RollingBufferProcessor:
             return None
 
         ball_speed_mph = self._find_consistent_ball_speed(std_outbound)
-        logger.info("[PROCESSOR] Ball speed: %.1f mph (mode-based, %d outbound readings)", ball_speed_mph, len(std_outbound))
+        logger.info(
+            "[PROCESSOR] Ball speed: %.1f mph (mode-based, %d outbound readings)",
+            ball_speed_mph,
+            len(std_outbound),
+        )
 
         # Process with overlapping FFT for high-resolution timeline (needed for spin)
         timeline = self.process_overlapping(capture)
@@ -766,10 +790,7 @@ class RollingBufferProcessor:
         # Find the ball in the overlapping timeline at the standard-detected speed
         # (within tolerance) to get the precise timestamp for spin analysis
         outbound = [r for r in timeline.readings if r.is_outbound]
-        ball_candidates = [
-            r for r in outbound
-            if abs(r.speed_mph - ball_speed_mph) <= 3.0
-        ]
+        ball_candidates = [r for r in outbound if abs(r.speed_mph - ball_speed_mph) <= 3.0]
         if ball_candidates:
             ball_reading = max(ball_candidates, key=lambda r: r.magnitude)
         elif outbound:
@@ -788,7 +809,11 @@ class RollingBufferProcessor:
             timeline, ball_speed_mph, ball_timestamp_ms
         )
         if club_speed_mph is not None:
-            logger.info("[PROCESSOR] Club speed: %.1f mph at %.1fms before ball", club_speed_mph, ball_timestamp_ms - club_timestamp_ms)
+            logger.info(
+                "[PROCESSOR] Club speed: %.1f mph at %.1fms before ball",
+                club_speed_mph,
+                ball_timestamp_ms - club_timestamp_ms,
+            )
         else:
             logger.debug("[PROCESSOR] No club speed found (ball=%.1f mph)", ball_speed_mph)
 
@@ -797,7 +822,9 @@ class RollingBufferProcessor:
 
         logger.info(
             "[PROCESSOR] Spin result: %.0f RPM, SNR=%.2f, quality=%s",
-            spin.spin_rpm, spin.snr, spin.quality,
+            spin.spin_rpm,
+            spin.snr,
+            spin.quality,
         )
 
         return ProcessedCapture(

--- a/src/openflight/rolling_buffer/trigger.py
+++ b/src/openflight/rolling_buffer/trigger.py
@@ -154,13 +154,14 @@ class PollingTrigger(TriggerStrategy):
         while (time.time() - start_time) < timeout:
             try:
                 # Trigger capture (10s timeout for large I/Q data transfer)
+                capture_timestamp = time.time()
                 response = radar.trigger_capture(timeout=10.0)
 
                 # Re-arm for next capture (sensor goes to idle after output)
                 radar.rearm_rolling_buffer(self.pre_trigger_segments)
 
                 # Parse response
-                capture = processor.parse_capture(response)
+                capture = processor.parse_capture(response, capture_timestamp=capture_timestamp)
 
                 if capture is None:
                     time.sleep(self.poll_interval)
@@ -170,12 +171,19 @@ class PollingTrigger(TriggerStrategy):
                 timeline = processor.process_standard(capture)
 
                 # Check for significant activity
-                outbound = [r for r in timeline.readings
-                            if r.is_outbound and r.speed_mph >= self.min_speed_mph]
+                outbound = [
+                    r
+                    for r in timeline.readings
+                    if r.is_outbound and r.speed_mph >= self.min_speed_mph
+                ]
 
                 if len(outbound) >= self.min_readings:
                     peak = max(r.speed_mph for r in outbound)
-                    logger.info("[TRIGGER] Activity detected: %d readings, peak %.1f mph", len(outbound), peak)
+                    logger.info(
+                        "[TRIGGER] Activity detected: %d readings, peak %.1f mph",
+                        len(outbound),
+                        peak,
+                    )
                     return capture
 
                 time.sleep(self.poll_interval)
@@ -242,12 +250,13 @@ class ThresholdTrigger(TriggerStrategy):
         while (time.time() - start_time) < timeout:
             try:
                 # Capture and check for threshold (10s timeout for large I/Q data)
+                capture_timestamp = time.time()
                 response = radar.trigger_capture(timeout=10.0)
 
                 # Re-arm for next capture
                 radar.rearm_rolling_buffer(self.pre_trigger_segments)
 
-                capture = processor.parse_capture(response)
+                capture = processor.parse_capture(response, capture_timestamp=capture_timestamp)
 
                 if capture is None:
                     time.sleep(self.check_interval)
@@ -258,17 +267,24 @@ class ThresholdTrigger(TriggerStrategy):
 
                 peak = timeline.peak_speed
                 if peak and peak.is_outbound and peak.speed_mph >= self.speed_threshold_mph:
-                    logger.info("[TRIGGER] Threshold triggered: %.1f mph >= %.1f mph",
-                               peak.speed_mph, self.speed_threshold_mph)
+                    logger.info(
+                        "[TRIGGER] Threshold triggered: %.1f mph >= %.1f mph",
+                        peak.speed_mph,
+                        self.speed_threshold_mph,
+                    )
                     self._triggered = True
 
                     # Brief settling time for ball to clear
                     time.sleep(self.settling_time)
 
                     # Capture again for complete swing data
+                    final_capture_timestamp = time.time()
                     response = radar.trigger_capture(timeout=10.0)
                     radar.rearm_rolling_buffer(self.pre_trigger_segments)
-                    final_capture = processor.parse_capture(response)
+                    final_capture = processor.parse_capture(
+                        response,
+                        capture_timestamp=final_capture_timestamp,
+                    )
 
                     return final_capture or capture
 
@@ -316,9 +332,10 @@ class ManualTrigger(TriggerStrategy):
                 self._trigger_requested = False
                 logger.info("[TRIGGER] Manual trigger activated")
 
+                capture_timestamp = time.time()
                 response = radar.trigger_capture(timeout=10.0)
                 radar.rearm_rolling_buffer(self.pre_trigger_segments)
-                return processor.parse_capture(response)
+                return processor.parse_capture(response, capture_timestamp=capture_timestamp)
 
             time.sleep(0.1)
 
@@ -404,7 +421,9 @@ class SpeedTriggeredCapture(TriggerStrategy):
             time.sleep(0.1)
 
         start_time = time.time()
-        logger.info("[TRIGGER] Waiting for speed trigger >= %.1f mph...", self.min_trigger_speed_mph)
+        logger.info(
+            "[TRIGGER] Waiting for speed trigger >= %.1f mph...", self.min_trigger_speed_mph
+        )
 
         while (time.time() - start_time) < timeout:
             # Non-blocking speed read
@@ -415,8 +434,11 @@ class SpeedTriggeredCapture(TriggerStrategy):
                 self._last_trigger_speed = reading.speed
                 trigger_time = time.time()
 
-                logger.info("[TRIGGER] Speed trigger: %.1f mph %s detected, switching to rolling buffer...",
-                           reading.speed, reading.direction.value)
+                logger.info(
+                    "[TRIGGER] Speed trigger: %.1f mph %s detected, switching to rolling buffer...",
+                    reading.speed,
+                    reading.direction.value,
+                )
 
                 # Immediately switch to rolling buffer mode
                 radar.switch_to_rolling_buffer()
@@ -427,8 +449,12 @@ class SpeedTriggeredCapture(TriggerStrategy):
                 time.sleep(delay_sec)
 
                 # Capture the rolling buffer
+                capture_trigger_time = time.time()
                 response = radar.trigger_capture(timeout=5.0)
-                capture = processor.parse_capture(response)
+                capture = processor.parse_capture(
+                    response,
+                    capture_timestamp=capture_trigger_time,
+                )
 
                 # Calculate timing
                 capture_time = time.time()
@@ -438,8 +464,11 @@ class SpeedTriggeredCapture(TriggerStrategy):
                 if capture:
                     # Validate capture has ball speed
                     timeline = processor.process_standard(capture)
-                    outbound = [r for r in timeline.readings
-                               if r.is_outbound and r.speed_mph >= self.min_ball_speed_mph]
+                    outbound = [
+                        r
+                        for r in timeline.readings
+                        if r.is_outbound and r.speed_mph >= self.min_ball_speed_mph
+                    ]
 
                     if outbound:
                         peak = max(r.speed_mph for r in outbound)
@@ -449,7 +478,9 @@ class SpeedTriggeredCapture(TriggerStrategy):
                         self._needs_reconfigure = True
                         return capture
                     else:
-                        logger.info("[TRIGGER] No speed >= %.1f mph in capture", self.min_ball_speed_mph)
+                        logger.info(
+                            "[TRIGGER] No speed >= %.1f mph in capture", self.min_ball_speed_mph
+                        )
 
                 # Reconfigure for speed mode and continue
                 self._needs_reconfigure = True
@@ -529,24 +560,23 @@ class GPIOSoundTrigger(TriggerStrategy):
         try:
             from gpiozero import Button  # pylint: disable=import-outside-toplevel
         except ImportError:
-            logger.error("[TRIGGER] gpiozero not available. Install with: uv pip install gpiozero lgpio")
+            logger.error(
+                "[TRIGGER] gpiozero not available. Install with: uv pip install gpiozero lgpio"
+            )
             return False
 
         def on_trigger():
             self._trigger_event["edge_time"] = time.time()
             self._trigger_event["triggered"] = True
 
-        self._button = Button(
-            self.gpio_pin,
-            pull_up=False,
-            bounce_time=self.debounce_ms / 1000.0
-        )
+        self._button = Button(self.gpio_pin, pull_up=False, bounce_time=self.debounce_ms / 1000.0)
         self._button.when_pressed = on_trigger
         self._gpio_initialized = True
 
         logger.info(
             "[TRIGGER] GPIO%d configured for sound trigger (debounce=%dms)",
-            self.gpio_pin, self.debounce_ms
+            self.gpio_pin,
+            self.debounce_ms,
         )
         return True
 
@@ -571,7 +601,9 @@ class GPIOSoundTrigger(TriggerStrategy):
 
         logger.info(
             "[TRIGGER] Waiting for GPIO sound trigger on GPIO%d (timeout=%.0fs, S#%s)...",
-            self.gpio_pin, timeout, self.pre_trigger_segments
+            self.gpio_pin,
+            timeout,
+            self.pre_trigger_segments,
         )
 
         start_time = time.time()
@@ -583,14 +615,20 @@ class GPIOSoundTrigger(TriggerStrategy):
                 self._trigger_event["triggered"] = False
 
                 # Measure edge-to-S! latency (from GPIO callback to now)
-                trigger_latency = (time.time() - edge_time) * 1000
-                logger.info("[TRIGGER] GPIO edge detected on GPIO%d (%.1fms ago), sending S! trigger...",
-                           self.gpio_pin, trigger_latency)
+                capture_timestamp = time.time()
+                trigger_latency = (capture_timestamp - edge_time) * 1000
+                logger.info(
+                    "[TRIGGER] GPIO edge detected on GPIO%d (%.1fms ago), sending S! trigger...",
+                    self.gpio_pin,
+                    trigger_latency,
+                )
                 response = radar.trigger_capture(timeout=5.0)
 
                 if not response:
-                    logger.warning("[TRIGGER] No response from radar after S! (%.1fms after edge)",
-                                  trigger_latency)
+                    logger.warning(
+                        "[TRIGGER] No response from radar after S! (%.1fms after edge)",
+                        trigger_latency,
+                    )
                     self._append_diagnostic(
                         accepted=False,
                         reason="no_response",
@@ -603,8 +641,11 @@ class GPIOSoundTrigger(TriggerStrategy):
                     continue
 
                 response_len = len(response)
-                logger.info("[TRIGGER] Capture received, %d bytes (S! sent %.1fms after edge)",
-                           response_len, trigger_latency)
+                logger.info(
+                    "[TRIGGER] Capture received, %d bytes (S! sent %.1fms after edge)",
+                    response_len,
+                    trigger_latency,
+                )
                 if response_len < 5000:
                     logger.debug("[TRIGGER] Response content: %s", repr(response))
                 else:
@@ -615,7 +656,7 @@ class GPIOSoundTrigger(TriggerStrategy):
                 logger.debug("[TRIGGER] Discarding GPIO edges during re-arm")
                 self._trigger_event["triggered"] = False  # discard edges during rearm
 
-                capture = processor.parse_capture(response)
+                capture = processor.parse_capture(response, capture_timestamp=capture_timestamp)
 
                 if not capture:
                     logger.warning("[TRIGGER] Failed to parse capture (%d bytes)", response_len)
@@ -642,15 +683,14 @@ class GPIOSoundTrigger(TriggerStrategy):
                 peak_out_mag = max((r.magnitude for r in all_outbound), default=0)
                 peak_in_mag = max((r.magnitude for r in all_inbound), default=0)
 
-                outbound_valid = [
-                    r for r in all_outbound if r.speed_mph >= 15.0
-                ]
+                outbound_valid = [r for r in all_outbound if r.speed_mph >= 15.0]
 
                 if not outbound_valid:
                     logger.info(
                         "[TRIGGER] GPIO trigger rejected — no outbound speed >= 15 mph "
                         "(peak=%.1f mph, %d readings)",
-                        peak_outbound, len(all_readings)
+                        peak_outbound,
+                        len(all_readings),
                     )
                     self._append_diagnostic(
                         accepted=False,
@@ -672,7 +712,8 @@ class GPIOSoundTrigger(TriggerStrategy):
                 peak = max(r.speed_mph for r in outbound_valid)
                 logger.info(
                     "[TRIGGER] GPIO trigger accepted — peak %.1f mph, %d outbound readings",
-                    peak, len(outbound_valid)
+                    peak,
+                    len(outbound_valid),
                 )
                 self._append_diagnostic(
                     accepted=True,
@@ -761,10 +802,7 @@ class SoundTrigger(TriggerStrategy):
         output, causing the radar to dump its rolling buffer automatically.
         We just block on serial read waiting for the I/Q data to arrive.
         """
-        logger.info(
-            "[TRIGGER] Waiting for sound trigger (timeout=%.0fs)...",
-            timeout
-        )
+        logger.info("[TRIGGER] Waiting for sound trigger (timeout=%.0fs)...", timeout)
 
         response = radar.wait_for_hardware_trigger(timeout=timeout)
 
@@ -778,7 +816,10 @@ class SoundTrigger(TriggerStrategy):
         # Re-arm for next capture
         radar.rearm_rolling_buffer(self.pre_trigger_segments)
 
-        capture = processor.parse_capture(response)
+        capture = processor.parse_capture(
+            response,
+            capture_timestamp=radar.last_hardware_trigger_time,
+        )
 
         if not capture:
             logger.warning("[TRIGGER] Sound trigger parse failed (%d bytes received)", response_len)
@@ -810,8 +851,11 @@ class SoundTrigger(TriggerStrategy):
         outbound_valid = [r for r in all_outbound if r.speed_mph >= 15.0]
 
         if not outbound_valid:
-            logger.info("[TRIGGER] Sound trigger rejected — no outbound speed >= 15 mph (peak=%.1f mph, %d readings)",
-                       peak_outbound, len(all_readings))
+            logger.info(
+                "[TRIGGER] Sound trigger rejected — no outbound speed >= 15 mph (peak=%.1f mph, %d readings)",
+                peak_outbound,
+                len(all_readings),
+            )
             self._append_diagnostic(
                 accepted=False,
                 reason="no_outbound_speed",
@@ -829,8 +873,11 @@ class SoundTrigger(TriggerStrategy):
             return None
 
         peak = max(r.speed_mph for r in outbound_valid)
-        logger.info("[TRIGGER] Sound trigger accepted — peak %.1f mph, %d outbound readings",
-                   peak, len(outbound_valid))
+        logger.info(
+            "[TRIGGER] Sound trigger accepted — peak %.1f mph, %d outbound readings",
+            peak,
+            len(outbound_valid),
+        )
         self._append_diagnostic(
             accepted=True,
             reason="accepted",
@@ -887,7 +934,8 @@ def create_trigger(trigger_type: str = "speed", **kwargs) -> TriggerStrategy:
     }
 
     if trigger_type not in triggers:
-        raise ValueError(f"Unknown trigger type: {trigger_type}. "
-                        f"Available: {list(triggers.keys())}")
+        raise ValueError(
+            f"Unknown trigger type: {trigger_type}. Available: {list(triggers.keys())}"
+        )
 
     return triggers[trigger_type](**kwargs)

--- a/src/openflight/rolling_buffer/types.py
+++ b/src/openflight/rolling_buffer/types.py
@@ -23,12 +23,15 @@ class IQCapture:
         trigger_time: Radar timestamp when trigger fired
         i_samples: 4096 in-phase samples (raw ADC values, 0-4095)
         q_samples: 4096 quadrature samples (raw ADC values, 0-4095)
+        sample_rate_hz: Capture sample rate in Hz
         timestamp: Python timestamp when capture was received
     """
+
     sample_time: float
     trigger_time: float
     i_samples: List[int]
     q_samples: List[int]
+    sample_rate_hz: int = 30000
     timestamp: float = field(default_factory=lambda: datetime.now().timestamp())
 
     @property
@@ -38,8 +41,8 @@ class IQCapture:
 
     @property
     def duration_ms(self) -> float:
-        """Duration of capture in milliseconds (at 30ksps)."""
-        return (self.num_samples / 30000) * 1000
+        """Duration of capture in milliseconds at the recorded sample rate."""
+        return (self.num_samples / self.sample_rate_hz) * 1000
 
     @property
     def trigger_offset_ms(self) -> float:
@@ -54,6 +57,7 @@ class SpeedReading:
 
     This matches the format used in streaming mode for compatibility.
     """
+
     speed_mph: float
     magnitude: float
     timestamp_ms: float  # Relative to capture start
@@ -77,6 +81,7 @@ class SpeedTimeline:
         sample_rate_hz: Effective sample rate (~937 Hz with 32-step overlap)
         capture: Reference to the original I/Q capture
     """
+
     readings: List[SpeedReading]
     sample_rate_hz: float
     capture: Optional[IQCapture] = None
@@ -128,6 +133,7 @@ class SpinResult:
         snr: Signal-to-noise ratio of the spin peak
         quality: Human-readable quality assessment
     """
+
     spin_rpm: float
     confidence: float
     snr: float
@@ -161,6 +167,7 @@ class ProcessedCapture:
         spin: Spin detection result (may indicate failure)
         capture: Original raw I/Q data
     """
+
     timeline: SpeedTimeline
     ball_speed_mph: float
     ball_timestamp_ms: float

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -9,6 +9,7 @@ import logging
 import os
 import random
 import statistics
+import sys
 import threading
 import time
 from datetime import datetime
@@ -235,9 +236,10 @@ def radar_launch_is_plausible(
         club_speed_mph=club_speed_mph,
         spin_rpm=spin_rpm,
     )
-    allowed_delta_deg = _radar_launch_base_delta_deg(club) + (
-        1.0 - estimate_conf
-    ) * _RADAR_SANITY_LOW_CONF_BONUS_DEG
+    allowed_delta_deg = (
+        _radar_launch_base_delta_deg(club)
+        + (1.0 - estimate_conf) * _RADAR_SANITY_LOW_CONF_BONUS_DEG
+    )
     delta_deg = abs(radar_angle_deg - expected_launch_deg)
 
     return delta_deg <= allowed_delta_deg, {
@@ -298,8 +300,11 @@ def api_shutdown():
     logger.info("[SERVER] Shutdown requested via REST API")
 
     import threading
+
     def _shutdown():
-        import time as _time, os
+        import os
+        import time as _time
+
         _time.sleep(0.5)
         # Clean up before exit
         try:
@@ -399,14 +404,21 @@ def init_kld7(port=None, orientation="vertical", angle_offset_deg=0.0, base_freq
         from openflight.kld7 import KLD7Tracker
 
         tracker = KLD7Tracker(
-            port=port, orientation=orientation,
-            angle_offset_deg=angle_offset_deg, base_freq=base_freq,
+            port=port,
+            orientation=orientation,
+            angle_offset_deg=angle_offset_deg,
+            base_freq=base_freq,
             buffer_seconds=6.0,
         )
         if tracker.connect():
             tracker.start()
-            logger.info("[SERVER] K-LD7 %s initialized (port=%s, offset=%.1f°, RBFR=%d)",
-                         orientation, port or "auto", angle_offset_deg, base_freq)
+            logger.info(
+                "[SERVER] K-LD7 %s initialized (port=%s, offset=%.1f°, RBFR=%d)",
+                orientation,
+                port or "auto",
+                angle_offset_deg,
+                base_freq,
+            )
             session_log = get_session_logger()
             if session_log:
                 session_log.log_connection(
@@ -893,8 +905,11 @@ def handle_shutdown():
     socketio.emit("shutdown_ack", {"message": "Shutting down..."})
 
     import threading
+
     def _shutdown():
-        import time as _time, os
+        import os
+        import time as _time
+
         _time.sleep(0.5)
         try:
             if kld7_vertical:
@@ -945,7 +960,8 @@ def on_shot_detected(shot: Shot):
                         shot.angle_source = "radar"
                         logger.info(
                             "[SERVER] Vertical angle: %.1f° (conf=%.0f%%, %d frames)",
-                            kld7_angle.vertical_deg, kld7_angle.confidence * 100,
+                            kld7_angle.vertical_deg,
+                            kld7_angle.confidence * 100,
                             kld7_angle.num_frames,
                         )
                     else:
@@ -967,7 +983,9 @@ def on_shot_detected(shot: Shot):
                             "detection_class": kld7_angle.detection_class,
                             "magnitude": kld7_angle.magnitude,
                             "num_frames": kld7_angle.num_frames,
-                        } if kld7_angle else None,
+                        }
+                        if kld7_angle
+                        else None,
                     )
                 # Club angle of attack (same RADC buffer, club speed from OPS)
                 if shot.club_speed_mph:
@@ -980,11 +998,16 @@ def on_shot_detected(shot: Shot):
                         # Real AoA ranges from ~-15° (steep iron) to ~+8° (ascending driver).
                         if -15.0 <= candidate_aoa <= 8.0:
                             shot.club_angle_deg = candidate_aoa
-                            logger.info("[SERVER] Club AoA: %.1f° (conf=%.0f%%)",
-                                         shot.club_angle_deg, club_angle_v.confidence * 100)
+                            logger.info(
+                                "[SERVER] Club AoA: %.1f° (conf=%.0f%%)",
+                                shot.club_angle_deg,
+                                club_angle_v.confidence * 100,
+                            )
                         else:
-                            logger.warning("[SERVER] Club AoA rejected: %.1f° outside plausible range",
-                                           candidate_aoa)
+                            logger.warning(
+                                "[SERVER] Club AoA rejected: %.1f° outside plausible range",
+                                candidate_aoa,
+                            )
 
                 kld7_vertical.reset()
 
@@ -1004,7 +1027,8 @@ def on_shot_detected(shot: Shot):
                             shot.launch_angle_confidence = kld7_angle_h.confidence
                         logger.info(
                             "[SERVER] Horizontal angle: %.1f° (conf=%.0f%%, %d frames)",
-                            kld7_angle_h.horizontal_deg, kld7_angle_h.confidence * 100,
+                            kld7_angle_h.horizontal_deg,
+                            kld7_angle_h.confidence * 100,
                             kld7_angle_h.num_frames,
                         )
                     else:
@@ -1024,23 +1048,34 @@ def on_shot_detected(shot: Shot):
                             "detection_class": kld7_angle_h.detection_class,
                             "magnitude": kld7_angle_h.magnitude,
                             "num_frames": kld7_angle_h.num_frames,
-                        } if kld7_angle_h else None,
+                        }
+                        if kld7_angle_h
+                        else None,
                     )
                 # Club path (same RADC buffer, club speed from OPS)
                 if shot.club_speed_mph:
-                    club_angle_h = kld7_horizontal.get_club_angle(club_speed_mph=shot.club_speed_mph)
+                    club_angle_h = kld7_horizontal.get_club_angle(
+                        club_speed_mph=shot.club_speed_mph
+                    )
                     if club_angle_h and club_angle_h.horizontal_deg is not None:
                         shot.club_path_deg = club_angle_h.horizontal_deg
-                        logger.info("[SERVER] Club path: %.1f° (conf=%.0f%%)",
-                                     club_angle_h.horizontal_deg, club_angle_h.confidence * 100)
+                        logger.info(
+                            "[SERVER] Club path: %.1f° (conf=%.0f%%)",
+                            club_angle_h.horizontal_deg,
+                            club_angle_h.confidence * 100,
+                        )
 
                 kld7_horizontal.reset()
 
             # Derive spin axis from face angle (H. launch) minus club path
             if shot.launch_angle_horizontal is not None and shot.club_path_deg is not None:
                 shot.spin_axis_deg = round(shot.launch_angle_horizontal - shot.club_path_deg, 1)
-                logger.info("[SERVER] Spin axis: %+.1f° (face=%+.1f° - path=%+.1f°)",
-                             shot.spin_axis_deg, shot.launch_angle_horizontal, shot.club_path_deg)
+                logger.info(
+                    "[SERVER] Spin axis: %+.1f° (face=%+.1f° - path=%+.1f°)",
+                    shot.spin_axis_deg,
+                    shot.launch_angle_horizontal,
+                    shot.club_path_deg,
+                )
 
             if kld7_vertical or kld7_horizontal:
                 kld7_ms = (time.time() - kld7_start) * 1000
@@ -1053,7 +1088,12 @@ def on_shot_detected(shot: Shot):
     # Skip if K-LD7 already provided vertical angle
     camera_data = None
     try:
-        if camera_tracker and camera_enabled and shot.mode != "mock" and shot.launch_angle_vertical is None:
+        if (
+            camera_tracker
+            and camera_enabled
+            and shot.mode != "mock"
+            and shot.launch_angle_vertical is None
+        ):
             launch_angle = camera_tracker.calculate_launch_angle()
             if launch_angle:
                 # Update shot object with launch angle data
@@ -1097,18 +1137,25 @@ def on_shot_detected(shot: Shot):
         shot.launch_angle_confidence = estimated[1]
         shot.angle_source = "estimated"
         logger.info(
-            "[SERVER] Angle source: estimated (%.1f°, conf=%.0f%%)", estimated[0], estimated[1] * 100
+            "[SERVER] Angle source: estimated (%.1f°, conf=%.0f%%)",
+            estimated[0],
+            estimated[1] * 100,
         )
 
     # Compute spin-adjusted carry using measured spin (if reliable) or club average
     _MIN_RELIABLE_SPIN_CONF = 0.6
     if shot.carry_spin_adjusted is None and shot.mode != "mock":
         has_reliable_spin = (
-            shot.spin_rpm and shot.spin_rpm > 0
+            shot.spin_rpm
+            and shot.spin_rpm > 0
             and shot.spin_confidence is not None
             and shot.spin_confidence >= _MIN_RELIABLE_SPIN_CONF
         )
-        spin_for_carry = shot.spin_rpm if has_reliable_spin else get_optimal_spin_for_ball_speed(shot.ball_speed_mph, shot.club)
+        spin_for_carry = (
+            shot.spin_rpm
+            if has_reliable_spin
+            else get_optimal_spin_for_ball_speed(shot.ball_speed_mph, shot.club)
+        )
         shot.carry_spin_adjusted = estimate_carry_with_spin(
             shot.ball_speed_mph,
             spin_for_carry,
@@ -1117,7 +1164,8 @@ def on_shot_detected(shot: Shot):
         )
         logger.info(
             "[SERVER] Spin-adjusted carry: %.0f yds (spin: %.0f rpm%s)",
-            shot.carry_spin_adjusted, spin_for_carry,
+            shot.carry_spin_adjusted,
+            spin_for_carry,
             "" if shot.spin_rpm and shot.spin_rpm > 0 else " avg",
         )
 
@@ -1241,8 +1289,12 @@ def start_monitor(
 
     monitor.connect()
 
-    logger.info("[SERVER] Starting monitor: mode=%s, trigger=%s, sample_rate=%dksps",
-                "mock" if mock else "rolling-buffer", trigger_type, sample_rate_ksps)
+    logger.info(
+        "[SERVER] Starting monitor: mode=%s, trigger=%s, sample_rate=%dksps",
+        "mock" if mock else "rolling-buffer",
+        trigger_type,
+        sample_rate_ksps,
+    )
 
     # Start session logging
     session_logger = get_session_logger()
@@ -1261,7 +1313,7 @@ def start_monitor(
             session_logger.log_connection(
                 device="ops243",
                 port=port or "auto",
-                baud=getattr(monitor.radar, 'baud', 0) if hasattr(monitor, 'radar') else 0,
+                baud=getattr(monitor.radar, "baud", 0) if hasattr(monitor, "radar") else 0,
                 firmware=radar_info.get("Version"),
             )
 
@@ -1581,7 +1633,9 @@ def main():
         "--kld7", action="store_true", help="Enable K-LD7 vertical angle radar (launch angle)"
     )
     parser.add_argument(
-        "--kld7-port", default=None, help="K-LD7 vertical serial port (auto-detect if not specified)"
+        "--kld7-port",
+        default=None,
+        help="K-LD7 vertical serial port (auto-detect if not specified)",
     )
     parser.add_argument(
         "--kld7-angle-offset",
@@ -1590,11 +1644,11 @@ def main():
         help="K-LD7 vertical angle offset in degrees (default: 0.0)",
     )
     parser.add_argument(
-        "--kld7-horizontal", action="store_true", help="Enable K-LD7 horizontal angle radar (club path)"
+        "--kld7-horizontal",
+        action="store_true",
+        help="Enable K-LD7 horizontal angle radar (club path)",
     )
-    parser.add_argument(
-        "--kld7-horizontal-port", default=None, help="K-LD7 horizontal serial port"
-    )
+    parser.add_argument("--kld7-horizontal-port", default=None, help="K-LD7 horizontal serial port")
     parser.add_argument(
         "--kld7-horizontal-offset",
         type=float,
@@ -1674,18 +1728,32 @@ def main():
 
     # Initialize K-LD7 angle radars (if enabled)
     if args.kld7:
-        if init_kld7(port=args.kld7_port, orientation="vertical",
-                     angle_offset_deg=args.kld7_angle_offset, base_freq=0):
-            offset_str = f", offset: {args.kld7_angle_offset:+.1f}°" if args.kld7_angle_offset else ""
+        if init_kld7(
+            port=args.kld7_port,
+            orientation="vertical",
+            angle_offset_deg=args.kld7_angle_offset,
+            base_freq=0,
+        ):
+            offset_str = (
+                f", offset: {args.kld7_angle_offset:+.1f}°" if args.kld7_angle_offset else ""
+            )
             print(f"K-LD7 vertical radar enabled (launch angle{offset_str})")
         else:
             print("ERROR: K-LD7 vertical requested but failed to connect. Exiting.")
             sys.exit(1)
 
     if args.kld7_horizontal:
-        if init_kld7(port=args.kld7_horizontal_port, orientation="horizontal",
-                     angle_offset_deg=args.kld7_horizontal_offset, base_freq=2):
-            offset_str = f", offset: {args.kld7_horizontal_offset:+.1f}°" if args.kld7_horizontal_offset else ""
+        if init_kld7(
+            port=args.kld7_horizontal_port,
+            orientation="horizontal",
+            angle_offset_deg=args.kld7_horizontal_offset,
+            base_freq=2,
+        ):
+            offset_str = (
+                f", offset: {args.kld7_horizontal_offset:+.1f}°"
+                if args.kld7_horizontal_offset
+                else ""
+            )
             print(f"K-LD7 horizontal radar enabled (club path{offset_str})")
         else:
             print("ERROR: K-LD7 horizontal requested but failed to connect. Exiting.")

--- a/tests/test_kld7.py
+++ b/tests/test_kld7.py
@@ -8,9 +8,9 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from openflight.kld7.types import KLD7Angle, KLD7Frame
 from openflight.kld7.tracker import KLD7Tracker
-from openflight.launch_monitor import Shot, ClubType
+from openflight.kld7.types import KLD7Angle, KLD7Frame
+from openflight.launch_monitor import Shot
 from openflight.server import shot_to_dict
 
 # Path to real captured K-LD7 data (golf swings + body movement)
@@ -33,12 +33,16 @@ class TestKLD7Types:
         assert len(frame_with_radc.radc) == 3072
 
     def test_kld7_angle_vertical(self):
-        angle = KLD7Angle(vertical_deg=12.5, distance_m=2.0, magnitude=5000, confidence=0.8, num_frames=3)
+        angle = KLD7Angle(
+            vertical_deg=12.5, distance_m=2.0, magnitude=5000, confidence=0.8, num_frames=3
+        )
         assert angle.vertical_deg == 12.5
         assert angle.horizontal_deg is None
 
     def test_kld7_angle_horizontal(self):
-        angle = KLD7Angle(horizontal_deg=-3.2, distance_m=1.5, magnitude=4000, confidence=0.7, num_frames=2)
+        angle = KLD7Angle(
+            horizontal_deg=-3.2, distance_m=1.5, magnitude=4000, confidence=0.7, num_frames=2
+        )
         assert angle.horizontal_deg == -3.2
         assert angle.vertical_deg is None
 
@@ -58,15 +62,19 @@ class TestKLD7TrackerRingBuffer:
         tracker = self._make_tracker()
         now = time.time()
         for i in range(5):
-            tracker._add_frame(KLD7Frame(
-                timestamp=now + i * 0.03, tdat=None, pdat=[],
-            ))
+            tracker._add_frame(
+                KLD7Frame(
+                    timestamp=now + i * 0.03,
+                    tdat=None,
+                    pdat=[],
+                )
+            )
         assert len(tracker._ring_buffer) == 5
 
     def test_ring_buffer_max_size(self):
         tracker = self._make_tracker()
         tracker.max_buffer_frames = 10
-        tracker._ring_buffer = __import__('collections').deque(maxlen=10)
+        tracker._ring_buffer = __import__("collections").deque(maxlen=10)
         now = time.time()
         for i in range(20):
             tracker._add_frame(KLD7Frame(timestamp=now + i * 0.03, tdat=None, pdat=[]))
@@ -82,7 +90,13 @@ class TestKLD7TrackerRingBuffer:
     def test_snapshot_buffer(self):
         tracker = self._make_tracker()
         now = time.time()
-        tracker._add_frame(KLD7Frame(timestamp=now, tdat={"distance": 1.0, "speed": 5.0, "angle": 0.0, "magnitude": 3000}, pdat=[]))
+        tracker._add_frame(
+            KLD7Frame(
+                timestamp=now,
+                tdat={"distance": 1.0, "speed": 5.0, "angle": 0.0, "magnitude": 3000},
+                pdat=[],
+            )
+        )
         snap = tracker.snapshot_buffer()
         assert len(snap) == 1
         assert snap[0]["tdat"]["distance"] == 1.0
@@ -121,11 +135,13 @@ class TestKLD7RealData:
         for f in raw_frames:
             t = f["timestamp"] - t0
             if 0.4 <= t <= 4.0:
-                tracker._add_frame(KLD7Frame(
-                    timestamp=f["timestamp"],
-                    tdat=f.get("tdat"),
-                    pdat=f.get("pdat", []),
-                ))
+                tracker._add_frame(
+                    KLD7Frame(
+                        timestamp=f["timestamp"],
+                        tdat=f.get("tdat"),
+                        pdat=f.get("pdat", []),
+                    )
+                )
         assert tracker.get_angle_for_shot() is None
 
     def test_quiet_period_produces_no_results(self):
@@ -136,11 +152,13 @@ class TestKLD7RealData:
         for f in raw_frames:
             t = f["timestamp"] - t0
             if 19.0 <= t <= 24.0:
-                tracker._add_frame(KLD7Frame(
-                    timestamp=f["timestamp"],
-                    tdat=f.get("tdat"),
-                    pdat=f.get("pdat", []),
-                ))
+                tracker._add_frame(
+                    KLD7Frame(
+                        timestamp=f["timestamp"],
+                        tdat=f.get("tdat"),
+                        pdat=f.get("pdat", []),
+                    )
+                )
         assert tracker.get_angle_for_shot() is None
 
 
@@ -149,8 +167,11 @@ class TestKLD7Integration:
 
     def test_angle_attaches_to_shot_vertical(self):
         shot = Shot(
-            ball_speed_mph=150.0, timestamp=datetime.now(),
-            launch_angle_vertical=12.5, launch_angle_confidence=0.8, angle_source="radar",
+            ball_speed_mph=150.0,
+            timestamp=datetime.now(),
+            launch_angle_vertical=12.5,
+            launch_angle_confidence=0.8,
+            angle_source="radar",
         )
         result = shot_to_dict(shot)
         assert result["launch_angle_vertical"] == 12.5
@@ -158,8 +179,11 @@ class TestKLD7Integration:
 
     def test_angle_attaches_to_shot_horizontal(self):
         shot = Shot(
-            ball_speed_mph=150.0, timestamp=datetime.now(),
-            launch_angle_horizontal=-3.5, launch_angle_confidence=0.7, angle_source="radar",
+            ball_speed_mph=150.0,
+            timestamp=datetime.now(),
+            launch_angle_horizontal=-3.5,
+            launch_angle_confidence=0.7,
+            angle_source="radar",
         )
         result = shot_to_dict(shot)
         assert result["launch_angle_horizontal"] == -3.5
@@ -167,14 +191,18 @@ class TestKLD7Integration:
     def test_carry_adjusts_for_vertical_angle(self):
         shot_no_angle = Shot(ball_speed_mph=150.0, timestamp=datetime.now())
         shot_with_angle = Shot(
-            ball_speed_mph=150.0, timestamp=datetime.now(),
-            launch_angle_vertical=15.0, launch_angle_confidence=0.8, angle_source="radar",
+            ball_speed_mph=150.0,
+            timestamp=datetime.now(),
+            launch_angle_vertical=15.0,
+            launch_angle_confidence=0.8,
+            angle_source="radar",
         )
         assert shot_no_angle.estimated_carry_yards != shot_with_angle.estimated_carry_yards
 
     def test_club_angle_in_shot_dict(self):
         shot = Shot(
-            ball_speed_mph=150.0, timestamp=datetime.now(),
+            ball_speed_mph=150.0,
+            timestamp=datetime.now(),
             club_angle_deg=-5.5,
         )
         result = shot_to_dict(shot)
@@ -183,8 +211,12 @@ class TestKLD7Integration:
     def test_full_tracker_to_shot_flow(self):
         """Full flow: KLD7Angle manually attached to Shot appears in shot_to_dict."""
         angle = KLD7Angle(
-            vertical_deg=18.0, horizontal_deg=None,
-            confidence=0.85, num_frames=3, magnitude=5.2, detection_class="ball",
+            vertical_deg=18.0,
+            horizontal_deg=None,
+            confidence=0.85,
+            num_frames=3,
+            magnitude=5.2,
+            detection_class="ball",
         )
 
         shot = Shot(ball_speed_mph=150.0, timestamp=datetime.now())
@@ -211,7 +243,7 @@ class TestRADCAngleExtraction:
 
     def _make_radc_payload_with_tone(self, velocity_kmh, angle_deg=10.0, amplitude=5000):
         """Create a synthetic RADC payload with a tone at the given velocity."""
-        from openflight.kld7.radc import ANTENNA_SPACING_M, WAVELENGTH_M, SAMPLES_PER_CHANNEL
+        from openflight.kld7.radc import ANTENNA_SPACING_M, SAMPLES_PER_CHANNEL, WAVELENGTH_M
 
         n = SAMPLES_PER_CHANNEL  # 256
         max_speed_kmh = 100.0
@@ -232,8 +264,12 @@ class TestRADCAngleExtraction:
         # F2A channel: same tone shifted by angle-dependent phase
         angle_rad = np.radians(angle_deg)
         steering_phase = 2 * np.pi * ANTENNA_SPACING_M * np.sin(angle_rad) / WAVELENGTH_M
-        f2a_i = (amplitude * np.cos(phase_per_sample * t + steering_phase) + 32768).astype(np.uint16)
-        f2a_q = (amplitude * np.sin(phase_per_sample * t + steering_phase) + 32768).astype(np.uint16)
+        f2a_i = (amplitude * np.cos(phase_per_sample * t + steering_phase) + 32768).astype(
+            np.uint16
+        )
+        f2a_q = (amplitude * np.sin(phase_per_sample * t + steering_phase) + 32768).astype(
+            np.uint16
+        )
 
         # F1B channel: zeros (not used for angle)
         zeros = np.full(n, 32768, dtype=np.uint16)
@@ -289,10 +325,12 @@ class TestRADCAngleExtraction:
         now = time.time()
 
         for i in range(3):
-            tracker._add_frame(KLD7Frame(
-                timestamp=now + i * 0.033,
-                pdat=[{"distance": 4.2, "speed": 25.0, "angle": 15.0, "magnitude": 2500}],
-            ))
+            tracker._add_frame(
+                KLD7Frame(
+                    timestamp=now + i * 0.033,
+                    pdat=[{"distance": 4.2, "speed": 25.0, "angle": 15.0, "magnitude": 2500}],
+                )
+            )
 
         result = tracker.get_angle_for_shot(ball_speed_mph=None)
         assert result is None
@@ -321,3 +359,39 @@ class TestRADCAngleExtraction:
         result = tracker.get_angle_for_shot(ball_speed_mph=ball_speed_mph)
         assert result is not None
         assert result.vertical_deg == pytest.approx(15.0, abs=3.0)
+
+    def test_shot_timestamp_filters_to_nearby_frames(self, monkeypatch):
+        """A provided shot timestamp should narrow RADC extraction to the nearby burst."""
+        tracker = self._make_tracker()
+        tracker._add_frame(KLD7Frame(timestamp=100.00, radc=b"early-1"))
+        tracker._add_frame(KLD7Frame(timestamp=100.03, radc=b"early-2"))
+        tracker._add_frame(KLD7Frame(timestamp=100.80, radc=b"late-1"))
+        tracker._add_frame(KLD7Frame(timestamp=100.83, radc=b"late-2"))
+
+        captured_frames = []
+
+        def fake_extract_launch_angle(frames, **kwargs):
+            captured_frames.append(frames)
+            return [
+                {
+                    "launch_angle_deg": 12.0,
+                    "ball_speed_mph": kwargs["ops243_ball_speed_mph"],
+                    "avg_snr_db": 8.0,
+                    "confidence": 0.8,
+                    "frame_count": len(frames),
+                }
+            ]
+
+        monkeypatch.setattr(
+            "openflight.kld7.radc.extract_launch_angle",
+            fake_extract_launch_angle,
+        )
+
+        result = tracker.get_angle_for_shot(shot_timestamp=100.82, ball_speed_mph=72.0)
+
+        assert result is not None
+        assert len(captured_frames) == 1
+        assert captured_frames[0] == [
+            {"timestamp": 100.80, "radc": b"late-1"},
+            {"timestamp": 100.83, "radc": b"late-2"},
+        ]

--- a/tests/test_rolling_buffer.py
+++ b/tests/test_rolling_buffer.py
@@ -1,36 +1,36 @@
 """Tests for rolling_buffer module."""
 
 import math
-import pytest
-import numpy as np
 from datetime import datetime
-from unittest.mock import Mock, patch, MagicMock
+
+import numpy as np
+import pytest
 
 from openflight.launch_monitor import ClubType, Shot
 from openflight.rolling_buffer import (
     # Types
     IQCapture,
+    ManualTrigger,
+    PollingTrigger,
+    ProcessedCapture,
+    RollingBufferMonitor,
+    # Processor
+    RollingBufferProcessor,
     SpeedReading,
     SpeedTimeline,
     SpinResult,
-    ProcessedCapture,
-    # Processor
-    RollingBufferProcessor,
-    # Triggers
-    TriggerStrategy,
-    PollingTrigger,
     ThresholdTrigger,
-    ManualTrigger,
+    # Triggers
     create_trigger,
     # Monitor functions
     estimate_carry_with_spin,
     get_optimal_spin_for_ball_speed,
 )
 
-
 # =============================================================================
 # Tests for Optimal Spin Calculation
 # =============================================================================
+
 
 class TestGetOptimalSpinForBallSpeed:
     """Tests for the optimal spin rate calculation based on ball speed."""
@@ -99,6 +99,7 @@ class TestGetOptimalSpinForBallSpeed:
 # Tests for Carry Distance with Spin
 # =============================================================================
 
+
 class TestEstimateCarryWithSpin:
     """Tests for the spin-adjusted carry distance calculation."""
 
@@ -158,14 +159,10 @@ class TestEstimateCarryWithSpin:
         spin = 2600
 
         # Good contact: 150 mph ball / 100 mph club = 1.50 smash
-        carry_good = estimate_carry_with_spin(
-            ball_speed, spin, ClubType.DRIVER, club_speed_mph=100
-        )
+        carry_good = estimate_carry_with_spin(ball_speed, spin, ClubType.DRIVER, club_speed_mph=100)
 
         # Poor contact: 150 mph ball / 115 mph club = 1.30 smash
-        carry_poor = estimate_carry_with_spin(
-            ball_speed, spin, ClubType.DRIVER, club_speed_mph=115
-        )
+        carry_poor = estimate_carry_with_spin(ball_speed, spin, ClubType.DRIVER, club_speed_mph=115)
 
         assert carry_poor < carry_good
 
@@ -176,7 +173,10 @@ class TestEstimateCarryWithSpin:
 
         carry_no_club = estimate_carry_with_spin(ball_speed, spin, ClubType.DRIVER)
         carry_with_club = estimate_carry_with_spin(
-            ball_speed, spin, ClubType.DRIVER, club_speed_mph=101  # 1.48 smash - optimal
+            ball_speed,
+            spin,
+            ClubType.DRIVER,
+            club_speed_mph=101,  # 1.48 smash - optimal
         )
 
         # Should be very close (club speed at optimal smash has minimal effect)
@@ -210,6 +210,7 @@ class TestEstimateCarryWithSpin:
 # Tests for Rolling Buffer Types
 # =============================================================================
 
+
 class TestIQCapture:
     """Tests for IQCapture dataclass."""
 
@@ -227,6 +228,18 @@ class TestIQCapture:
         assert capture.sample_time == 0.136
         assert len(capture.i_samples) == 4096
         assert len(capture.q_samples) == 4096
+
+    def test_duration_ms_uses_capture_sample_rate(self):
+        """Duration should respect non-default sample rates."""
+        capture = IQCapture(
+            sample_time=0.164,
+            trigger_time=0.0,
+            i_samples=[100] * 4096,
+            q_samples=[100] * 4096,
+            sample_rate_hz=25000,
+        )
+
+        assert capture.duration_ms == pytest.approx((4096 / 25000) * 1000)
 
 
 class TestSpeedReading:
@@ -314,9 +327,43 @@ class TestSpinResult:
         assert result.quality == "low"
 
 
+class TestRollingBufferMonitor:
+    """Tests for RollingBufferMonitor shot creation."""
+
+    def _make_monitor(self):
+        monitor = RollingBufferMonitor.__new__(RollingBufferMonitor)
+        monitor._current_club = ClubType.DRIVER
+        return monitor
+
+    def test_create_shot_sets_impact_timestamp_from_capture_timing(self):
+        """Impact timestamp should be reconstructed from the capture timing data."""
+        monitor = self._make_monitor()
+        capture = IQCapture(
+            sample_time=10.000,
+            trigger_time=10.050,
+            i_samples=[100] * 4096,
+            q_samples=[100] * 4096,
+            timestamp=1_700_000_000.250,
+        )
+        timeline = SpeedTimeline(readings=[], sample_rate_hz=937.5, capture=capture)
+        processed = ProcessedCapture(
+            timeline=timeline,
+            ball_speed_mph=152.0,
+            ball_timestamp_ms=30.0,
+            club_speed_mph=101.0,
+            capture=capture,
+        )
+
+        shot = monitor._create_shot(processed)
+
+        assert shot is not None
+        assert shot.impact_timestamp == pytest.approx(1_700_000_000.230)
+
+
 # =============================================================================
 # Tests for Rolling Buffer Processor
 # =============================================================================
+
 
 class TestRollingBufferProcessor:
     """Tests for the FFT-based rolling buffer processor."""
@@ -341,6 +388,7 @@ class TestRollingBufferProcessor:
         q_samples = [2048 + int(100 * math.cos(2 * math.pi * i / 128)) for i in range(4096)]
 
         import json
+
         response = (
             '{"sample_time": 0.136}\n'
             '{"trigger_time": 0.0}\n'
@@ -355,6 +403,7 @@ class TestRollingBufferProcessor:
         assert len(capture.q_samples) == 4096
         assert capture.sample_time == 0.136
         assert capture.trigger_time == 0.0
+        assert capture.sample_rate_hz == processor.SAMPLE_RATE
 
     def test_parse_capture_invalid_json(self, processor):
         """Parser should handle invalid JSON gracefully."""
@@ -372,8 +421,12 @@ class TestRollingBufferProcessor:
         # 1500 Hz → bin ~205 → ~20.9 mph, safely above the mask.
         # I=sin, Q=cos produces a negative-frequency (inbound) tone.
         doppler_freq = 1500  # Hz - corresponds to ~20.9 mph
-        i_samples = [2048 + int(500 * math.sin(2 * math.pi * doppler_freq * i / 30000)) for i in range(4096)]
-        q_samples = [2048 + int(500 * math.cos(2 * math.pi * doppler_freq * i / 30000)) for i in range(4096)]
+        i_samples = [
+            2048 + int(500 * math.sin(2 * math.pi * doppler_freq * i / 30000)) for i in range(4096)
+        ]
+        q_samples = [
+            2048 + int(500 * math.cos(2 * math.pi * doppler_freq * i / 30000)) for i in range(4096)
+        ]
 
         capture = IQCapture(
             sample_time=0.136,
@@ -393,8 +446,12 @@ class TestRollingBufferProcessor:
     def test_process_overlapping_higher_resolution(self, processor):
         """Overlapping processing should give more readings than standard."""
         doppler_freq = 1500  # Hz - ~20.9 mph, above DC mask
-        i_samples = [2048 + int(500 * math.sin(2 * math.pi * doppler_freq * i / 30000)) for i in range(4096)]
-        q_samples = [2048 + int(500 * math.cos(2 * math.pi * doppler_freq * i / 30000)) for i in range(4096)]
+        i_samples = [
+            2048 + int(500 * math.sin(2 * math.pi * doppler_freq * i / 30000)) for i in range(4096)
+        ]
+        q_samples = [
+            2048 + int(500 * math.cos(2 * math.pi * doppler_freq * i / 30000)) for i in range(4096)
+        ]
 
         capture = IQCapture(
             sample_time=0.136,
@@ -417,6 +474,7 @@ class TestRollingBufferProcessor:
 # =============================================================================
 # Tests for Trigger Strategies
 # =============================================================================
+
 
 class TestTriggerFactory:
     """Tests for the trigger factory function."""
@@ -516,6 +574,7 @@ class TestManualTrigger:
 # Tests for Shot with Spin Fields
 # =============================================================================
 
+
 class TestShotWithSpin:
     """Tests for Shot dataclass spin-related fields."""
 
@@ -601,6 +660,7 @@ class TestShotWithSpin:
 # Integration Tests
 # =============================================================================
 
+
 class TestCarryCalculationIntegration:
     """Integration tests for the complete carry calculation pipeline."""
 
@@ -610,9 +670,6 @@ class TestCarryCalculationIntegration:
         ball_speed = 167  # Tour average
         club_speed = 113  # Tour average
         spin = 2686  # Tour average
-
-        # Calculate optimal spin for validation
-        optimal_spin = get_optimal_spin_for_ball_speed(ball_speed, ClubType.DRIVER)
 
         # Calculate carry
         carry = estimate_carry_with_spin(
@@ -629,14 +686,10 @@ class TestCarryCalculationIntegration:
     def test_amateur_shot_comparison(self):
         """Compare amateur vs Tour carry distances."""
         # Amateur: 140 mph ball, 95 mph club, 3000 rpm spin (slightly high)
-        amateur_carry = estimate_carry_with_spin(
-            140, 3000, ClubType.DRIVER, club_speed_mph=95
-        )
+        amateur_carry = estimate_carry_with_spin(140, 3000, ClubType.DRIVER, club_speed_mph=95)
 
         # Tour: 167 mph ball, 113 mph club, 2686 rpm spin (optimal)
-        tour_carry = estimate_carry_with_spin(
-            167, 2686, ClubType.DRIVER, club_speed_mph=113
-        )
+        tour_carry = estimate_carry_with_spin(167, 2686, ClubType.DRIVER, club_speed_mph=113)
 
         # Tour should be significantly longer (at least 30 yards more)
         assert tour_carry > amateur_carry + 30
@@ -669,6 +722,7 @@ class TestCarryCalculationIntegration:
 # =============================================================================
 # Tests for Trigger Diagnostics
 # =============================================================================
+
 
 class TestTriggerStrategyDiagnostics:
     """Tests for the diagnostic accumulation in TriggerStrategy."""
@@ -795,6 +849,7 @@ class TestTriggerStrategyDiagnostics:
 # Tests for FFT Dual-Peak Extraction and DC Mask
 # =============================================================================
 
+
 class TestDualPeakExtraction:
     """Tests for dual-peak FFT processing and DC mask."""
 
@@ -823,13 +878,11 @@ class TestDualPeakExtraction:
 
         # Outbound = positive frequency, Inbound = negative frequency
         # I + jQ: positive freq => I=cos, Q=sin; negative freq => I=cos, Q=-sin
-        i_signal = (
-            500 * np.cos(2 * np.pi * outbound_freq * t)
-            + 400 * np.cos(2 * np.pi * inbound_freq * t)
+        i_signal = 500 * np.cos(2 * np.pi * outbound_freq * t) + 400 * np.cos(
+            2 * np.pi * inbound_freq * t
         )
-        q_signal = (
-            500 * np.sin(2 * np.pi * outbound_freq * t)
-            - 400 * np.sin(2 * np.pi * inbound_freq * t)
+        q_signal = 500 * np.sin(2 * np.pi * outbound_freq * t) - 400 * np.sin(
+            2 * np.pi * inbound_freq * t
         )
 
         # Offset to simulate ADC midpoint
@@ -890,14 +943,8 @@ class TestDualPeakExtraction:
         club_freq = (40 / processor.MPS_TO_MPH) * 2 / processor.WAVELENGTH_M
         ball_freq = (120 / processor.MPS_TO_MPH) * 2 / processor.WAVELENGTH_M
 
-        i_signal = (
-            400 * np.cos(2 * np.pi * club_freq * t)
-            + 300 * np.cos(2 * np.pi * ball_freq * t)
-        )
-        q_signal = (
-            400 * np.sin(2 * np.pi * club_freq * t)
-            + 300 * np.sin(2 * np.pi * ball_freq * t)
-        )
+        i_signal = 400 * np.cos(2 * np.pi * club_freq * t) + 300 * np.cos(2 * np.pi * ball_freq * t)
+        q_signal = 400 * np.sin(2 * np.pi * club_freq * t) + 300 * np.sin(2 * np.pi * ball_freq * t)
 
         i_block = (i_signal + 2048).astype(np.float64)
         q_block = (q_signal + 2048).astype(np.float64)
@@ -944,13 +991,11 @@ class TestDualPeakExtraction:
         # Weaker outbound (ball) at 120 mph, amplitude 300
         outbound_freq = (120 / processor.MPS_TO_MPH) * 2 / processor.WAVELENGTH_M
 
-        i_signal = (
-            300 * np.cos(2 * np.pi * outbound_freq * t)
-            + 800 * np.cos(2 * np.pi * inbound_freq * t)
+        i_signal = 300 * np.cos(2 * np.pi * outbound_freq * t) + 800 * np.cos(
+            2 * np.pi * inbound_freq * t
         )
-        q_signal = (
-            300 * np.sin(2 * np.pi * outbound_freq * t)
-            - 800 * np.sin(2 * np.pi * inbound_freq * t)
+        q_signal = 300 * np.sin(2 * np.pi * outbound_freq * t) - 800 * np.sin(
+            2 * np.pi * inbound_freq * t
         )
 
         i_samples = (i_signal + 2048).astype(int).tolist()
@@ -982,6 +1027,7 @@ class TestDualPeakExtraction:
 # Tests for _find_peaks
 # =============================================================================
 
+
 class TestFindPeaks:
     """Tests for the _find_peaks local maxima finder."""
 
@@ -995,7 +1041,7 @@ class TestFindPeaks:
 
         magnitude = np.zeros(2048)
         magnitude[500] = 100.0  # Clear peak
-        magnitude[499] = 20.0   # Neighbors lower
+        magnitude[499] = 20.0  # Neighbors lower
         magnitude[501] = 20.0
 
         peaks = processor._find_peaks(magnitude, start=1, end=2048)
@@ -1101,6 +1147,7 @@ class TestFindPeaks:
 # Tests for find_club_speed with concurrent readings
 # =============================================================================
 
+
 class TestFindClubSpeedOverlap:
     """Tests for find_club_speed searching concurrent timestamps."""
 
@@ -1192,6 +1239,7 @@ class TestFindClubSpeedOverlap:
 # Tests for Multi-Peak Integration (end-to-end)
 # =============================================================================
 
+
 class TestMultiPeakIntegration:
     """End-to-end test: process_capture with synthetic club+ball I/Q."""
 
@@ -1210,14 +1258,8 @@ class TestMultiPeakIntegration:
         club_freq = (60 / processor.MPS_TO_MPH) * 2 / processor.WAVELENGTH_M
         ball_freq = (80 / processor.MPS_TO_MPH) * 2 / processor.WAVELENGTH_M
 
-        i_signal = (
-            400 * np.cos(2 * np.pi * club_freq * t)
-            + 300 * np.cos(2 * np.pi * ball_freq * t)
-        )
-        q_signal = (
-            400 * np.sin(2 * np.pi * club_freq * t)
-            + 300 * np.sin(2 * np.pi * ball_freq * t)
-        )
+        i_signal = 400 * np.cos(2 * np.pi * club_freq * t) + 300 * np.cos(2 * np.pi * ball_freq * t)
+        q_signal = 400 * np.sin(2 * np.pi * club_freq * t) + 300 * np.sin(2 * np.pi * ball_freq * t)
 
         i_samples = (i_signal + 2048).astype(int).tolist()
         q_samples = (q_signal + 2048).astype(int).tolist()
@@ -1246,6 +1288,7 @@ class TestMultiPeakIntegration:
 # Tests for extract_ball_speeds (spin detection fix)
 # =============================================================================
 
+
 class TestExtractBallSpeeds:
     """Tests for the updated extract_ball_speeds using ball position instead of trigger offset."""
 
@@ -1264,18 +1307,20 @@ class TestExtractBallSpeeds:
 
     def test_finds_ball_readings_at_ball_timestamp(self):
         """Ball readings at ball_timestamp_ms are included."""
-        timeline = self._make_timeline([
-            # Ball signal at t=10-60ms
-            (75.0, 10.0, 10.0, "outbound"),
-            (74.5, 9.0, 20.0, "outbound"),
-            (75.2, 8.0, 30.0, "outbound"),
-            (74.8, 7.0, 40.0, "outbound"),
-            (75.1, 6.0, 50.0, "outbound"),
-            # Club signal earlier
-            (55.0, 15.0, 0.0, "outbound"),
-            # Inbound noise
-            (30.0, 5.0, 25.0, "inbound"),
-        ])
+        timeline = self._make_timeline(
+            [
+                # Ball signal at t=10-60ms
+                (75.0, 10.0, 10.0, "outbound"),
+                (74.5, 9.0, 20.0, "outbound"),
+                (75.2, 8.0, 30.0, "outbound"),
+                (74.8, 7.0, 40.0, "outbound"),
+                (75.1, 6.0, 50.0, "outbound"),
+                # Club signal earlier
+                (55.0, 15.0, 0.0, "outbound"),
+                # Inbound noise
+                (30.0, 5.0, 25.0, "inbound"),
+            ]
+        )
         processor = RollingBufferProcessor()
         speeds = processor.extract_ball_speeds(
             timeline, ball_timestamp_ms=10.0, ball_speed_mph=75.0
@@ -1285,15 +1330,19 @@ class TestExtractBallSpeeds:
 
     def test_filters_by_speed_band(self):
         """Only readings within speed tolerance of ball_speed_mph are included."""
-        timeline = self._make_timeline([
-            (75.0, 10.0, 10.0, "outbound"),  # In band
-            (74.0, 9.0, 20.0, "outbound"),   # In band
-            (55.0, 15.0, 15.0, "outbound"),  # Out of band (club speed)
-            (90.0, 5.0, 25.0, "outbound"),   # Out of band (too fast)
-        ])
+        timeline = self._make_timeline(
+            [
+                (75.0, 10.0, 10.0, "outbound"),  # In band
+                (74.0, 9.0, 20.0, "outbound"),  # In band
+                (55.0, 15.0, 15.0, "outbound"),  # Out of band (club speed)
+                (90.0, 5.0, 25.0, "outbound"),  # Out of band (too fast)
+            ]
+        )
         processor = RollingBufferProcessor()
         speeds = processor.extract_ball_speeds(
-            timeline, ball_timestamp_ms=10.0, ball_speed_mph=75.0,
+            timeline,
+            ball_timestamp_ms=10.0,
+            ball_speed_mph=75.0,
             speed_tolerance_mph=5.0,
         )
         assert len(speeds) == 2
@@ -1302,43 +1351,55 @@ class TestExtractBallSpeeds:
 
     def test_respects_window(self):
         """Only readings within window_ms after ball_timestamp_ms are included."""
-        timeline = self._make_timeline([
-            (75.0, 10.0, 10.0, "outbound"),
-            (74.5, 9.0, 30.0, "outbound"),
-            (75.2, 8.0, 50.0, "outbound"),
-            (74.8, 7.0, 80.0, "outbound"),  # Outside 50ms window
-            (75.1, 6.0, 100.0, "outbound"),  # Outside 50ms window
-        ])
+        timeline = self._make_timeline(
+            [
+                (75.0, 10.0, 10.0, "outbound"),
+                (74.5, 9.0, 30.0, "outbound"),
+                (75.2, 8.0, 50.0, "outbound"),
+                (74.8, 7.0, 80.0, "outbound"),  # Outside 50ms window
+                (75.1, 6.0, 100.0, "outbound"),  # Outside 50ms window
+            ]
+        )
         processor = RollingBufferProcessor()
         speeds = processor.extract_ball_speeds(
-            timeline, ball_timestamp_ms=10.0, ball_speed_mph=75.0,
+            timeline,
+            ball_timestamp_ms=10.0,
+            ball_speed_mph=75.0,
             window_ms=50,
         )
         assert len(speeds) == 3
 
     def test_excludes_inbound_readings(self):
         """Inbound readings are always excluded."""
-        timeline = self._make_timeline([
-            (75.0, 10.0, 10.0, "outbound"),
-            (74.0, 9.0, 20.0, "inbound"),   # Same speed band but inbound
-        ])
+        timeline = self._make_timeline(
+            [
+                (75.0, 10.0, 10.0, "outbound"),
+                (74.0, 9.0, 20.0, "inbound"),  # Same speed band but inbound
+            ]
+        )
         processor = RollingBufferProcessor()
         speeds = processor.extract_ball_speeds(
-            timeline, ball_timestamp_ms=10.0, ball_speed_mph=75.0,
+            timeline,
+            ball_timestamp_ms=10.0,
+            ball_speed_mph=75.0,
         )
         assert len(speeds) == 1
 
     def test_excludes_readings_before_ball_timestamp(self):
         """Readings before ball_timestamp_ms are excluded."""
-        timeline = self._make_timeline([
-            (75.0, 10.0, 0.0, "outbound"),   # Before ball_timestamp
-            (74.5, 9.0, 5.0, "outbound"),    # Before ball_timestamp
-            (75.2, 8.0, 10.0, "outbound"),   # At ball_timestamp (included)
-            (74.8, 7.0, 20.0, "outbound"),   # After (included)
-        ])
+        timeline = self._make_timeline(
+            [
+                (75.0, 10.0, 0.0, "outbound"),  # Before ball_timestamp
+                (74.5, 9.0, 5.0, "outbound"),  # Before ball_timestamp
+                (75.2, 8.0, 10.0, "outbound"),  # At ball_timestamp (included)
+                (74.8, 7.0, 20.0, "outbound"),  # After (included)
+            ]
+        )
         processor = RollingBufferProcessor()
         speeds = processor.extract_ball_speeds(
-            timeline, ball_timestamp_ms=10.0, ball_speed_mph=75.0,
+            timeline,
+            ball_timestamp_ms=10.0,
+            ball_speed_mph=75.0,
         )
         assert len(speeds) == 2
 
@@ -1347,20 +1408,26 @@ class TestExtractBallSpeeds:
         timeline = self._make_timeline([])
         processor = RollingBufferProcessor()
         speeds = processor.extract_ball_speeds(
-            timeline, ball_timestamp_ms=10.0, ball_speed_mph=75.0,
+            timeline,
+            ball_timestamp_ms=10.0,
+            ball_speed_mph=75.0,
         )
         assert speeds == []
 
     def test_custom_speed_tolerance(self):
         """Custom speed_tolerance_mph is respected."""
-        timeline = self._make_timeline([
-            (75.0, 10.0, 10.0, "outbound"),
-            (72.0, 9.0, 20.0, "outbound"),  # Within ±5 but not ±2
-            (74.0, 8.0, 30.0, "outbound"),  # Within ±2
-        ])
+        timeline = self._make_timeline(
+            [
+                (75.0, 10.0, 10.0, "outbound"),
+                (72.0, 9.0, 20.0, "outbound"),  # Within ±5 but not ±2
+                (74.0, 8.0, 30.0, "outbound"),  # Within ±2
+            ]
+        )
         processor = RollingBufferProcessor()
         speeds = processor.extract_ball_speeds(
-            timeline, ball_timestamp_ms=10.0, ball_speed_mph=75.0,
+            timeline,
+            ball_timestamp_ms=10.0,
+            ball_speed_mph=75.0,
             speed_tolerance_mph=2.0,
         )
         assert len(speeds) == 2  # 75.0 and 74.0 only
@@ -1401,11 +1468,15 @@ class TestSpinDetectionIntegration:
     def test_spin_detected_7iron(self):
         """7-iron at 7000 RPM should be reliably detected."""
         i_samples, q_samples = self._make_iq_with_seam_modulation(
-            base_speed_mph=120, spin_rpm=7000, modulation_depth=0.03,
+            base_speed_mph=120,
+            spin_rpm=7000,
+            modulation_depth=0.03,
         )
         capture = IQCapture(
-            sample_time=0.0, trigger_time=0.068,
-            i_samples=i_samples, q_samples=q_samples,
+            sample_time=0.0,
+            trigger_time=0.068,
+            i_samples=i_samples,
+            q_samples=q_samples,
         )
         processor = RollingBufferProcessor()
         result = processor.process_capture(capture)
@@ -1423,11 +1494,15 @@ class TestSpinDetectionIntegration:
         the spin algorithm independent of the speed timeline.
         """
         i_samples, q_samples = self._make_iq_with_seam_modulation(
-            base_speed_mph=160, spin_rpm=3000, modulation_depth=0.03,
+            base_speed_mph=160,
+            spin_rpm=3000,
+            modulation_depth=0.03,
         )
         capture = IQCapture(
-            sample_time=0.0, trigger_time=0.068,
-            i_samples=i_samples, q_samples=q_samples,
+            sample_time=0.0,
+            trigger_time=0.068,
+            i_samples=i_samples,
+            q_samples=q_samples,
         )
         processor = RollingBufferProcessor()
         result = processor.detect_spin(capture, ball_speed_mph=160, ball_timestamp_ms=5.0)
@@ -1437,11 +1512,15 @@ class TestSpinDetectionIntegration:
     def test_spin_detected_wedge(self):
         """Wedge at 10000 RPM."""
         i_samples, q_samples = self._make_iq_with_seam_modulation(
-            base_speed_mph=90, spin_rpm=10000, modulation_depth=0.05,
+            base_speed_mph=90,
+            spin_rpm=10000,
+            modulation_depth=0.05,
         )
         capture = IQCapture(
-            sample_time=0.0, trigger_time=0.068,
-            i_samples=i_samples, q_samples=q_samples,
+            sample_time=0.0,
+            trigger_time=0.068,
+            i_samples=i_samples,
+            q_samples=q_samples,
         )
         processor = RollingBufferProcessor()
         result = processor.process_capture(capture)
@@ -1466,24 +1545,30 @@ class TestSpinDetectionIntegration:
         q_samples = (200 * np.sin(phase) + 2048).astype(int).clip(0, 4095).tolist()
 
         capture = IQCapture(
-            sample_time=0.0, trigger_time=0.068,
-            i_samples=i_samples, q_samples=q_samples,
+            sample_time=0.0,
+            trigger_time=0.068,
+            i_samples=i_samples,
+            q_samples=q_samples,
         )
         processor = RollingBufferProcessor()
         result = processor.process_capture(capture)
         assert result is not None
         assert result.spin is not None
-        assert result.spin.spin_rpm == 0 or result.spin.quality not in ("high", "medium"), \
+        assert result.spin.spin_rpm == 0 or result.spin.quality not in ("high", "medium"), (
             f"Unexpected spin: {result.spin.spin_rpm} RPM, quality={result.spin.quality}"
+        )
 
     def test_spin_result_is_populated(self):
         """process_capture should always populate the spin field."""
         i_samples, q_samples = self._make_iq_with_seam_modulation(
-            base_speed_mph=130, spin_rpm=5000,
+            base_speed_mph=130,
+            spin_rpm=5000,
         )
         capture = IQCapture(
-            sample_time=0.0, trigger_time=0.068,
-            i_samples=i_samples, q_samples=q_samples,
+            sample_time=0.0,
+            trigger_time=0.068,
+            i_samples=i_samples,
+            q_samples=q_samples,
         )
         processor = RollingBufferProcessor()
         result = processor.process_capture(capture)
@@ -1494,6 +1579,7 @@ class TestSpinDetectionIntegration:
 # =============================================================================
 # Tests for Spin Validation Gates
 # =============================================================================
+
 
 class TestSpinValidationGates:
     """Tests for spin detection validation: RPM ceiling, confidence tiers, modulation floor."""
@@ -1527,27 +1613,33 @@ class TestSpinValidationGates:
         """
         processor = RollingBufferProcessor()
         i_samples, q_samples = self._make_iq_with_seam_modulation(
-            base_speed_mph=100, spin_rpm=18000, modulation_depth=0.05,
+            base_speed_mph=100,
+            spin_rpm=18000,
+            modulation_depth=0.05,
         )
         capture = IQCapture(
-            sample_time=0.0, trigger_time=0.068,
-            i_samples=i_samples, q_samples=q_samples,
+            sample_time=0.0,
+            trigger_time=0.068,
+            i_samples=i_samples,
+            q_samples=q_samples,
         )
         result = processor.detect_spin(capture, ball_speed_mph=100, ball_timestamp_ms=5.0)
-        assert result.spin_rpm == 0, (
-            f"18000 RPM should be rejected, got {result.spin_rpm} RPM"
-        )
+        assert result.spin_rpm == 0, f"18000 RPM should be rejected, got {result.spin_rpm} RPM"
 
     def test_medium_snr_low_cycles_gets_reduced_confidence(self):
         """SNR >= 5 but < 3 seam cycles should score 0.5, not 0.7."""
         processor = RollingBufferProcessor()
         i_samples, q_samples = self._make_iq_with_seam_modulation(
-            base_speed_mph=130, spin_rpm=4000, modulation_depth=0.04,
+            base_speed_mph=130,
+            spin_rpm=4000,
+            modulation_depth=0.04,
             num_samples=700,
         )
         capture = IQCapture(
-            sample_time=0.0, trigger_time=0.003,
-            i_samples=i_samples, q_samples=q_samples,
+            sample_time=0.0,
+            trigger_time=0.003,
+            i_samples=i_samples,
+            q_samples=q_samples,
         )
         result = processor.detect_spin(capture, ball_speed_mph=130, ball_timestamp_ms=1.0)
         if result.spin_rpm > 0:
@@ -1559,11 +1651,15 @@ class TestSpinValidationGates:
         """Modulation depth < 1% should cap confidence at 0.5 max."""
         processor = RollingBufferProcessor()
         i_samples, q_samples = self._make_iq_with_seam_modulation(
-            base_speed_mph=130, spin_rpm=5000, modulation_depth=0.008,
+            base_speed_mph=130,
+            spin_rpm=5000,
+            modulation_depth=0.008,
         )
         capture = IQCapture(
-            sample_time=0.0, trigger_time=0.068,
-            i_samples=i_samples, q_samples=q_samples,
+            sample_time=0.0,
+            trigger_time=0.068,
+            i_samples=i_samples,
+            q_samples=q_samples,
         )
         result = processor.detect_spin(capture, ball_speed_mph=130, ball_timestamp_ms=5.0)
         if result.spin_rpm > 0:
@@ -1575,14 +1671,16 @@ class TestSpinValidationGates:
         """Clean spin with good SNR and many cycles should still score >= 0.8."""
         processor = RollingBufferProcessor()
         i_samples, q_samples = self._make_iq_with_seam_modulation(
-            base_speed_mph=120, spin_rpm=7000, modulation_depth=0.03,
+            base_speed_mph=120,
+            spin_rpm=7000,
+            modulation_depth=0.03,
         )
         capture = IQCapture(
-            sample_time=0.0, trigger_time=0.068,
-            i_samples=i_samples, q_samples=q_samples,
+            sample_time=0.0,
+            trigger_time=0.068,
+            i_samples=i_samples,
+            q_samples=q_samples,
         )
         result = processor.detect_spin(capture, ball_speed_mph=120, ball_timestamp_ms=5.0)
         assert result.spin_rpm > 0, f"Should detect spin, got quality={result.quality}"
-        assert result.confidence >= 0.8, (
-            f"Strong spin should score >= 0.8, got {result.confidence}"
-        )
+        assert result.confidence >= 0.8, f"Strong spin should score >= 0.8, got {result.confidence}"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,14 +1,16 @@
 """Tests for server module."""
 
+import argparse
 import json
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
-from openflight.launch_monitor import Shot, ClubType
-from openflight.kld7.types import KLD7Angle
 from openflight import server as server_module
+from openflight.kld7.types import KLD7Angle
+from openflight.launch_monitor import ClubType, Shot
 from openflight.server import (
     MockLaunchMonitor,
     estimate_launch_angle,
@@ -65,7 +67,6 @@ class TestShotToDict:
         assert result["ball_speed_mph"] == 150.5  # 1 decimal
         assert result["club_speed_mph"] == 103.8  # 1 decimal
         assert result["smash_factor"] == 1.45  # 2 decimals
-
 
     def test_angle_source_field(self):
         """shot_to_dict should include angle_source."""
@@ -187,9 +188,7 @@ class TestEstimateLaunchAngle:
 
     def test_spin_with_smash_raises_confidence(self):
         """Providing both club speed and spin should raise confidence to 0.5."""
-        _, conf = estimate_launch_angle(
-            ClubType.DRIVER, 143, club_speed_mph=96.6, spin_rpm=2500
-        )
+        _, conf = estimate_launch_angle(ClubType.DRIVER, 143, club_speed_mph=96.6, spin_rpm=2500)
         assert conf == 0.5
 
     def test_spin_alone_confidence(self):
@@ -258,6 +257,56 @@ class TestMockLaunchMonitor:
         shot = monitor.simulate_shot()
 
         assert shot.club == ClubType.IRON_7
+
+
+class TestMain:
+    """Tests for server startup and shutdown paths."""
+
+    def test_main_exits_cleanly_when_kld7_init_fails(self, monkeypatch):
+        """Requesting K-LD7 should exit with status 1 if initialization fails."""
+        args = argparse.Namespace(
+            port=None,
+            mock=False,
+            host="127.0.0.1",
+            web_port=8080,
+            debug=False,
+            radar_log=False,
+            show_raw=False,
+            no_camera=True,
+            camera_model=None,
+            camera_imgsz=256,
+            hough_param2=33,
+            hough_param1=48,
+            hough_min_radius=4,
+            hough_max_radius=43,
+            hough_min_dist=266,
+            roboflow_model=None,
+            roboflow_api_key=None,
+            session_location="range",
+            log_dir=None,
+            no_logging=True,
+            trigger="polling",
+            sound_pre_trigger=16,
+            sample_rate=30,
+            kld7=True,
+            kld7_port=None,
+            kld7_angle_offset=0.0,
+            kld7_horizontal=False,
+            kld7_horizontal_port=None,
+            kld7_horizontal_offset=0.0,
+        )
+        start_monitor = Mock()
+
+        monkeypatch.setattr("argparse.ArgumentParser.parse_args", lambda self: args)
+        monkeypatch.setattr(server_module, "init_kld7", lambda **kwargs: False)
+        monkeypatch.setattr(server_module, "init_session_logger", Mock())
+        monkeypatch.setattr(server_module, "start_monitor", start_monitor)
+
+        with pytest.raises(SystemExit) as exc_info:
+            server_module.main()
+
+        assert exc_info.value.code == 1
+        start_monitor.assert_not_called()
 
     def test_get_shots(self):
         """Get shots should return copy of shots list."""
@@ -401,7 +450,9 @@ class TestOnShotDetected:
         monkeypatch.setattr(server_module, "monitor", None)
         monkeypatch.setattr(server_module, "debug_mode", False)
         monkeypatch.setattr(server_module, "get_session_logger", lambda: None)
-        monkeypatch.setattr(server_module.socketio, "emit", lambda *args, **kwargs: emitted.append((args, kwargs)))
+        monkeypatch.setattr(
+            server_module.socketio, "emit", lambda *args, **kwargs: emitted.append((args, kwargs))
+        )
 
         shot = Shot(
             ball_speed_mph=150.0,
@@ -417,6 +468,7 @@ class TestOnShotDetected:
 
     def test_implausible_kld7_angle_falls_back_to_estimate(self, monkeypatch):
         """Radar angles that conflict with club+speed should not override the estimate."""
+
         class StubTracker:
             orientation = "vertical"
 
@@ -450,6 +502,7 @@ class TestOnShotDetected:
 
     def test_implausible_club_aoa_is_rejected(self, monkeypatch):
         """A +31° club AoA is physically impossible and should be discarded."""
+
         class StubTracker:
             orientation = "vertical"
 
@@ -489,6 +542,7 @@ class TestOnShotDetected:
 
     def test_plausible_kld7_angle_remains_radar_source(self, monkeypatch):
         """Plausible radar angles should continue to override the estimate."""
+
         class StubTracker:
             orientation = "vertical"
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes the timing handoff between rolling-buffer shot detection and K-LD7 angle correlation. Before this change, the live path could correlate K-LD7 data against delayed callback time or scan too much of the ring buffer, which made shot matching less reliable. It also fixes rolling-buffer capture metadata so duration and timing stay correct when the radar is not running at the default sample rate.

### Before / after

- `impact_timestamp` on rolling-buffer shots
  - Before: a shot detected at ball impact could reach the server without an `impact_timestamp`, so K-LD7 correlation fell back to callback wall-clock time.
  - After: rolling-buffer shots carry a reconstructed impact timestamp based on capture timing and ball offset, so K-LD7 correlation is anchored to the captured impact moment.

- K-LD7 `shot_timestamp` handling
  - Before: `get_angle_for_shot(shot_timestamp=...)` accepted a timestamp but still scanned the full RADC ring buffer.
  - After: the tracker narrows RADC frame selection around the provided shot timestamp before extracting the angle.

- K-LD7 startup failure path
  - Before: if K-LD7 initialization failed, the server tried to call `sys.exit(1)` without importing `sys`, raising `NameError` instead of exiting cleanly.
  - After: the failure path exits cleanly with status `1`.

- Rolling-buffer capture duration metadata
  - Before: `IQCapture.duration_ms` always assumed `30 ksps`, so a `25 ksps` capture reported the wrong duration.
  - After: capture duration uses the stored sample rate from the actual capture, so non-default rates report correct timing.

## How was this tested?

- `uv run --python .venv\Scripts\python.exe --no-project pytest tests -q --basetemp=.pytest-tmp`
- `uv run --python .venv\Scripts\python.exe --no-project pylint src/openflight --fail-under=9`
- `npm.cmd run lint`
- `npm.cmd run build`
- `ruff` was run through pre-commit for the touched files and passed
- repo-wide `uv run ruff check src/openflight` still reports pre-existing unrelated issues in camera and package init modules

## Checklist

- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [ ] Ruff passes (`uv run ruff check src/openflight/`)
- [x] UI builds (`cd ui && npm run build`)
- [x] UI lint passes (`cd ui && npm run lint`)
- [x] Updated docs or CHANGELOG if needed
- [x] No unrelated changes mixed in