### PR TITLE
Tv display mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ scripts/start-kiosk.sh --mock
 
 Then open http://localhost:8080 or use the touchscreen.
 
+### TV Display Mode
+
+OpenFlight also serves a fullscreen-friendly browser display for tablets, TV browsers, or a Chrome tab cast to Chromecast.
+
+1. Start OpenFlight as usual with `scripts/start-kiosk.sh`.
+2. Find the OpenFlight host IP address on your LAN.
+3. Open `http://<openflight-host-ip>:8080/display` from another laptop, tablet, or TV browser.
+4. For Chromecast, open the display page in Chrome and use Chrome's built-in **Cast** feature to cast the tab.
+
+This is browser/tab casting only. OpenFlight does not include native Cast SDK support yet.
+
 ## How It Works
 
 ### System Architecture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
     "scipy>=1.10.0",
     "trackers @ git+https://github.com/roboflow/trackers.git",
     "supervision>=0.26.0",
+    "flask>=3.1.3",
+    "flask-cors>=6.0.2",
+    "flask-socketio>=5.6.1",
 ]
 
 [project.optional-dependencies]

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -418,6 +418,12 @@ def index():
     return send_from_directory(app.static_folder, "index.html")
 
 
+@app.route("/display", strict_slashes=False)
+def display():
+    """Serve the React app for TV display mode."""
+    return send_from_directory(app.static_folder, "index.html")
+
+
 @app.route("/<path:path>")
 def static_files(path):
     """Serve static files."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,6 +18,28 @@ from openflight.server import (
 )
 
 
+class TestStaticRoutes:
+    """Tests for frontend static routes."""
+
+    def test_display_route_serves_react_app(self):
+        """Direct refresh of /display should return the React app."""
+        client = server_module.app.test_client()
+
+        response = client.get("/display")
+
+        assert response.status_code == 200
+        assert b'<div id="root"></div>' in response.data
+
+    def test_display_route_accepts_trailing_slash(self):
+        """TV browsers may preserve a trailing slash on /display/."""
+        client = server_module.app.test_client()
+
+        response = client.get("/display/")
+
+        assert response.status_code == 200
+        assert b'<div id="root"></div>' in response.data
+
+
 class TestShotToDict:
     """Tests for shot_to_dict conversion."""
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,6 +8,7 @@ import { CameraFeed } from './components/CameraFeed';
 import { ConnectionStatus } from './components/ConnectionStatus';
 import { ClubPicker } from './components/ClubPicker';
 import { BallDetectionIndicator } from './components/BallDetectionIndicator';
+import { DisplayMode } from './components/DisplayMode';
 import {
   LaunchDaddyProvider,
   useLaunchDaddy,
@@ -86,6 +87,8 @@ function AppContent() {
   const [showShutdown, setShowShutdown] = useState(false);
   const { isLaunchDaddyMode, isExploding, triggerExplosion, handleSecretTap } = useLaunchDaddy();
   const { unitSystem, setUnitSystem } = useUnitPreference();
+  const isDisplayRoute =
+    typeof window !== 'undefined' && window.location.pathname.replace(/\/$/, '') === '/display';
 
   // Trigger explosion when a new shot is detected in Launch Daddy mode
   useEffect(() => {
@@ -99,6 +102,17 @@ function AppContent() {
     setSelectedClub(club);
     setClub(club);
   };
+
+  if (isDisplayRoute) {
+    return (
+      <DisplayMode
+        connected={connected}
+        cameraStatus={cameraStatus}
+        latestShot={latestShot}
+        shots={shots}
+      />
+    );
+  }
 
   return (
     <div className={`app ${isLaunchDaddyMode ? 'app--launch-daddy' : ''} ${isExploding ? 'app--exploding' : ''}`}>

--- a/ui/src/components/CameraFeed.tsx
+++ b/ui/src/components/CameraFeed.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { CameraStatus } from '../hooks/useSocket';
+import { getServerOrigin } from '../utils/serverOrigin';
 import './CameraFeed.css';
 
 interface CameraFeedProps {
@@ -8,9 +9,7 @@ interface CameraFeedProps {
   onToggleStream: () => void;
 }
 
-const STREAM_URL = import.meta.env.VITE_SOCKET_URL
-  ? `${import.meta.env.VITE_SOCKET_URL}/camera/stream`
-  : 'http://localhost:8080/camera/stream';
+const STREAM_URL = `${getServerOrigin()}/camera/stream`;
 
 export function CameraFeed({ cameraStatus, onToggleCamera, onToggleStream }: CameraFeedProps) {
   const [streamError, setStreamError] = useState(false);

--- a/ui/src/components/DisplayMode.css
+++ b/ui/src/components/DisplayMode.css
@@ -1,0 +1,273 @@
+.display-mode {
+  min-height: 100vh;
+  width: 100%;
+  padding: clamp(1rem, 2vw, 2rem);
+  background:
+    radial-gradient(ellipse at top left, rgba(212, 175, 55, 0.1), transparent 38rem),
+    var(--color-bg-deep);
+  color: var(--text-primary);
+  overflow: hidden;
+}
+
+.display-mode__hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(28rem, 0.75fr);
+  gap: clamp(1rem, 2vw, 2rem);
+  min-height: calc(100vh - 9.5rem);
+}
+
+.display-mode__camera,
+.display-mode__shot-panel {
+  min-width: 0;
+}
+
+.display-mode__camera {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 24rem;
+  border: 1px solid rgba(245, 240, 230, 0.12);
+  border-radius: var(--radius-lg);
+  background: #050508;
+  overflow: hidden;
+  box-shadow: var(--shadow-card);
+}
+
+.display-mode__camera-image {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  flex: 1;
+  object-fit: cover;
+  background: #050508;
+}
+
+.display-mode__camera-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  min-height: 24rem;
+  padding: 2rem;
+  color: var(--text-secondary);
+  font-size: clamp(1.5rem, 3vw, 3rem);
+  font-weight: 700;
+  text-align: center;
+}
+
+.display-mode__status-row {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.display-mode__status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0.4rem 0.75rem;
+  border: 1px solid rgba(245, 240, 230, 0.14);
+  border-radius: 999px;
+  background: rgba(10, 10, 15, 0.78);
+  color: var(--text-secondary);
+  font-size: clamp(0.8rem, 1.1vw, 1rem);
+  font-weight: 700;
+}
+
+.display-mode__status::before {
+  content: '';
+  width: 0.55rem;
+  height: 0.55rem;
+  margin-right: 0.45rem;
+  border-radius: 999px;
+  background: var(--color-danger);
+}
+
+.display-mode__status--online::before {
+  background: var(--color-success);
+}
+
+.display-mode__shot-panel {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.75rem, 1.6vw, 1.25rem);
+}
+
+.display-mode__eyebrow {
+  color: var(--color-gold);
+  font-size: clamp(0.85rem, 1.2vw, 1.1rem);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.display-mode__title {
+  margin: 0;
+  color: var(--color-cream);
+  font-family: var(--font-display);
+  font-size: clamp(3rem, 5vw, 6rem);
+  font-weight: 400;
+  line-height: 0.95;
+  text-transform: capitalize;
+}
+
+.display-mode__primary-grid,
+.display-mode__metrics-grid {
+  display: grid;
+  gap: clamp(0.65rem, 1.2vw, 1rem);
+}
+
+.display-mode__primary-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.display-mode__metrics-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  flex: 1;
+}
+
+.display-metric {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 8.5rem;
+  padding: clamp(0.8rem, 1.4vw, 1.25rem);
+  border: 1px solid rgba(245, 240, 230, 0.1);
+  border-radius: var(--radius-md);
+  background: rgba(18, 18, 26, 0.86);
+  box-shadow: var(--shadow-card);
+}
+
+.display-metric--featured {
+  min-height: clamp(10rem, 18vh, 15rem);
+  border-color: rgba(212, 175, 55, 0.35);
+  background: linear-gradient(145deg, rgba(212, 175, 55, 0.18), rgba(18, 18, 26, 0.92));
+}
+
+.display-metric__label,
+.display-metric__detail {
+  color: var(--text-muted);
+  font-size: clamp(0.8rem, 1.15vw, 1rem);
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.display-metric__value-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.display-metric__value {
+  color: var(--color-cream);
+  font-size: clamp(2.35rem, 4vw, 4.75rem);
+  font-weight: 800;
+  line-height: 1;
+}
+
+.display-metric--featured .display-metric__value {
+  color: var(--color-gold-bright);
+  font-size: clamp(4rem, 7.4vw, 8.5rem);
+}
+
+.display-metric__unit {
+  color: var(--text-secondary);
+  font-size: clamp(0.95rem, 1.4vw, 1.4rem);
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.display-metric__detail {
+  min-height: 1.25rem;
+  margin-top: 0.4rem;
+  color: var(--color-gold);
+}
+
+.display-mode__recent {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: clamp(0.6rem, 1vw, 0.9rem);
+  margin-top: clamp(0.75rem, 1.5vw, 1.25rem);
+}
+
+.display-mode__empty-strip,
+.display-shot-chip {
+  min-height: 4.9rem;
+  border: 1px solid rgba(245, 240, 230, 0.1);
+  border-radius: var(--radius-md);
+  background: rgba(18, 18, 26, 0.78);
+}
+
+.display-mode__empty-strip {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: clamp(1rem, 1.5vw, 1.35rem);
+  font-weight: 700;
+}
+
+.display-shot-chip {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.2rem 0.6rem;
+  align-content: center;
+  padding: 0.75rem;
+}
+
+.display-shot-chip__number,
+.display-shot-chip__club {
+  color: var(--color-gold);
+  font-weight: 800;
+}
+
+.display-shot-chip__club {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: capitalize;
+  white-space: nowrap;
+}
+
+.display-shot-chip__stat {
+  color: var(--text-secondary);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+@media (max-width: 1100px) {
+  .display-mode {
+    overflow: auto;
+  }
+
+  .display-mode__hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  .display-mode__camera {
+    aspect-ratio: 16 / 9;
+  }
+
+  .display-mode__recent {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 700px) {
+  .display-mode__primary-grid,
+  .display-mode__metrics-grid,
+  .display-mode__recent {
+    grid-template-columns: 1fr;
+  }
+
+  .display-mode__camera-placeholder {
+    min-height: 16rem;
+  }
+}

--- a/ui/src/components/DisplayMode.test.tsx
+++ b/ui/src/components/DisplayMode.test.tsx
@@ -1,0 +1,52 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { UnitPreferenceProvider } from '../state/UnitPreferenceProvider';
+import type { CameraStatus } from '../hooks/useSocket';
+import type { Shot } from '../types/shot';
+import { DisplayMode } from './DisplayMode';
+
+const cameraStatus: CameraStatus = {
+  available: true,
+  enabled: true,
+  streaming: true,
+  ball_detected: false,
+  ball_confidence: 0,
+};
+
+const shot: Shot = {
+  ball_speed_mph: 151.2,
+  club_speed_mph: 101.1,
+  smash_factor: 1.5,
+  estimated_carry_yards: 254,
+  carry_range: [244, 264],
+  club: 'driver',
+  timestamp: '2026-05-18T12:00:00Z',
+  peak_magnitude: 42,
+  launch_angle_vertical: 13.4,
+  launch_angle_horizontal: -1.2,
+  launch_angle_confidence: 0.82,
+  angle_source: 'radar',
+  club_angle_deg: 1.1,
+  club_path_deg: 2.5,
+  spin_axis_deg: -3.1,
+  spin_rpm: 2450,
+  spin_confidence: 0.8,
+  spin_quality: 'high',
+  carry_spin_adjusted: 261,
+};
+
+describe('DisplayMode', () => {
+  it('renders latest shot metrics and recent shot strip', () => {
+    const html = renderToString(
+      <UnitPreferenceProvider>
+        <DisplayMode connected cameraStatus={cameraStatus} latestShot={shot} shots={[shot]} />
+      </UnitPreferenceProvider>,
+    );
+
+    expect(html).toContain('OpenFlight Display');
+    expect(html).toContain('151.2');
+    expect(html).toContain('261');
+    expect(html).toContain('Socket connected');
+    expect(html).toContain('display-shot-chip__number');
+  });
+});

--- a/ui/src/components/DisplayMode.tsx
+++ b/ui/src/components/DisplayMode.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react';
+import type { CameraStatus } from '../hooks/useSocket';
+import type { Shot } from '../types/shot';
+import { useUnitPreference } from '../state/useUnitPreference';
+import { formatDistance, formatSpeed, getDistanceUnit, getSpeedUnit } from '../utils/units';
+import { getServerOrigin } from '../utils/serverOrigin';
+import './DisplayMode.css';
+
+interface DisplayModeProps {
+  connected: boolean;
+  cameraStatus: CameraStatus;
+  latestShot: Shot | null;
+  shots: Shot[];
+}
+
+interface DisplayMetric {
+  label: string;
+  value: string;
+  unit?: string;
+  detail?: string;
+}
+
+const CAMERA_STREAM_URL = `${getServerOrigin()}/camera/stream`;
+const RECENT_SHOT_COUNT = 5;
+
+function formatOptionalNumber(value: number | null, digits = 1, prefixPositive = false): string {
+  if (value === null) {
+    return '--';
+  }
+
+  const prefix = prefixPositive && value > 0 ? '+' : '';
+  return `${prefix}${value.toFixed(digits)}`;
+}
+
+function formatSpin(value: number | null): string {
+  if (value === null) {
+    return '--';
+  }
+
+  return value.toLocaleString('en-US', { maximumFractionDigits: 0 });
+}
+
+function buildMetrics(shot: Shot | null, unitSystem: 'imperial' | 'metric'): DisplayMetric[] {
+  if (!shot) {
+    return [
+      { label: 'Ball Speed', value: '--', unit: getSpeedUnit(unitSystem) },
+      { label: 'Carry', value: '--', unit: getDistanceUnit(unitSystem) },
+      { label: 'Club Speed', value: '--', unit: getSpeedUnit(unitSystem) },
+      { label: 'Smash', value: '--' },
+      { label: 'Launch', value: '--', unit: 'deg' },
+      { label: 'Spin', value: '--', unit: 'rpm' },
+      { label: 'Club Path', value: '--', unit: 'deg' },
+      { label: 'H. Launch', value: '--', unit: 'deg' },
+    ];
+  }
+
+  const carryYards = shot.carry_spin_adjusted ?? shot.estimated_carry_yards;
+
+  return [
+    {
+      label: 'Ball Speed',
+      value: formatSpeed(shot.ball_speed_mph, unitSystem, 1),
+      unit: getSpeedUnit(unitSystem),
+    },
+    {
+      label: 'Carry',
+      value: formatDistance(carryYards, unitSystem, 0),
+      unit: getDistanceUnit(unitSystem),
+      detail: shot.carry_spin_adjusted ? 'spin-adjusted' : undefined,
+    },
+    {
+      label: 'Club Speed',
+      value: shot.club_speed_mph === null ? '--' : formatSpeed(shot.club_speed_mph, unitSystem, 1),
+      unit: shot.club_speed_mph === null ? undefined : getSpeedUnit(unitSystem),
+    },
+    {
+      label: 'Smash',
+      value: shot.smash_factor === null ? '--' : shot.smash_factor.toFixed(2),
+    },
+    {
+      label: 'Launch',
+      value: formatOptionalNumber(shot.launch_angle_vertical),
+      unit: shot.launch_angle_vertical === null ? undefined : 'deg',
+      detail: shot.angle_source ?? undefined,
+    },
+    {
+      label: 'Spin',
+      value: formatSpin(shot.spin_rpm),
+      unit: shot.spin_rpm === null ? undefined : 'rpm',
+      detail: shot.spin_quality ?? undefined,
+    },
+    {
+      label: 'Club Path',
+      value: formatOptionalNumber(shot.club_path_deg, 1, true),
+      unit: shot.club_path_deg === null ? undefined : 'deg',
+    },
+    {
+      label: 'H. Launch',
+      value: formatOptionalNumber(shot.launch_angle_horizontal, 1, true),
+      unit: shot.launch_angle_horizontal === null ? undefined : 'deg',
+    },
+  ];
+}
+
+function DisplayMetricCard({ metric, featured = false }: { metric: DisplayMetric; featured?: boolean }) {
+  return (
+    <div className={`display-metric ${featured ? 'display-metric--featured' : ''}`}>
+      <span className="display-metric__label">{metric.label}</span>
+      <span className="display-metric__value-row">
+        <span className="display-metric__value">{metric.value}</span>
+        {metric.unit && <span className="display-metric__unit">{metric.unit}</span>}
+      </span>
+      {metric.detail && <span className="display-metric__detail">{metric.detail}</span>}
+    </div>
+  );
+}
+
+export function DisplayMode({ connected, cameraStatus, latestShot, shots }: DisplayModeProps) {
+  const [failedCameraKey, setFailedCameraKey] = useState<string | null>(null);
+  const { unitSystem } = useUnitPreference();
+  const metrics = buildMetrics(latestShot, unitSystem);
+  const recentShots = shots.slice(-RECENT_SHOT_COUNT).reverse();
+  const cameraKey = `${cameraStatus.available}-${cameraStatus.streaming}`;
+  const cameraError = failedCameraKey === cameraKey;
+
+  return (
+    <main className="display-mode">
+      <section className="display-mode__hero" aria-label="TV display mode">
+        <div className="display-mode__camera">
+          {cameraError ? (
+            <div className="display-mode__camera-placeholder">
+              <span>Camera stream unavailable</span>
+            </div>
+          ) : (
+            <img
+              src={CAMERA_STREAM_URL}
+              alt="OpenFlight camera stream"
+              className="display-mode__camera-image"
+              onError={() => setFailedCameraKey(cameraKey)}
+              onLoad={() => setFailedCameraKey(null)}
+            />
+          )}
+          <div className="display-mode__status-row">
+            <span className={`display-mode__status ${connected ? 'display-mode__status--online' : 'display-mode__status--offline'}`}>
+              {connected ? 'Socket connected' : 'Socket disconnected'}
+            </span>
+            <span className={`display-mode__status ${cameraStatus.available && cameraStatus.streaming && !cameraError ? 'display-mode__status--online' : 'display-mode__status--offline'}`}>
+              {cameraStatus.available && cameraStatus.streaming && !cameraError ? 'Camera stream active' : 'Camera unavailable'}
+            </span>
+          </div>
+        </div>
+
+        <div className="display-mode__shot-panel">
+          <div className="display-mode__eyebrow">OpenFlight Display</div>
+          <h1 className="display-mode__title">{latestShot ? latestShot.club : 'Ready'}</h1>
+          <div className="display-mode__primary-grid">
+            <DisplayMetricCard metric={metrics[0]} featured />
+            <DisplayMetricCard metric={metrics[1]} featured />
+          </div>
+          <div className="display-mode__metrics-grid">
+            {metrics.slice(2).map((metric) => (
+              <DisplayMetricCard key={metric.label} metric={metric} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="display-mode__recent" aria-label="Recent shots">
+        {recentShots.length === 0 ? (
+          <div className="display-mode__empty-strip">Recent shots will appear here</div>
+        ) : (
+          recentShots.map((shot, index) => (
+            <div className="display-shot-chip" key={shot.timestamp}>
+              <span className="display-shot-chip__number">#{shots.length - index}</span>
+              <span className="display-shot-chip__club">{shot.club}</span>
+              <span className="display-shot-chip__stat">
+                {formatSpeed(shot.ball_speed_mph, unitSystem, 0)} {getSpeedUnit(unitSystem)}
+              </span>
+              <span className="display-shot-chip__stat">
+                {formatDistance(shot.carry_spin_adjusted ?? shot.estimated_carry_yards, unitSystem, 0)} {getDistanceUnit(unitSystem)}
+              </span>
+            </div>
+          ))
+        )}
+      </section>
+    </main>
+  );
+}

--- a/ui/src/hooks/useSocket.ts
+++ b/ui/src/hooks/useSocket.ts
@@ -2,8 +2,9 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { io, type Socket } from 'socket.io-client';
 import type { Shot, SessionStats, SessionState, TriggerDiagnostic, TriggerStatus } from '../types/shot';
 import { useShotContext } from '../state/useShotContext';
+import { getServerOrigin } from '../utils/serverOrigin';
 
-const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || 'http://localhost:8080';
+const SOCKET_URL = getServerOrigin();
 
 export interface DebugReading {
   speed: number;

--- a/ui/src/utils/serverOrigin.ts
+++ b/ui/src/utils/serverOrigin.ts
@@ -1,0 +1,17 @@
+export function getServerOrigin(): string {
+  if (import.meta.env.VITE_SOCKET_URL) {
+    return import.meta.env.VITE_SOCKET_URL;
+  }
+
+  if (typeof window === 'undefined') {
+    return 'http://localhost:8080';
+  }
+
+  const { protocol, hostname, port, origin } = window.location;
+
+  if (port === '5173') {
+    return `${protocol}//${hostname}:8080`;
+  }
+
+  return origin;
+}


### PR DESCRIPTION
 ## Summary

 Adds a TV/tablet-friendly Display Mode at `/display` for viewing live OpenFlight shot data and the existing camera stream from another device on the same LAN.

 This is intended for tablets, TV browsers, or Chrome tab casting to Chromecast. It does not add native Chromecast SDK support, authentication, HTTPS, or any radar/shot detection changes.

 ## Changes

  - Adds a new `/display` frontend view with:
    - fullscreen-friendly dark layout
    - large readable shot metric cards
    - live camera stream from `/camera/stream`
    - socket connection and camera status indicators
    - compact recent-shot strip
  - Reuses existing socket/session state and shot data flow.
  - Updates server routing so direct refreshes of `/display` and `/display/` serve the React app.
  - Updates camera/socket origin handling so LAN clients connect back to the OpenFlight host instead of hardcoded `localhost`.
  - Adds README usage docs for TV Display Mode and browser/tab casting.
  - Adds focused tests for the display component and Flask display route.

 ## Verification

  - `cd ui && npm run test`
  - `cd ui && npm run lint`
  - `cd ui && npm run build`
  - `uv run pytest tests/test_server.py -v`
  - `uv run ruff check src/openflight/server.py tests/test_server.py`

 ## Notes

  - Camera failure is handled in the UI with a clear unavailable placeholder.
  - Shot metrics continue to render even if the camera stream is unavailable.
  - Chromecast support is limited to Chrome’s built-in tab casting for now.