### PR TITLE
Add missing Flask server dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
     "scipy>=1.10.0",
     "trackers @ git+https://github.com/roboflow/trackers.git",
     "supervision>=0.26.0",
+    "flask>=3.1.3",
+    "flask-cors>=6.0.2",
+    "flask-socketio>=5.6.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What does this PR do?

Adds missing Flask server dependencies used by `src/openflight/server.py`.

The server imports these packages but they were not declared in `pyproject.toml`, which caused `make test` to fail during test collection on a fresh install:

- `flask`
- `flask-cors`
- `flask-socketio`

This PR adds those dependencies so a clean `make install` environment can import the server module correctly.

## How was this tested?

Tested on a fresh local setup with:

```bash
make install
make test