### PR TITLE
Add K-LD7 vertical candidate ranker analysis

### DIFF
--- a/docs/prs/2026-05-25-kld7-vertical-candidate-ranker-analysis.md
+++ b/docs/prs/2026-05-25-kld7-vertical-candidate-ranker-analysis.md
@@ -1,0 +1,216 @@
+# K-LD7 Vertical Candidate Ranker Analysis
+
+## Summary
+
+This analysis revisits the K-LD7 vertical launch angle replay using the May 22
+and May 23 TrackMan comparison sessions.
+
+The important finding is that the K-LD7 raw data often contains a good vertical
+launch candidate, but candidate generation and selection must use the same
+effective angle offset as the replay baseline:
+
+```text
+effective_offset = vertical_mount_angle + software_offset
+
+0 deg mount  -> +8 deg
+8 deg mount  -> +16 deg
+18 deg mount -> +26 deg
+```
+
+Before applying that effective offset during candidate-pool generation, the
+candidate oracle looked much worse and did not reproduce the strong May 23
+18-degree results. After applying it, candidate coverage improved substantially.
+
+## Terminology
+
+### Candidate oracle
+
+`candidate_oracle` is an offline diagnostic ceiling.
+
+For each shot, it:
+
+1. Generates all plausible K-LD7 launch candidates.
+2. Looks at the TrackMan vertical launch angle.
+3. Picks the K-LD7 candidate closest to TrackMan.
+4. Reports the remaining error.
+
+This **requires TrackMan data** and cannot run in production. Its purpose is to
+answer one question:
+
+> Did the K-LD7 candidate pool contain a good answer?
+
+If candidate oracle is good, the sensor/candidate generation path likely found
+the ball and the remaining problem is production candidate selection.
+
+If candidate oracle is bad, selector changes alone cannot fix the shot because
+the right answer was not present in the candidate pool.
+
+### Learned error ranker
+
+`learned_error` is a TrackMan-trained, leave-one-session-out candidate ranker.
+It uses TrackMan only during offline training/evaluation. The features used for
+selection are runtime-available radar features:
+
+- predicted launch angle
+- mount angle
+- OPS ball speed
+- support across candidate sweeps
+- nearby candidate support
+- confidence
+- SNR
+- frame count
+- per-frame consistency metrics
+- expected launch plausibility
+- candidate fallback/source flags
+
+The current implementation is analysis-only. It is not yet production code.
+
+## What Changed In The Analysis
+
+The analysis now generates geometry candidate buckets with:
+
+```python
+angle_offset_deg = mount_deg + 8.0
+```
+
+This matches the effective offset used by the existing replay/baseline data.
+The earlier geometry candidate cache used `angle_offset_deg=0.0`, which meant
+many good candidates were shifted into the wrong launch-angle lane.
+
+Two offline scripts support this analysis:
+
+- `scripts/analysis/geometry_candidate_selector.py`
+- `scripts/analysis/track_candidate_ranker.py`
+
+## Reproduction
+
+Run from the repo root:
+
+```bash
+uv run --no-sync env PYTHONPATH=src:scripts/analysis \
+  python scripts/analysis/geometry_candidate_selector.py \
+  --output-dir /Users/john.pacino/Desktop/openflight_sessions/_analysis_geometry_candidate_selector_effective_offset
+```
+
+Then run the candidate ranker on that corrected bucket cache:
+
+```bash
+uv run --no-sync env PYTHONPATH=src:scripts/analysis \
+  python scripts/analysis/track_candidate_ranker.py \
+  --bucket-csv /Users/john.pacino/Desktop/openflight_sessions/_analysis_geometry_candidate_selector_effective_offset/bucket_geometry_candidate_selector.csv \
+  --output-dir /Users/john.pacino/Desktop/openflight_sessions/_analysis_track_candidate_ranker_effective_offset
+```
+
+Lint check:
+
+```bash
+uv run --no-sync ruff check \
+  scripts/analysis/geometry_candidate_selector.py \
+  scripts/analysis/track_candidate_ranker.py
+```
+
+Result:
+
+```text
+All checks passed.
+```
+
+## Results
+
+### Overall
+
+| Strategy | Rows | MAE | Bias | RMSE | P90 abs | <=8 deg |
+|---|---:|---:|---:|---:|---:|---:|
+| latest | 120 | 5.562 | 0.557 | 7.795 | 12.400 | 97/120 |
+| fixed | 120 | 5.316 | -0.591 | 7.301 | 11.600 | 98/120 |
+| prev_oracle | 120 | 2.940 | -0.497 | 3.816 | 5.800 | 116/120 |
+| geom_v5 | 120 | 3.594 | -0.861 | 4.582 | 7.200 | 111/120 |
+| manual_track | 120 | 3.185 | -1.685 | 4.371 | 7.300 | 112/120 |
+| learned_error | 120 | 2.463 | -0.623 | 3.584 | 5.900 | 114/120 |
+| learned_pairwise | 120 | 2.831 | -0.912 | 4.294 | 7.000 | 112/120 |
+| candidate_oracle | 120 | 1.162 | -0.333 | 2.016 | 3.500 | 120/120 |
+
+### By mount angle
+
+| Mount | Shots | fixed MAE | geom_v5 MAE | learned_error MAE | candidate_oracle MAE |
+|---:|---:|---:|---:|---:|---:|
+| 0 deg | 83 | 5.447 | 3.412 | 2.688 | 1.148 |
+| 8 deg | 13 | 6.762 | 4.708 | 2.946 | 2.423 |
+| 18 deg | 24 | 4.079 | 3.621 | 1.425 | 0.529 |
+
+### By session
+
+| Session | Shots | fixed MAE | geom_v5 MAE | learned_error MAE | candidate_oracle MAE |
+|---|---:|---:|---:|---:|---:|
+| `20260522_135647_0deg_7iron_16shots` | 16 | 3.875 | 2.975 | 1.869 | 1.275 |
+| `20260522_141038_8deg_7iron_13shots` | 13 | 6.762 | 4.708 | 2.946 | 2.423 |
+| `20260522_141949_18deg_7iron_11shots` | 11 | 4.845 | 4.845 | 1.327 | 0.718 |
+| `20260522_142538_0deg_4club_68shots` | 67 | 5.822 | 3.516 | 2.884 | 1.118 |
+| `20260523_143732_18deg_7iron_8shots` | 8 | 3.513 | 2.938 | 1.513 | 0.175 |
+| `20260523_144415_18deg_7iron_5shots_cleaned` | 5 | 3.300 | 2.020 | 1.500 | 0.680 |
+
+### Candidate coverage
+
+Candidate coverage is the most important diagnostic in this run.
+
+| Group | Shots | Oracle MAE | <=1 deg | <=2 deg | <=3 deg | <=5 deg |
+|---|---:|---:|---:|---:|---:|---:|
+| all shots | 120 | 1.162 | 83 | 96 | 104 | 114 |
+| 0 deg mount | 83 | 1.148 | 58 | 66 | 72 | 80 |
+| 8 deg mount | 13 | 2.423 | 5 | 7 | 8 | 10 |
+| 18 deg mount | 24 | 0.529 | 20 | 23 | 24 | 24 |
+| non-driver | 96 | 1.032 | 69 | 80 | 85 | 92 |
+| 7-iron only | 64 | 1.222 | 42 | 51 | 55 | 60 |
+
+## Key Finding
+
+With effective-offset candidate generation, the K-LD7 candidate pool is much
+stronger than previous geometry runs suggested.
+
+The earlier hard failures in the May 22 18-degree session now have good
+candidates:
+
+| Shot | TrackMan | Previous fixed/latest style value | Candidate oracle |
+|---:|---:|---:|---:|
+| 8 | 18.8 deg | 29.5 deg | 19.7 deg |
+| 10 | 18.4 deg | 28.7 deg | 17.0 deg |
+
+That means those shots are no longer best explained as missing sensor data.
+They are candidate selection failures.
+
+## Interpretation
+
+The MIMO-style takeaway still applies even though K-LD7 is not a true MIMO
+array: this should be treated as a track/candidate-selection problem, not a
+single strongest-angle problem.
+
+Good candidates tend to be supported by multiple pieces of evidence:
+
+- plausible launch angle for mount and club
+- repeated or nearby support across timing/candidate sweeps
+- frame-level consistency
+- reasonable confidence/SNR
+- agreement with OPS speed constraints
+
+The current `learned_error` ranker is not production-ready, but it proves that a
+runtime-feature selector can get much closer to the TrackMan-selected oracle
+without using TrackMan at inference time.
+
+## Recommendation
+
+Use this PR to document and preserve the offline analysis path, but do not ship
+the candidate oracle or TM-trained weights as production behavior yet.
+
+Recommended next implementation step:
+
+1. Keep effective-offset candidate generation in the offline replay tools.
+2. Turn the best runtime-only features into a deterministic selector that can be
+   reviewed and tested.
+3. Validate the selector with leave-one-session-out tests before moving it into
+   `openflight.kld7`.
+4. Add regression tests around the May 22 18-degree hard shots so candidates
+   near `18-20 deg` are not hidden by the high-angle `28-30 deg` alternatives.
+
+The practical goal should be to make production selection approach the
+`learned_error` result first, then continue toward the candidate-oracle ceiling
+as more geometry and camera-derived setup measurements become available.

--- a/scripts/analysis/geometry_candidate_selector.py
+++ b/scripts/analysis/geometry_candidate_selector.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Geometry/frame scoring on production-style K-LD7 candidates.
+
+This experiment keeps ``extract_launch_angle(...)`` as the event/candidate
+generator and adds per-frame consistency metrics to the resulting candidate
+groups. It is intentionally offline-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from timing_candidate_sweep import (
+    build_impact_anchors,
+    discover_sessions,
+    load_baseline_csv,
+    load_labels,
+    load_timing_map,
+    load_vertical_buffers,
+    summarize,
+    write_csv,
+)
+
+from openflight.kld7.radc import extract_launch_angle
+
+
+def _to_float(value: Any, default: float = 0.0) -> float:
+    if value in (None, ""):
+        return default
+    return float(value)
+
+
+def _weighted_mean(values: list[float], weights: list[float]) -> float:
+    total = float(sum(weights))
+    if total <= 0.0:
+        return float(sum(values) / len(values)) if values else 0.0
+    return float(sum(v * w for v, w in zip(values, weights)) / total)
+
+
+def _weighted_std(values: list[float], weights: list[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mean = _weighted_mean(values, weights)
+    var = _weighted_mean([(v - mean) ** 2 for v in values], weights)
+    return float(math.sqrt(max(var, 0.0)))
+
+
+def _linear_residual(values: list[float], times: list[float], weights: list[float]) -> float:
+    if len(values) < 3:
+        return _weighted_std(values, weights)
+    x = np.column_stack([np.ones(len(times)), np.array(times, dtype=float)])
+    y = np.array(values, dtype=float)
+    w = np.sqrt(np.maximum(np.array(weights, dtype=float), 1e-9))
+    beta, *_ = np.linalg.lstsq(x * w[:, None], y * w, rcond=None)
+    pred = x @ beta
+    return float(math.sqrt(_weighted_mean(list((y - pred) ** 2), weights)))
+
+
+def frame_metrics(candidate: dict[str, Any]) -> dict[str, float]:
+    per_frame = (candidate.get("aim_correction") or {}).get("per_frame") or []
+    corrected: list[float] = []
+    raw: list[float] = []
+    times: list[float] = []
+    for item in per_frame:
+        t = item.get("t_after_impact_s")
+        c = item.get("corrected_bearing_deg")
+        r = item.get("raw_bearing_deg")
+        if t is None or c is None or r is None:
+            continue
+        times.append(float(t))
+        corrected.append(float(c))
+        raw.append(float(r))
+    weights = [1.0] * len(corrected)
+    return {
+        "per_frame_count": float(len(corrected)),
+        "corrected_std_deg": _weighted_std(corrected, weights) if corrected else 99.0,
+        "corrected_linear_resid_deg": _linear_residual(corrected, times, weights) if corrected else 99.0,
+        "raw_std_deg": _weighted_std(raw, weights) if raw else 99.0,
+        "t_span_s": float(max(times) - min(times)) if len(times) >= 2 else 0.0,
+        "t_min_s": float(min(times)) if times else 0.0,
+        "t_max_s": float(max(times)) if times else 0.0,
+    }
+
+
+def build_candidates_with_metrics(
+    frames: list[dict[str, Any]],
+    anchors: list[float],
+    *,
+    ops_speed_mph: float,
+    distance_ft: float,
+    radar_height_in: float,
+    angle_offset_deg: float,
+) -> list[dict[str, Any]]:
+    # Slightly wider than timing_candidate_sweep: the v4/deep checks showed
+    # useful candidates just outside the earlier lane/gating settings.
+    impact_thresholds = [1.8, 2.2]
+    speed_tolerances = [8.0, 12.0]
+    centroid_fracs = [0.55]
+    outlier_tols = [15, 35]
+
+    out: list[dict[str, Any]] = []
+    seen: set[tuple[int, int, int, int]] = set()
+    for impact_ts in anchors:
+        for thr in impact_thresholds:
+            for tol in speed_tolerances:
+                for frac in centroid_fracs:
+                    for out_tol in outlier_tols:
+                        shots = extract_launch_angle(
+                            frames=frames,
+                            fft_size=2048,
+                            max_speed_kmh=100.0,
+                            cfar_threshold=2.5,
+                            impact_energy_threshold=thr,
+                            angle_offset_deg=angle_offset_deg,
+                            ops243_ball_speed_mph=ops_speed_mph,
+                            speed_tolerance_mph=tol,
+                            orientation="vertical",
+                            ops_bin_outlier_tol=out_tol,
+                            ops_bin_outlier_penalty=10.0,
+                            centroid_floor_frac=frac,
+                            ball_lateral_offset_in=radar_height_in,
+                            ball_initial_range_in=distance_ft * 12.0,
+                            impact_timestamp=impact_ts,
+                        )
+                        for shot in shots:
+                            key = (
+                                int(round(_to_float(shot.get("launch_angle_deg")) * 10)),
+                                int(round(_to_float(shot.get("raw_angle_deg")) * 10)),
+                                int(round(_to_float(shot.get("confidence")) * 100)),
+                                int(_to_float(shot.get("frame_count"))),
+                            )
+                            if key in seen:
+                                continue
+                            seen.add(key)
+                            rec = dict(shot)
+                            rec.update(frame_metrics(shot))
+                            rec["sweep_impact_ts"] = impact_ts
+                            rec["sweep_thr"] = thr
+                            rec["sweep_tol"] = tol
+                            rec["sweep_frac"] = frac
+                            rec["sweep_out_tol"] = out_tol
+                            out.append(rec)
+    return out
+
+
+def bucket_candidates(candidates: list[dict[str, Any]]) -> list[dict[str, float]]:
+    buckets: dict[float, list[dict[str, Any]]] = defaultdict(list)
+    for cand in candidates:
+        pred = round(_to_float(cand.get("launch_angle_deg")), 1)
+        buckets[pred].append(cand)
+
+    out: list[dict[str, float]] = []
+    for pred, rows in buckets.items():
+        n = float(len(rows))
+        out.append(
+            {
+                "pred_v_deg": pred,
+                "support": n,
+                "confidence": sum(_to_float(r.get("confidence")) for r in rows) / n,
+                "avg_snr_db": sum(_to_float(r.get("avg_snr_db")) for r in rows) / n,
+                "frame_count": sum(_to_float(r.get("frame_count")) for r in rows) / n,
+                "corrected_std_deg": sum(_to_float(r.get("corrected_std_deg"), 99.0) for r in rows) / n,
+                "corrected_linear_resid_deg": sum(_to_float(r.get("corrected_linear_resid_deg"), 99.0) for r in rows) / n,
+                "per_frame_count": sum(_to_float(r.get("per_frame_count")) for r in rows) / n,
+                "t_span_s": sum(_to_float(r.get("t_span_s")) for r in rows) / n,
+            }
+        )
+    return out
+
+
+def _best_in_lane(
+    buckets: list[dict[str, float]],
+    lo: float,
+    hi: float,
+    *,
+    use_geometry: bool,
+) -> dict[str, float] | None:
+    lane = [b for b in buckets if lo <= b["pred_v_deg"] <= hi]
+    if not lane:
+        return None
+
+    def score(bucket: dict[str, float]) -> tuple[float, float, float, float]:
+        geom_penalty = 0.0
+        if use_geometry:
+            geom_penalty = (
+                0.25 * bucket["corrected_linear_resid_deg"]
+                + 0.10 * bucket["corrected_std_deg"]
+                - 0.15 * min(bucket["per_frame_count"], 6.0)
+            )
+        return (
+            bucket["support"]
+            + 0.50 * bucket["confidence"]
+            + 0.03 * bucket["avg_snr_db"]
+            - geom_penalty,
+            bucket["support"],
+            bucket["confidence"],
+            -abs(bucket["pred_v_deg"] - 16.0),
+        )
+
+    return max(lane, key=score)
+
+
+def predict_v4_like(
+    buckets: list[dict[str, float]],
+    fixed: float,
+    latest: float,
+    *,
+    use_geometry: bool,
+) -> tuple[float, str]:
+    base = fixed if abs(fixed - 16.0) <= abs(latest - 16.0) else latest
+    low = _best_in_lane(buckets, 9.0, 20.0, use_geometry=use_geometry)
+    high = _best_in_lane(buckets, 18.0, 32.0, use_geometry=use_geometry)
+    pred = base
+    source = "base"
+
+    if low and low["confidence"] >= 0.50 and base < 14.0 and low["pred_v_deg"] > base + 0.5:
+        return low["pred_v_deg"], "low_lane"
+
+    if base > 24.0:
+        chosen: dict[str, float] | None = None
+        source = "base"
+        if low and low["confidence"] >= 0.50 and low["pred_v_deg"] < base - 0.5:
+            chosen = low
+            source = "low_lane"
+        if high and high["confidence"] >= 0.50 and high["pred_v_deg"] < base - 0.5:
+            if chosen is None or high["pred_v_deg"] > chosen["pred_v_deg"]:
+                chosen = high
+                source = "high_lane"
+        if chosen is not None:
+            pred = chosen["pred_v_deg"]
+    return pred, source
+
+
+def predict_geom_score(buckets: list[dict[str, float]]) -> tuple[float | None, str]:
+    if not buckets:
+        return None, "none"
+
+    def score(bucket: dict[str, float]) -> float:
+        pred = bucket["pred_v_deg"]
+        plausibility = 0.0
+        if pred < 4.0:
+            plausibility += 2.0
+        if pred > 32.0:
+            plausibility += 2.0
+        return (
+            1.0 * bucket["support"]
+            + 0.7 * bucket["confidence"]
+            + 0.04 * bucket["avg_snr_db"]
+            + 0.1 * min(bucket["per_frame_count"], 6.0)
+            - 0.18 * bucket["corrected_linear_resid_deg"]
+            - 0.08 * abs(pred - 16.0)
+            - plausibility
+        )
+
+    best = max(buckets, key=score)
+    return best["pred_v_deg"], "geom_score"
+
+
+def _delta(pred: float | None, truth: float) -> float | None:
+    if pred is None:
+        return None
+    return pred - truth
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sessions-root", type=Path, default=Path("~/Desktop/openflight_sessions").expanduser())
+    parser.add_argument(
+        "--timing-csv",
+        type=Path,
+        default=Path("~/Desktop/openflight_sessions/_analysis_terminal_shot_matching/terminal_shot_timing_strict_matches.csv").expanduser(),
+    )
+    parser.add_argument(
+        "--baseline-csv",
+        type=Path,
+        default=Path("~/Desktop/openflight_sessions/_analysis_fixed_not_high_else_grid_oracle/per_shot_vertical_deltas_latest_fixed_oracle.csv").expanduser(),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("~/Desktop/openflight_sessions/_analysis_geometry_candidate_selector").expanduser(),
+    )
+    parser.add_argument("--radar-height-in", type=float, default=4.0)
+    args = parser.parse_args()
+
+    logging.getLogger("openflight.kld7.radc").setLevel(logging.ERROR)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    specs = discover_sessions(args.sessions_root)
+    labels = load_labels(specs)
+    timing = load_timing_map(args.timing_csv)
+    baseline = load_baseline_csv(args.baseline_csv)
+    buffers_by_session = {
+        s.session_dir: load_vertical_buffers(s.session_path)
+        for s in specs
+    }
+
+    per_shot: list[dict[str, Any]] = []
+    bucket_rows: list[dict[str, Any]] = []
+    for label in labels:
+        base = baseline.get((label.session_dir, label.comparison_file, label.shot_number))
+        if base is None:
+            continue
+        buf = buffers_by_session.get(label.session_dir, {}).get(label.shot_number)
+        if not buf or not buf["frames"]:
+            continue
+        anchors = build_impact_anchors(
+            timing.get((label.session_dir, label.shot_number)),
+            fallback_shot_ts=float(buf["shot_timestamp"]),
+        )
+        candidates = build_candidates_with_metrics(
+            buf["frames"],
+            anchors,
+            ops_speed_mph=label.ops_ball_speed_mph,
+            distance_ft=label.distance_ft,
+            radar_height_in=args.radar_height_in,
+            angle_offset_deg=label.mount_deg + 8.0,
+        )
+        buckets = bucket_candidates(candidates)
+        for bucket in buckets:
+            bucket_rows.append(
+                {
+                    "session": label.session_dir,
+                    "comparison_file": label.comparison_file,
+                    "shot_number": label.shot_number,
+                    "tm_launch_v_deg": label.tm_launch_v_deg,
+                    **bucket,
+                }
+            )
+
+        fixed = base["fixed_pred_v_deg"]
+        latest = base["latest_pred_v_deg"]
+        plain_pred, plain_source = predict_v4_like(buckets, fixed, latest, use_geometry=False)
+        geom_lane_pred, geom_lane_source = predict_v4_like(buckets, fixed, latest, use_geometry=True)
+        geom_score_pred, geom_score_source = predict_geom_score(buckets)
+        oracle_pred = None
+        if buckets:
+            oracle_pred = min(buckets, key=lambda b: abs(b["pred_v_deg"] - label.tm_launch_v_deg))["pred_v_deg"]
+
+        row: dict[str, Any] = {
+            "session": label.session_dir,
+            "comparison_file": label.comparison_file,
+            "shot_number": label.shot_number,
+            "club": label.club,
+            "mount_deg": label.mount_deg,
+            "distance_ft": label.distance_ft,
+            "distance_source": label.distance_source,
+            "ops_ball_speed_mph": label.ops_ball_speed_mph,
+            "tm_launch_v_deg": label.tm_launch_v_deg,
+            "latest_pred_v_deg": latest,
+            "fixed_pred_v_deg": fixed,
+            "prev_oracle_pred_v_deg": base["oracle_pred_v_deg"],
+            "plain_lane_pred_v_deg": plain_pred,
+            "geom_lane_pred_v_deg": geom_lane_pred,
+            "geom_score_pred_v_deg": geom_score_pred if geom_score_pred is not None else "",
+            "candidate_oracle_pred_v_deg": oracle_pred if oracle_pred is not None else "",
+            "plain_lane_source": plain_source,
+            "geom_lane_source": geom_lane_source,
+            "geom_score_source": geom_score_source,
+            "bucket_count": len(buckets),
+            "candidate_count": len(candidates),
+        }
+        for name in ("latest", "fixed", "prev_oracle", "plain_lane", "geom_lane", "geom_score", "candidate_oracle"):
+            pred = _to_float(row.get(f"{name}_pred_v_deg"), default=float("nan"))
+            delta = _delta(pred, label.tm_launch_v_deg) if math.isfinite(pred) else None
+            row[f"{name}_delta_deg"] = delta if delta is not None else ""
+            row[f"{name}_abs_err_deg"] = abs(delta) if delta is not None else ""
+        per_shot.append(row)
+
+    write_csv(args.output_dir / "per_shot_geometry_candidate_selector.csv", per_shot)
+    write_csv(args.output_dir / "bucket_geometry_candidate_selector.csv", bucket_rows)
+
+    strategies = [
+        ("latest", "latest_pred_v_deg", "latest_delta_deg"),
+        ("fixed", "fixed_pred_v_deg", "fixed_delta_deg"),
+        ("prev_oracle", "prev_oracle_pred_v_deg", "prev_oracle_delta_deg"),
+        ("plain_lane", "plain_lane_pred_v_deg", "plain_lane_delta_deg"),
+        ("geom_lane", "geom_lane_pred_v_deg", "geom_lane_delta_deg"),
+        ("geom_score", "geom_score_pred_v_deg", "geom_score_delta_deg"),
+        ("candidate_oracle", "candidate_oracle_pred_v_deg", "candidate_oracle_delta_deg"),
+    ]
+    overall: list[dict[str, Any]] = []
+    for name, pred_key, delta_key in strategies:
+        stats = summarize(per_shot, pred_key, delta_key)
+        overall.append(
+            {
+                "strategy": name,
+                "n": int(stats["n"]),
+                "mae_deg": stats["mae"],
+                "bias_deg": stats["bias"],
+                "rmse_deg": stats["rmse"],
+                "p90_abs_deg": stats["p90_abs"],
+                "retained_le8": int(stats["retained_le8"]),
+                "retention_pct": stats["ret_pct"],
+            }
+        )
+    write_csv(args.output_dir / "overall_summary_geometry_candidate_selector.csv", overall)
+
+    session_rows: list[dict[str, Any]] = []
+    for session in sorted({r["session"] for r in per_shot}):
+        rows = [r for r in per_shot if r["session"] == session]
+        out: dict[str, Any] = {"session": session, "shots": len(rows)}
+        for name, pred_key, delta_key in strategies:
+            stats = summarize(rows, pred_key, delta_key)
+            out[f"{name}_mae_deg"] = stats["mae"]
+            out[f"{name}_retention_pct"] = stats["ret_pct"]
+        session_rows.append(out)
+    write_csv(args.output_dir / "session_summary_geometry_candidate_selector.csv", session_rows)
+
+    report = args.output_dir / "geometry_candidate_selector_report.md"
+    with report.open("w") as f:
+        f.write("# Geometry Candidate Selector Report\n\n")
+        f.write("- Candidate generation: production `extract_launch_angle(...)` groups\n")
+        f.write("- Added metrics: support, confidence, SNR, corrected-bearing std/residual\n")
+        f.write("- TM is only used for validation and oracle rows\n\n")
+        f.write("## Overall\n\n")
+        f.write("| strategy | n | MAE | Bias | RMSE | P90 abs | <=8deg | retention |\n")
+        f.write("|---|---:|---:|---:|---:|---:|---:|---:|\n")
+        for row in overall:
+            f.write(
+                f"| {row['strategy']} | {row['n']} | {row['mae_deg']:.3f} | {row['bias_deg']:.3f} | "
+                f"{row['rmse_deg']:.3f} | {row['p90_abs_deg']:.3f} | {row['retained_le8']} | {row['retention_pct']:.1f}% |\n"
+            )
+        f.write("\n## By Session MAE\n\n")
+        f.write("| session | shots | fixed | plain_lane | geom_lane | geom_score | candidate_oracle |\n")
+        f.write("|---|---:|---:|---:|---:|---:|---:|\n")
+        for row in session_rows:
+            f.write(
+                f"| {row['session']} | {row['shots']} | {row['fixed_mae_deg']:.3f} | "
+                f"{row['plain_lane_mae_deg']:.3f} | {row['geom_lane_mae_deg']:.3f} | "
+                f"{row['geom_score_mae_deg']:.3f} | {row['candidate_oracle_mae_deg']:.3f} |\n"
+            )
+    print(f"Wrote {args.output_dir}")
+    print(f"- {args.output_dir / 'overall_summary_geometry_candidate_selector.csv'}")
+    print(f"- {report}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/timing_candidate_sweep.py
+++ b/scripts/analysis/timing_candidate_sweep.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+"""Timing-aware candidate-pool rerun from raw kld7_buffer frames.
+
+Builds per-shot candidate pools by re-running extract_launch_angle() over
+multiple timing anchors and RADC parameters, then compares:
+1) TM-oracle selector (analysis ceiling only)
+2) Mount-aware TM-free pseudo selector
+
+This is an offline analysis script and does not modify runtime behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import json
+import logging
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from openflight.kld7.radc import extract_launch_angle
+
+KNOWN_DISTANCE_FT = {
+    "20260523_143732_18deg_7iron_8shots": 6.0,
+    "20260523_144415_18deg_7iron_5shots_cleaned": 5.0,
+}
+
+
+@dataclass(frozen=True)
+class SessionSpec:
+    session_dir: str
+    mount_deg: float
+    session_path: Path
+    comparison_csvs: list[Path]
+    distance_ft: float
+    distance_source: str
+
+
+@dataclass(frozen=True)
+class ShotLabel:
+    session_dir: str
+    comparison_file: str
+    shot_number: int
+    club: str
+    mount_deg: float
+    ops_ball_speed_mph: float
+    tm_launch_v_deg: float
+    distance_ft: float
+    distance_source: str
+
+
+@dataclass(frozen=True)
+class ShotTiming:
+    first_byte_ts: float | None
+    accept_ts: float | None
+    shot_log_ts: float | None
+    callback_ms: float | None
+    total_ms: float | None
+
+
+def _to_float(value: str | None, default: float | None = None) -> float | None:
+    if value in (None, ""):
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+def _parse_dt(value: str | None) -> float | None:
+    if value in (None, ""):
+        return None
+    # Strict file uses "YYYY-MM-DD HH:MM:SS.ssssss"
+    return datetime.strptime(value, "%Y-%m-%d %H:%M:%S.%f").timestamp()
+
+
+def _mae(values: list[float]) -> float:
+    return float(sum(abs(v) for v in values) / len(values)) if values else float("nan")
+
+
+def _rmse(values: list[float]) -> float:
+    return float(math.sqrt(sum(v * v for v in values) / len(values))) if values else float("nan")
+
+
+def _p90_abs(values: list[float]) -> float:
+    if not values:
+        return float("nan")
+    arr = sorted(abs(v) for v in values)
+    idx = int((len(arr) - 1) * 0.9)
+    return float(arr[idx])
+
+
+def discover_sessions(root: Path) -> list[SessionSpec]:
+    specs: list[SessionSpec] = []
+    for d in sorted(p for p in root.iterdir() if p.is_dir() and re.match(r"^\d{8}_\d{6}_", p.name)):
+        m = re.search(r"_(\d+)deg_", d.name)
+        if not m:
+            continue
+        mount = float(m.group(1))
+        session_files = sorted(d.glob("session_*.jsonl"))
+        if not session_files:
+            continue
+        comparison_files = sorted(d.glob("comparison_*.csv"))
+        if not comparison_files:
+            continue
+        distance_ft = KNOWN_DISTANCE_FT.get(d.name, 6.0)
+        distance_source = "known" if d.name in KNOWN_DISTANCE_FT else "assumed_6ft"
+        specs.append(
+            SessionSpec(
+                session_dir=d.name,
+                mount_deg=mount,
+                session_path=session_files[0],
+                comparison_csvs=comparison_files,
+                distance_ft=distance_ft,
+                distance_source=distance_source,
+            )
+        )
+    return specs
+
+
+def load_labels(specs: list[SessionSpec]) -> list[ShotLabel]:
+    out: list[ShotLabel] = []
+    for spec in specs:
+        for comp in spec.comparison_csvs:
+            with comp.open() as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    if row.get("match_quality") != "good":
+                        continue
+                    tm = _to_float(row.get("launch_v_tm"))
+                    if tm is None:
+                        continue
+                    shot = int(float(row["shot_number_of"]))
+                    out.append(
+                        ShotLabel(
+                            session_dir=spec.session_dir,
+                            comparison_file=comp.name,
+                            shot_number=shot,
+                            club=row.get("club", "unknown"),
+                            mount_deg=spec.mount_deg,
+                            ops_ball_speed_mph=float(row["ball_speed_of"]),
+                            tm_launch_v_deg=tm,
+                            distance_ft=spec.distance_ft,
+                            distance_source=spec.distance_source,
+                        )
+                    )
+    return out
+
+
+def load_timing_map(path: Path) -> dict[tuple[str, int], ShotTiming]:
+    out: dict[tuple[str, int], ShotTiming] = {}
+    with path.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            session = row["session"]
+            shot = int(float(row["json_shot_no"]))
+            out[(session, shot)] = ShotTiming(
+                first_byte_ts=_parse_dt(row.get("first_byte_ts")),
+                accept_ts=_parse_dt(row.get("accept_ts")),
+                shot_log_ts=_parse_dt(row.get("json_shot_ts")),
+                callback_ms=_to_float(row.get("callback_ms")),
+                total_ms=_to_float(row.get("total_ms")),
+            )
+    return out
+
+
+def load_baseline_csv(path: Path) -> dict[tuple[str, str, int], dict[str, float]]:
+    out: dict[tuple[str, str, int], dict[str, float]] = {}
+    with path.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row.get("status") != "ok":
+                continue
+            tm = _to_float(row.get("trackman_launch_v_deg"))
+            if tm is None:
+                continue
+            key = (row["session_dir"], row["comparison_file"], int(float(row["shot_number"])))
+            out[key] = {
+                "latest_pred_v_deg": float(row["latest_pred_v_deg"]),
+                "fixed_pred_v_deg": float(row["fixed_pred_v_deg"]),
+                "oracle_pred_v_deg": float(row["oracle_pred_v_deg"]),
+                "latest_raw_angle_deg": float(row["latest_raw_angle_deg"]),
+                "fixed_raw_angle_deg": float(row["fixed_raw_angle_deg"]),
+                "candidate_count": float(row.get("candidate_count") or 0.0),
+            }
+    return out
+
+
+def load_vertical_buffers(path: Path) -> dict[int, dict[str, Any]]:
+    out: dict[int, dict[str, Any]] = {}
+    with path.open() as f:
+        for line in f:
+            if not line.strip():
+                continue
+            rec = json.loads(line)
+            if rec.get("type") != "kld7_buffer":
+                continue
+            if rec.get("orientation") != "vertical":
+                continue
+            shot_no = int(rec.get("shot_number", 0))
+            if shot_no <= 0:
+                continue
+            frames = rec.get("frames") or []
+            decoded: list[dict[str, Any]] = []
+            for fr in frames:
+                if not fr.get("has_radc"):
+                    continue
+                b64 = fr.get("radc_b64")
+                if not b64:
+                    continue
+                try:
+                    payload = base64.b64decode(b64)
+                except (ValueError, TypeError):
+                    continue
+                if len(payload) != 3072:
+                    continue
+                decoded.append(
+                    {
+                        "timestamp": float(fr["timestamp"]),
+                        "radc": payload,
+                    }
+                )
+            out[shot_no] = {
+                "shot_timestamp": float(rec.get("shot_timestamp", 0.0)),
+                "frames": decoded,
+                "frame_count": int(rec.get("frame_count", len(frames))),
+            }
+    return out
+
+
+def _mount_raw_prior_center(mount_deg: float, speed_mph: float) -> tuple[float, float]:
+    m = int(round(mount_deg))
+    if m >= 16:
+        return (-8.0, 2.8)
+    if m >= 6:
+        return (1.0, 2.3)
+    center = 9.0
+    if speed_mph > 145.0:
+        center -= 2.0
+    elif speed_mph > 130.0:
+        center -= 1.0
+    return (center, 3.2)
+
+
+def pseudo_score(candidate: dict[str, float], mount_deg: float, ops_speed_mph: float) -> float:
+    pred = float(candidate["launch_angle_deg"])
+    raw = float(candidate["raw_angle_deg"])
+    conf = float(candidate.get("confidence", 0.0))
+    snr = float(candidate.get("avg_snr_db", 0.0))
+    frames = float(candidate.get("frame_count", 1.0))
+    ball = float(candidate.get("ball_speed_mph", ops_speed_mph))
+    speed_err = abs(ball - ops_speed_mph)
+
+    center, sigma = _mount_raw_prior_center(mount_deg, ops_speed_mph)
+    z = (raw - center) / max(sigma, 1e-6)
+    score = -(z * z)
+    score += 0.9 * (conf - 0.5)
+    score += 0.5 * min(snr / 10.0, 1.0)
+    score += 0.08 * min(frames, 3.0)
+    score -= 0.04 * speed_err
+
+    if mount_deg >= 16.0:
+        if pred > 24.0:
+            score -= 2.2
+        if pred < 9.0:
+            score -= 1.2
+        if raw > -1.0:
+            score -= 0.8
+    elif mount_deg >= 6.0:
+        if pred > 24.0:
+            score -= 1.8
+        if pred < 8.0:
+            score -= 1.1
+        if raw > 5.0:
+            score -= 0.9
+    else:
+        if pred > 30.0:
+            score -= 2.0
+        if pred < 4.0:
+            score -= 1.3
+        if raw < 1.0:
+            score -= 0.8
+    return score
+
+
+def build_impact_anchors(timing: ShotTiming | None, fallback_shot_ts: float) -> list[float]:
+    anchors: list[float] = []
+    if timing is not None:
+        if timing.first_byte_ts is not None:
+            anchors.extend(
+                [
+                    timing.first_byte_ts - 0.12,
+                    timing.first_byte_ts - 0.06,
+                    timing.first_byte_ts,
+                    timing.first_byte_ts + 0.06,
+                ]
+            )
+        if timing.accept_ts is not None:
+            anchors.extend(
+                [
+                    timing.accept_ts - 4.7,
+                ]
+            )
+    anchors.extend([fallback_shot_ts - 4.9])
+    # Preserve order, remove dup-ish anchors.
+    out: list[float] = []
+    for a in anchors:
+        if not out or abs(a - out[-1]) > 1e-4:
+            out.append(a)
+    return out
+
+
+def build_candidates(
+    frames: list[dict[str, Any]],
+    anchors: list[float],
+    ops_speed_mph: float,
+    lateral_in: float,
+    distance_ft: float,
+) -> list[dict[str, Any]]:
+    impact_thresholds = [2.2, 3.0]
+    speed_tolerances = [8.0, 10.0]
+    centroid_fracs = [0.45, 0.55]
+    outlier_tols = [15, 25]
+
+    seen: set[tuple[int, int, int, int]] = set()
+    out: list[dict[str, Any]] = []
+
+    for impact_ts in anchors:
+        for thr in impact_thresholds:
+            for tol in speed_tolerances:
+                for frac in centroid_fracs:
+                    for out_tol in outlier_tols:
+                        shots = extract_launch_angle(
+                            frames=frames,
+                            fft_size=2048,
+                            max_speed_kmh=100.0,
+                            cfar_threshold=2.5,
+                            impact_energy_threshold=thr,
+                            angle_offset_deg=0.0,
+                            ops243_ball_speed_mph=ops_speed_mph,
+                            speed_tolerance_mph=tol,
+                            orientation="vertical",
+                            ops_bin_outlier_tol=out_tol,
+                            ops_bin_outlier_penalty=10.0,
+                            centroid_floor_frac=frac,
+                            ball_lateral_offset_in=lateral_in,
+                            ball_initial_range_in=distance_ft * 12.0,
+                            impact_timestamp=impact_ts,
+                        )
+                        for s in shots:
+                            key = (
+                                int(round(float(s["launch_angle_deg"]) * 10)),
+                                int(round(float(s["raw_angle_deg"]) * 10)),
+                                int(round(float(s.get("confidence", 0.0)) * 100)),
+                                int(float(s.get("frame_count", 0))),
+                            )
+                            if key in seen:
+                                continue
+                            seen.add(key)
+                            rec = dict(s)
+                            rec["sweep_impact_ts"] = impact_ts
+                            rec["sweep_thr"] = thr
+                            rec["sweep_tol"] = tol
+                            rec["sweep_frac"] = frac
+                            rec["sweep_out_tol"] = out_tol
+                            out.append(rec)
+    return out
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fields = list(rows[0].keys())
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow(r)
+
+
+def summarize(rows: list[dict[str, Any]], pred_key: str, delta_key: str) -> dict[str, float]:
+    deltas = [float(r[delta_key]) for r in rows if r.get(pred_key) not in (None, "")]
+    retained = sum(1 for d in deltas if abs(d) <= 8.0)
+    return {
+        "n": float(len(deltas)),
+        "mae": _mae(deltas),
+        "bias": float(sum(deltas) / len(deltas)) if deltas else float("nan"),
+        "rmse": _rmse(deltas),
+        "p90_abs": _p90_abs(deltas),
+        "retained_le8": float(retained),
+        "ret_pct": (retained / len(deltas) * 100.0) if deltas else 0.0,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sessions-root",
+        type=Path,
+        default=Path("~/Desktop/openflight_sessions").expanduser(),
+    )
+    parser.add_argument(
+        "--timing-csv",
+        type=Path,
+        default=Path(
+            "~/Desktop/openflight_sessions/_analysis_terminal_shot_matching/terminal_shot_timing_strict_matches.csv"
+        ).expanduser(),
+    )
+    parser.add_argument(
+        "--baseline-csv",
+        type=Path,
+        default=Path(
+            "~/Desktop/openflight_sessions/_analysis_fixed_not_high_else_grid_oracle/per_shot_vertical_deltas_latest_fixed_oracle.csv"
+        ).expanduser(),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("~/Desktop/openflight_sessions/_analysis_timing_candidate_sweep").expanduser(),
+    )
+    parser.add_argument("--lateral-in", type=float, default=4.0)
+    args = parser.parse_args()
+    logging.getLogger("openflight.kld7.radc").setLevel(logging.ERROR)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    specs = discover_sessions(args.sessions_root)
+    labels = load_labels(specs)
+    timing = load_timing_map(args.timing_csv)
+    baseline = load_baseline_csv(args.baseline_csv)
+
+    buffers_by_session = {
+        s.session_dir: load_vertical_buffers(s.session_path)
+        for s in specs
+    }
+
+    per_shot_rows: list[dict[str, Any]] = []
+    all_candidate_rows: list[dict[str, Any]] = []
+
+    for label in labels:
+        bkey = (label.session_dir, label.comparison_file, label.shot_number)
+        base = baseline.get(bkey)
+        if base is None:
+            continue
+
+        shot_map = buffers_by_session.get(label.session_dir, {})
+        buf = shot_map.get(label.shot_number)
+        if not buf:
+            continue
+        frames: list[dict[str, Any]] = buf["frames"]
+        if not frames:
+            continue
+
+        timing_row = timing.get((label.session_dir, label.shot_number))
+        anchors = build_impact_anchors(timing_row, fallback_shot_ts=float(buf["shot_timestamp"]))
+        candidates = build_candidates(
+            frames=frames,
+            anchors=anchors,
+            ops_speed_mph=label.ops_ball_speed_mph,
+            lateral_in=args.lateral_in,
+            distance_ft=label.distance_ft,
+        )
+
+        for c in candidates:
+            all_candidate_rows.append(
+                {
+                    "session": label.session_dir,
+                    "comparison_file": label.comparison_file,
+                    "shot_number": label.shot_number,
+                    "mount_deg": label.mount_deg,
+                    "distance_ft": label.distance_ft,
+                    "distance_source": label.distance_source,
+                    "ops_ball_speed_mph": label.ops_ball_speed_mph,
+                    "tm_launch_v_deg": label.tm_launch_v_deg,
+                    "cand_pred_v_deg": c.get("launch_angle_deg"),
+                    "cand_raw_angle_deg": c.get("raw_angle_deg"),
+                    "cand_confidence": c.get("confidence"),
+                    "cand_frame_count": c.get("frame_count"),
+                    "cand_avg_snr_db": c.get("avg_snr_db"),
+                    "cand_ball_speed_mph": c.get("ball_speed_mph"),
+                    "sweep_impact_ts": c.get("sweep_impact_ts"),
+                    "sweep_thr": c.get("sweep_thr"),
+                    "sweep_tol": c.get("sweep_tol"),
+                    "sweep_frac": c.get("sweep_frac"),
+                    "sweep_out_tol": c.get("sweep_out_tol"),
+                }
+            )
+
+        # Add current production-like candidates for fair compare in same selector.
+        pseudo_pool: list[dict[str, Any]] = list(candidates)
+        pseudo_pool.append(
+            {
+                "launch_angle_deg": base["latest_pred_v_deg"],
+                "raw_angle_deg": base["latest_raw_angle_deg"],
+                "confidence": 0.50,
+                "frame_count": 1,
+                "avg_snr_db": 5.0,
+                "ball_speed_mph": label.ops_ball_speed_mph,
+                "candidate_src": "latest",
+            }
+        )
+        pseudo_pool.append(
+            {
+                "launch_angle_deg": base["fixed_pred_v_deg"],
+                "raw_angle_deg": base["fixed_raw_angle_deg"],
+                "confidence": 0.50,
+                "frame_count": 1,
+                "avg_snr_db": 5.0,
+                "ball_speed_mph": label.ops_ball_speed_mph,
+                "candidate_src": "fixed",
+            }
+        )
+
+        if pseudo_pool:
+            pseudo_best = max(
+                pseudo_pool,
+                key=lambda c: pseudo_score(c, label.mount_deg, label.ops_ball_speed_mph),
+            )
+            oracle_best = min(
+                pseudo_pool,
+                key=lambda c: abs(float(c["launch_angle_deg"]) - label.tm_launch_v_deg),
+            )
+            pseudo_pred = float(pseudo_best["launch_angle_deg"])
+            oracle_pred = float(oracle_best["launch_angle_deg"])
+            pseudo_raw = float(pseudo_best["raw_angle_deg"])
+            oracle_raw = float(oracle_best["raw_angle_deg"])
+        else:
+            pseudo_pred = float("nan")
+            oracle_pred = float("nan")
+            pseudo_raw = float("nan")
+            oracle_raw = float("nan")
+
+        latest_delta = base["latest_pred_v_deg"] - label.tm_launch_v_deg
+        fixed_delta = base["fixed_pred_v_deg"] - label.tm_launch_v_deg
+        prev_oracle_delta = base["oracle_pred_v_deg"] - label.tm_launch_v_deg
+        pseudo_delta = pseudo_pred - label.tm_launch_v_deg
+        sweep_oracle_delta = oracle_pred - label.tm_launch_v_deg
+
+        per_shot_rows.append(
+            {
+                "session": label.session_dir,
+                "comparison_file": label.comparison_file,
+                "shot_number": label.shot_number,
+                "club": label.club,
+                "mount_deg": label.mount_deg,
+                "distance_ft": label.distance_ft,
+                "distance_source": label.distance_source,
+                "ops_ball_speed_mph": round(label.ops_ball_speed_mph, 3),
+                "tm_launch_v_deg": label.tm_launch_v_deg,
+                "latest_pred_v_deg": base["latest_pred_v_deg"],
+                "fixed_pred_v_deg": base["fixed_pred_v_deg"],
+                "prev_oracle_pred_v_deg": base["oracle_pred_v_deg"],
+                "pseudo_pred_v_deg": pseudo_pred,
+                "sweep_oracle_pred_v_deg": oracle_pred,
+                "latest_delta_deg": latest_delta,
+                "fixed_delta_deg": fixed_delta,
+                "prev_oracle_delta_deg": prev_oracle_delta,
+                "pseudo_delta_deg": pseudo_delta,
+                "sweep_oracle_delta_deg": sweep_oracle_delta,
+                "latest_abs_err_deg": abs(latest_delta),
+                "fixed_abs_err_deg": abs(fixed_delta),
+                "prev_oracle_abs_err_deg": abs(prev_oracle_delta),
+                "pseudo_abs_err_deg": abs(pseudo_delta),
+                "sweep_oracle_abs_err_deg": abs(sweep_oracle_delta),
+                "candidate_pool_size": len(candidates),
+                "pseudo_selected_raw_deg": pseudo_raw,
+                "sweep_oracle_selected_raw_deg": oracle_raw,
+            }
+        )
+
+    write_csv(args.output_dir / "candidate_pool_rows.csv", all_candidate_rows)
+    write_csv(args.output_dir / "per_shot_timing_candidate_sweep.csv", per_shot_rows)
+
+    overall_rows: list[dict[str, Any]] = []
+    strategies = [
+        ("latest", "latest_pred_v_deg", "latest_delta_deg"),
+        ("fixed", "fixed_pred_v_deg", "fixed_delta_deg"),
+        ("prev_oracle", "prev_oracle_pred_v_deg", "prev_oracle_delta_deg"),
+        ("pseudo", "pseudo_pred_v_deg", "pseudo_delta_deg"),
+        ("sweep_oracle", "sweep_oracle_pred_v_deg", "sweep_oracle_delta_deg"),
+    ]
+    for name, pred_k, delta_k in strategies:
+        s = summarize(per_shot_rows, pred_k, delta_k)
+        overall_rows.append(
+            {
+                "strategy": name,
+                "n": int(s["n"]),
+                "mae_deg": s["mae"],
+                "bias_deg": s["bias"],
+                "rmse_deg": s["rmse"],
+                "p90_abs_deg": s["p90_abs"],
+                "retained_le8": int(s["retained_le8"]),
+                "retention_pct": s["ret_pct"],
+            }
+        )
+    write_csv(args.output_dir / "overall_summary_timing_candidate_sweep.csv", overall_rows)
+
+    per_session_rows: list[dict[str, Any]] = []
+    sessions = sorted({r["session"] for r in per_shot_rows})
+    for session in sessions:
+        chunk = [r for r in per_shot_rows if r["session"] == session]
+        row: dict[str, Any] = {"session": session, "shots": len(chunk)}
+        for name, pred_k, delta_k in strategies:
+            s = summarize(chunk, pred_k, delta_k)
+            row[f"{name}_mae_deg"] = s["mae"]
+            row[f"{name}_retention_pct"] = s["ret_pct"]
+        per_session_rows.append(row)
+    write_csv(args.output_dir / "session_summary_timing_candidate_sweep.csv", per_session_rows)
+
+    per_mount_rows: list[dict[str, Any]] = []
+    mounts = sorted({float(r["mount_deg"]) for r in per_shot_rows})
+    for mount in mounts:
+        chunk = [r for r in per_shot_rows if float(r["mount_deg"]) == mount]
+        row = {"mount_deg": mount, "shots": len(chunk)}
+        for name, pred_k, delta_k in strategies:
+            s = summarize(chunk, pred_k, delta_k)
+            row[f"{name}_mae_deg"] = s["mae"]
+            row[f"{name}_retention_pct"] = s["ret_pct"]
+        per_mount_rows.append(row)
+    write_csv(args.output_dir / "mount_summary_timing_candidate_sweep.csv", per_mount_rows)
+
+    report = args.output_dir / "timing_candidate_sweep_report.md"
+    with report.open("w") as f:
+        f.write("# Timing Candidate Sweep Report\n\n")
+        f.write("- Candidate pool source: raw `kld7_buffer` (vertical) per shot\n")
+        f.write("- Distance assumption: known (5/6ft) where provided, else assumed 6ft\n")
+        f.write("- Geometry: lateral offset 4in, distance by session\n")
+        f.write("- Timing anchors: first-byte centered plus near-equivalent accept/shot-log back-shifts\n")
+        f.write("- Oracle uses TM only for analysis ceiling, not production\n\n")
+
+        f.write("## Overall\n\n")
+        f.write("| strategy | n | MAE | Bias | RMSE | P90 abs | <=8deg | retention |\n")
+        f.write("|---|---:|---:|---:|---:|---:|---:|---:|\n")
+        for r in overall_rows:
+            f.write(
+                f"| {r['strategy']} | {r['n']} | {r['mae_deg']:.3f} | {r['bias_deg']:.3f} | "
+                f"{r['rmse_deg']:.3f} | {r['p90_abs_deg']:.3f} | {r['retained_le8']} | {r['retention_pct']:.1f}% |\n"
+            )
+        f.write("\n## By Session (MAE)\n\n")
+        f.write("| session | shots | latest | fixed | prev_oracle | pseudo | sweep_oracle |\n")
+        f.write("|---|---:|---:|---:|---:|---:|---:|\n")
+        for r in per_session_rows:
+            f.write(
+                f"| {r['session']} | {r['shots']} | {r['latest_mae_deg']:.3f} | {r['fixed_mae_deg']:.3f} | "
+                f"{r['prev_oracle_mae_deg']:.3f} | {r['pseudo_mae_deg']:.3f} | {r['sweep_oracle_mae_deg']:.3f} |\n"
+            )
+        f.write("\n## By Mount (MAE)\n\n")
+        f.write("| mount | shots | latest | fixed | prev_oracle | pseudo | sweep_oracle |\n")
+        f.write("|---:|---:|---:|---:|---:|---:|---:|\n")
+        for r in per_mount_rows:
+            f.write(
+                f"| {r['mount_deg']:.1f} | {r['shots']} | {r['latest_mae_deg']:.3f} | {r['fixed_mae_deg']:.3f} | "
+                f"{r['prev_oracle_mae_deg']:.3f} | {r['pseudo_mae_deg']:.3f} | {r['sweep_oracle_mae_deg']:.3f} |\n"
+            )
+
+    print(f"Wrote: {args.output_dir}")
+    print(f"- per_shot: {args.output_dir / 'per_shot_timing_candidate_sweep.csv'}")
+    print(f"- overall:  {args.output_dir / 'overall_summary_timing_candidate_sweep.csv'}")
+    print(f"- report:   {report}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/track_candidate_ranker.py
+++ b/scripts/analysis/track_candidate_ranker.py
@@ -1,0 +1,792 @@
+#!/usr/bin/env python3
+"""Track-style K-LD7 candidate ranker.
+
+This is an offline analysis tool. It treats each K-LD7 launch candidate as
+part of a small "track" through the candidate space: support across timing
+sweeps, nearby support, frame consistency, confidence, SNR, and launch
+plausibility. TrackMan is used only for labeling/evaluation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def _to_float(value: Any, default: float = 0.0) -> float:
+    if value in (None, ""):
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_int(value: Any, default: int = 0) -> int:
+    return int(round(_to_float(value, float(default))))
+
+
+def _mae(values: list[float]) -> float:
+    return float(sum(abs(v) for v in values) / len(values)) if values else float("nan")
+
+
+def _rmse(values: list[float]) -> float:
+    return float(math.sqrt(sum(v * v for v in values) / len(values))) if values else float("nan")
+
+
+def _p90_abs(values: list[float]) -> float:
+    if not values:
+        return float("nan")
+    arr = sorted(abs(v) for v in values)
+    return float(arr[int((len(arr) - 1) * 0.9)])
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fields = list(rows[0].keys())
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _read_csv(path: Path) -> list[dict[str, Any]]:
+    with path.open() as f:
+        return list(csv.DictReader(f))
+
+
+def _shot_key(row: dict[str, Any]) -> tuple[str, str, int]:
+    return (
+        row["session"],
+        row["comparison_file"],
+        _to_int(row["shot_number"]),
+    )
+
+
+def _club_expected_launch(club: str) -> float:
+    normalized = club.lower().replace(" ", "").replace("_", "-")
+    if "driver" in normalized:
+        return 12.0
+    if "9" in normalized:
+        return 19.0
+    if "8" in normalized:
+        return 18.0
+    if "7" in normalized:
+        return 16.5
+    return 16.0
+
+
+def _mount_center(mount_deg: float, club: str) -> float:
+    expected = _club_expected_launch(club)
+    if mount_deg >= 16.0:
+        return max(15.5, min(19.0, expected + 0.5))
+    if mount_deg >= 6.0:
+        return max(14.0, min(19.5, expected))
+    return expected
+
+
+def _lane_penalty(pred: float, mount_deg: float, club: str) -> float:
+    center = _mount_center(mount_deg, club)
+    lo = max(3.0, center - 8.0)
+    hi = center + 8.0
+    if mount_deg >= 16.0:
+        lo = max(lo, 8.0)
+        hi = min(hi, 25.0)
+    elif mount_deg >= 6.0:
+        hi = min(hi, 27.0)
+    else:
+        hi = min(hi, 32.0)
+    if pred < lo:
+        return lo - pred
+    if pred > hi:
+        return pred - hi
+    return 0.0
+
+
+def _safe_ratio(num: float, denom: float) -> float:
+    return num / denom if denom else 0.0
+
+
+def load_shot_rows(per_shot_csv: Path) -> dict[tuple[str, str, int], dict[str, Any]]:
+    rows = {}
+    for row in _read_csv(per_shot_csv):
+        rows[_shot_key(row)] = row
+    return rows
+
+
+def load_candidate_rows(
+    bucket_csv: Path,
+    shot_rows: dict[tuple[str, str, int], dict[str, Any]],
+) -> dict[tuple[str, str, int], list[dict[str, Any]]]:
+    by_shot: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in _read_csv(bucket_csv):
+        key = _shot_key(row)
+        if key not in shot_rows:
+            continue
+        by_shot[key].append(
+            {
+                "source": "bucket",
+                "pred_v_deg": round(_to_float(row["pred_v_deg"]), 1),
+                "support": _to_float(row.get("support")),
+                "confidence": _to_float(row.get("confidence")),
+                "avg_snr_db": _to_float(row.get("avg_snr_db")),
+                "frame_count": _to_float(row.get("frame_count")),
+                "corrected_std_deg": _to_float(row.get("corrected_std_deg"), 99.0),
+                "corrected_linear_resid_deg": _to_float(
+                    row.get("corrected_linear_resid_deg"), 99.0
+                ),
+                "per_frame_count": _to_float(row.get("per_frame_count")),
+                "t_span_s": _to_float(row.get("t_span_s")),
+            }
+        )
+
+    for key, shot in shot_rows.items():
+        pool = by_shot[key]
+        existing = {round(_to_float(c["pred_v_deg"]), 1) for c in pool}
+        for source, pred_key in (
+            ("latest", "latest_pred_v_deg"),
+            ("fixed", "fixed_pred_v_deg"),
+        ):
+            pred = round(_to_float(shot.get(pred_key)), 1)
+            if pred in existing:
+                continue
+            pool.append(
+                {
+                    "source": source,
+                    "pred_v_deg": pred,
+                    "support": 0.0,
+                    "confidence": 0.50,
+                    "avg_snr_db": 5.0,
+                    "frame_count": 1.0,
+                    "corrected_std_deg": 99.0,
+                    "corrected_linear_resid_deg": 99.0,
+                    "per_frame_count": 0.0,
+                    "t_span_s": 0.0,
+                }
+            )
+    return by_shot
+
+
+def enrich_candidates(
+    shot_rows: dict[tuple[str, str, int], dict[str, Any]],
+    by_shot: dict[tuple[str, str, int], list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for key, shot in shot_rows.items():
+        pool = by_shot.get(key, [])
+        if not pool:
+            continue
+        total_support = sum(_to_float(c["support"]) for c in pool)
+        max_support = max((_to_float(c["support"]) for c in pool), default=0.0)
+        max_conf = max((_to_float(c["confidence"]) for c in pool), default=0.0)
+        preds = [_to_float(c["pred_v_deg"]) for c in pool]
+        support_sorted = sorted(
+            ((_to_float(c["support"]), _to_float(c["pred_v_deg"])) for c in pool),
+            reverse=True,
+        )
+        rank_by_pred = {
+            pred: idx + 1
+            for idx, (_, pred) in enumerate(support_sorted)
+        }
+
+        session, comparison_file, shot_number = key
+        mount = _to_float(shot.get("mount_deg"))
+        club = shot.get("club", "unknown")
+        center = _mount_center(mount, club)
+        for cand in pool:
+            pred = _to_float(cand["pred_v_deg"])
+            support = _to_float(cand["support"])
+            neighbor_05 = sum(
+                _to_float(other["support"])
+                for other in pool
+                if abs(_to_float(other["pred_v_deg"]) - pred) <= 0.5
+            )
+            neighbor_10 = sum(
+                _to_float(other["support"])
+                for other in pool
+                if abs(_to_float(other["pred_v_deg"]) - pred) <= 1.0
+            )
+            stronger = [
+                abs(_to_float(other["pred_v_deg"]) - pred)
+                for other in pool
+                if _to_float(other["support"]) > support
+            ]
+            nearest_stronger = min(stronger) if stronger else 99.0
+            out.append(
+                {
+                    "session": session,
+                    "comparison_file": comparison_file,
+                    "shot_number": shot_number,
+                    "club": club,
+                    "mount_deg": mount,
+                    "distance_ft": _to_float(shot.get("distance_ft")),
+                    "distance_source": shot.get("distance_source", ""),
+                    "ops_ball_speed_mph": _to_float(shot.get("ops_ball_speed_mph")),
+                    "tm_launch_v_deg": _to_float(shot.get("tm_launch_v_deg")),
+                    "source": cand["source"],
+                    "pred_v_deg": pred,
+                    "candidate_count": len(pool),
+                    "support": support,
+                    "support_share": _safe_ratio(support, total_support),
+                    "max_support_share": _safe_ratio(max_support, total_support),
+                    "support_rank": rank_by_pred.get(pred, len(pool)),
+                    "neighbor_support_05": neighbor_05,
+                    "neighbor_support_10": neighbor_10,
+                    "neighbor_share_05": _safe_ratio(neighbor_05, total_support),
+                    "neighbor_share_10": _safe_ratio(neighbor_10, total_support),
+                    "nearest_stronger_deg": nearest_stronger,
+                    "confidence": _to_float(cand.get("confidence")),
+                    "confidence_share": _safe_ratio(_to_float(cand.get("confidence")), max_conf),
+                    "avg_snr_db": _to_float(cand.get("avg_snr_db")),
+                    "frame_count": _to_float(cand.get("frame_count")),
+                    "corrected_std_deg": _to_float(cand.get("corrected_std_deg"), 99.0),
+                    "corrected_linear_resid_deg": _to_float(
+                        cand.get("corrected_linear_resid_deg"), 99.0
+                    ),
+                    "per_frame_count": _to_float(cand.get("per_frame_count")),
+                    "t_span_s": _to_float(cand.get("t_span_s")),
+                    "expected_launch_deg": center,
+                    "abs_from_expected": abs(pred - center),
+                    "lane_penalty": _lane_penalty(pred, mount, club),
+                    "is_high_pred": 1.0 if pred > 24.0 else 0.0,
+                    "is_low_pred": 1.0 if pred < 8.0 else 0.0,
+                    "is_fallback": 1.0 if cand["source"] != "bucket" else 0.0,
+                    "has_nearby_pred": 1.0 if any(abs(other - pred) <= 1.0 and other != pred for other in preds) else 0.0,
+                }
+            )
+    return out
+
+
+FEATURE_COLUMNS = [
+    "pred_v_deg",
+    "support",
+    "support_share",
+    "max_support_share",
+    "support_rank",
+    "neighbor_support_05",
+    "neighbor_support_10",
+    "neighbor_share_05",
+    "neighbor_share_10",
+    "nearest_stronger_deg",
+    "confidence",
+    "confidence_share",
+    "avg_snr_db",
+    "frame_count",
+    "corrected_std_deg",
+    "corrected_linear_resid_deg",
+    "per_frame_count",
+    "t_span_s",
+    "expected_launch_deg",
+    "abs_from_expected",
+    "lane_penalty",
+    "is_high_pred",
+    "is_low_pred",
+    "is_fallback",
+    "has_nearby_pred",
+    "mount_deg",
+    "distance_ft",
+    "ops_ball_speed_mph",
+    "candidate_count",
+]
+
+
+def feature_vector(row: dict[str, Any]) -> np.ndarray:
+    values = [_to_float(row.get(name)) for name in FEATURE_COLUMNS]
+    pred = _to_float(row["pred_v_deg"])
+    mount = _to_float(row["mount_deg"])
+    expected = _to_float(row["expected_launch_deg"])
+    values.extend(
+        [
+            pred * pred / 100.0,
+            pred * mount / 100.0,
+            abs(pred - 16.0),
+            abs(pred - expected) ** 2 / 25.0,
+            math.log1p(max(_to_float(row["support"]), 0.0)),
+            math.log1p(max(_to_float(row["neighbor_support_10"]), 0.0)),
+        ]
+    )
+    return np.array(values, dtype=float)
+
+
+def manual_track_score(row: dict[str, Any]) -> float:
+    pred = _to_float(row["pred_v_deg"])
+    mount = _to_float(row["mount_deg"])
+    score = 0.0
+    score += 2.2 * _to_float(row["support_share"])
+    score += 1.8 * _to_float(row["neighbor_share_10"])
+    score += 0.8 * _to_float(row["confidence"])
+    score += 0.04 * min(_to_float(row["avg_snr_db"]), 25.0)
+    score += 0.10 * min(_to_float(row["frame_count"]), 5.0)
+    score += 0.08 * min(_to_float(row["per_frame_count"]), 5.0)
+    score += 0.20 * _to_float(row["has_nearby_pred"])
+    score -= 0.16 * _to_float(row["abs_from_expected"])
+    score -= 0.40 * _to_float(row["lane_penalty"])
+    score -= 0.015 * min(_to_float(row["corrected_linear_resid_deg"]), 30.0)
+    score -= 0.020 * min(_to_float(row["corrected_std_deg"]), 30.0)
+    score -= 0.18 * _to_float(row["is_fallback"])
+    if mount >= 16.0 and pred > 24.0:
+        score -= 1.7
+    if mount >= 16.0 and pred < 10.0:
+        score -= 1.1
+    if mount < 6.0 and pred < 5.0:
+        score -= 1.0
+    return score
+
+
+def summarize(rows: list[dict[str, Any]], pred_key: str) -> dict[str, float]:
+    deltas = [
+        _to_float(row[pred_key]) - _to_float(row["tm_launch_v_deg"])
+        for row in rows
+        if row.get(pred_key) not in (None, "")
+    ]
+    retained = sum(1 for delta in deltas if abs(delta) <= 8.0)
+    return {
+        "n": float(len(deltas)),
+        "mae_deg": _mae(deltas),
+        "bias_deg": float(sum(deltas) / len(deltas)) if deltas else float("nan"),
+        "rmse_deg": _rmse(deltas),
+        "p90_abs_deg": _p90_abs(deltas),
+        "retained_le8": float(retained),
+        "retention_pct": retained / len(deltas) * 100.0 if deltas else 0.0,
+    }
+
+
+def _select_best(
+    candidates: list[dict[str, Any]],
+    score_key: str,
+) -> dict[str, Any]:
+    return max(candidates, key=lambda row: (_to_float(row[score_key]), -_to_float(row["support_rank"])))
+
+
+def _select_oracle(candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    return min(
+        candidates,
+        key=lambda row: abs(_to_float(row["pred_v_deg"]) - _to_float(row["tm_launch_v_deg"])),
+    )
+
+
+def _fit_pairwise_ranker(train_rows: list[dict[str, Any]], ridge_lambda: float) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    by_shot: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in train_rows:
+        by_shot[_shot_key(row)].append(row)
+
+    diffs: list[np.ndarray] = []
+    for candidates in by_shot.values():
+        if len(candidates) < 2:
+            continue
+        oracle = _select_oracle(candidates)
+        oracle_err = abs(_to_float(oracle["pred_v_deg"]) - _to_float(oracle["tm_launch_v_deg"]))
+        oracle_x = feature_vector(oracle)
+        for row in candidates:
+            if row is oracle:
+                continue
+            err = abs(_to_float(row["pred_v_deg"]) - _to_float(row["tm_launch_v_deg"]))
+            if err <= oracle_err + 0.25:
+                continue
+            diff = oracle_x - feature_vector(row)
+            diffs.append(diff)
+            diffs.append(-diff)
+
+    if not diffs:
+        n = len(feature_vector(train_rows[0]))
+        return np.zeros(n), np.zeros(n), np.ones(n)
+
+    x_raw = np.vstack(diffs)
+    y = np.array([1.0 if i % 2 == 0 else -1.0 for i in range(len(diffs))])
+    scale_rows = np.vstack([feature_vector(row) for row in train_rows])
+    mean = np.mean(scale_rows, axis=0)
+    std = np.std(scale_rows, axis=0)
+    std[std < 1e-9] = 1.0
+    x = x_raw / std
+    xtx = x.T @ x
+    reg = ridge_lambda * np.eye(x.shape[1])
+    weights = np.linalg.solve(xtx + reg, x.T @ y)
+    return weights, mean, std
+
+
+def _ranker_score(row: dict[str, Any], weights: np.ndarray, mean: np.ndarray, std: np.ndarray) -> float:
+    return float(((feature_vector(row) - mean) / std) @ weights)
+
+
+def _fit_error_ranker(
+    train_rows: list[dict[str, Any]],
+    ridge_lambda: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    x_raw = np.vstack([feature_vector(row) for row in train_rows])
+    mean = np.mean(x_raw, axis=0)
+    std = np.std(x_raw, axis=0)
+    std[std < 1e-9] = 1.0
+    x = (x_raw - mean) / std
+    abs_err = np.array(
+        [
+            abs(_to_float(row["pred_v_deg"]) - _to_float(row["tm_launch_v_deg"]))
+            for row in train_rows
+        ],
+        dtype=float,
+    )
+    # Higher score should be better at selection time, so train against
+    # negative absolute error rather than absolute error.
+    y = -abs_err
+    xtx = x.T @ x
+    reg = ridge_lambda * np.eye(x.shape[1])
+    weights = np.linalg.solve(xtx + reg, x.T @ y)
+    return weights, mean, std
+
+
+def run_loso_error_ranker(
+    candidate_rows: list[dict[str, Any]],
+    ridge_lambda: float,
+) -> tuple[dict[tuple[str, str, int], tuple[float, str, float]], list[dict[str, Any]]]:
+    sessions = sorted({row["session"] for row in candidate_rows})
+    selected: dict[tuple[str, str, int], tuple[float, str, float]] = {}
+    weight_rows: list[dict[str, Any]] = []
+    feature_names = FEATURE_COLUMNS + [
+        "pred_sq",
+        "pred_x_mount",
+        "abs_pred_16",
+        "abs_expected_sq",
+        "log_support",
+        "log_neighbor10",
+    ]
+    for test_session in sessions:
+        train = [row for row in candidate_rows if row["session"] != test_session]
+        test = [row for row in candidate_rows if row["session"] == test_session]
+        weights, mean, std = _fit_error_ranker(train, ridge_lambda)
+        for feature, weight in sorted(
+            zip(feature_names, weights),
+            key=lambda item: abs(item[1]),
+            reverse=True,
+        )[:12]:
+            weight_rows.append(
+                {
+                    "ranker": "error",
+                    "heldout_session": test_session,
+                    "feature": feature,
+                    "weight": weight,
+                }
+            )
+
+        by_shot: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+        for row in test:
+            scored = dict(row)
+            scored["learned_error_score"] = _ranker_score(row, weights, mean, std)
+            by_shot[_shot_key(scored)].append(scored)
+        for key, rows in by_shot.items():
+            best = _select_best(rows, "learned_error_score")
+            selected[key] = (
+                _to_float(best["pred_v_deg"]),
+                str(best["source"]),
+                _to_float(best["learned_error_score"]),
+            )
+    return selected, weight_rows
+
+
+def run_loso_pairwise_ranker(
+    candidate_rows: list[dict[str, Any]],
+    ridge_lambda: float,
+) -> tuple[dict[tuple[str, str, int], tuple[float, str, float]], list[dict[str, Any]]]:
+    sessions = sorted({row["session"] for row in candidate_rows})
+    selected: dict[tuple[str, str, int], tuple[float, str, float]] = {}
+    weight_rows: list[dict[str, Any]] = []
+    for test_session in sessions:
+        train = [row for row in candidate_rows if row["session"] != test_session]
+        test = [row for row in candidate_rows if row["session"] == test_session]
+        weights, mean, std = _fit_pairwise_ranker(train, ridge_lambda)
+        for feature, weight in sorted(
+            zip(FEATURE_COLUMNS + ["pred_sq", "pred_x_mount", "abs_pred_16", "abs_expected_sq", "log_support", "log_neighbor10"], weights),
+            key=lambda item: abs(item[1]),
+            reverse=True,
+        )[:12]:
+            weight_rows.append(
+                {
+                    "ranker": "pairwise",
+                    "heldout_session": test_session,
+                    "feature": feature,
+                    "weight": weight,
+                }
+            )
+
+        by_shot: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+        for row in test:
+            scored = dict(row)
+            scored["learned_rank_score"] = _ranker_score(row, weights, mean, std)
+            by_shot[_shot_key(scored)].append(scored)
+        for key, rows in by_shot.items():
+            best = _select_best(rows, "learned_rank_score")
+            selected[key] = (
+                _to_float(best["pred_v_deg"]),
+                str(best["source"]),
+                _to_float(best["learned_rank_score"]),
+            )
+    return selected, weight_rows
+
+
+def build_per_shot_output(
+    shot_rows: dict[tuple[str, str, int], dict[str, Any]],
+    candidate_rows: list[dict[str, Any]],
+    learned_error_selected: dict[tuple[str, str, int], tuple[float, str, float]],
+    learned_pairwise_selected: dict[tuple[str, str, int], tuple[float, str, float]],
+) -> list[dict[str, Any]]:
+    by_shot: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in candidate_rows:
+        scored = dict(row)
+        scored["manual_track_score"] = manual_track_score(row)
+        by_shot[_shot_key(row)].append(scored)
+
+    out: list[dict[str, Any]] = []
+    for key, shot in sorted(shot_rows.items()):
+        candidates = by_shot.get(key)
+        if not candidates:
+            continue
+        oracle = _select_oracle(candidates)
+        manual = _select_best(candidates, "manual_track_score")
+        learned_error_pred, learned_error_source, learned_error_score = learned_error_selected.get(
+            key,
+            (_to_float(shot["fixed_pred_v_deg"]), "fallback_missing", 0.0),
+        )
+        learned_pairwise_pred, learned_pairwise_source, learned_pairwise_score = (
+            learned_pairwise_selected.get(
+                key,
+                (_to_float(shot["fixed_pred_v_deg"]), "fallback_missing", 0.0),
+            )
+        )
+        tm = _to_float(shot["tm_launch_v_deg"])
+        row = {
+            "session": key[0],
+            "comparison_file": key[1],
+            "shot_number": key[2],
+            "club": shot.get("club", ""),
+            "mount_deg": _to_float(shot.get("mount_deg")),
+            "distance_ft": _to_float(shot.get("distance_ft")),
+            "distance_source": shot.get("distance_source", ""),
+            "ops_ball_speed_mph": _to_float(shot.get("ops_ball_speed_mph")),
+            "tm_launch_v_deg": tm,
+            "latest_pred_v_deg": _to_float(shot.get("latest_pred_v_deg")),
+            "fixed_pred_v_deg": _to_float(shot.get("fixed_pred_v_deg")),
+            "prev_oracle_pred_v_deg": _to_float(shot.get("prev_oracle_pred_v_deg")),
+            "geom_v5_pred_v_deg": _to_float(shot.get("geom_v5_pred_v_deg"), float("nan")),
+            "manual_track_pred_v_deg": _to_float(manual["pred_v_deg"]),
+            "manual_track_source": manual["source"],
+            "manual_track_score": manual["manual_track_score"],
+            "learned_error_pred_v_deg": learned_error_pred,
+            "learned_error_source": learned_error_source,
+            "learned_error_score": learned_error_score,
+            "learned_pairwise_pred_v_deg": learned_pairwise_pred,
+            "learned_pairwise_source": learned_pairwise_source,
+            "learned_pairwise_score": learned_pairwise_score,
+            "candidate_oracle_pred_v_deg": _to_float(oracle["pred_v_deg"]),
+            "candidate_oracle_source": oracle["source"],
+            "candidate_count": len(candidates),
+            "bucket_count": sum(1 for c in candidates if c["source"] == "bucket"),
+        }
+        for name in (
+            "latest",
+            "fixed",
+            "prev_oracle",
+            "geom_v5",
+            "manual_track",
+            "learned_error",
+            "learned_pairwise",
+            "candidate_oracle",
+        ):
+            pred = _to_float(row.get(f"{name}_pred_v_deg"), float("nan"))
+            if math.isfinite(pred):
+                delta = pred - tm
+                row[f"{name}_delta_deg"] = delta
+                row[f"{name}_abs_err_deg"] = abs(delta)
+            else:
+                row[f"{name}_delta_deg"] = ""
+                row[f"{name}_abs_err_deg"] = ""
+        out.append(row)
+    return out
+
+
+def write_summaries(output_dir: Path, per_shot: list[dict[str, Any]], weight_rows: list[dict[str, Any]]) -> None:
+    strategies = [
+        "latest",
+        "fixed",
+        "prev_oracle",
+        "geom_v5",
+        "manual_track",
+        "learned_error",
+        "learned_pairwise",
+        "candidate_oracle",
+    ]
+    overall = []
+    for strategy in strategies:
+        stats = summarize(per_shot, f"{strategy}_pred_v_deg")
+        overall.append({"strategy": strategy, **stats})
+    _write_csv(output_dir / "overall_summary_track_candidate_ranker.csv", overall)
+
+    session_rows = []
+    for session in sorted({row["session"] for row in per_shot}):
+        rows = [row for row in per_shot if row["session"] == session]
+        out: dict[str, Any] = {"session": session, "shots": len(rows)}
+        for strategy in strategies:
+            stats = summarize(rows, f"{strategy}_pred_v_deg")
+            out[f"{strategy}_mae_deg"] = stats["mae_deg"]
+            out[f"{strategy}_retention_pct"] = stats["retention_pct"]
+        session_rows.append(out)
+    _write_csv(output_dir / "session_summary_track_candidate_ranker.csv", session_rows)
+
+    mount_rows = []
+    for mount in sorted({_to_float(row["mount_deg"]) for row in per_shot}):
+        rows = [row for row in per_shot if _to_float(row["mount_deg"]) == mount]
+        out = {"mount_deg": mount, "shots": len(rows)}
+        for strategy in strategies:
+            stats = summarize(rows, f"{strategy}_pred_v_deg")
+            out[f"{strategy}_mae_deg"] = stats["mae_deg"]
+            out[f"{strategy}_retention_pct"] = stats["retention_pct"]
+        mount_rows.append(out)
+    _write_csv(output_dir / "mount_summary_track_candidate_ranker.csv", mount_rows)
+
+    coverage_rows = []
+    coverage_groups: list[tuple[str, str, list[dict[str, Any]]]] = [
+        ("overall", "ALL", per_shot),
+    ]
+    coverage_groups.extend(
+        ("session", session, [row for row in per_shot if row["session"] == session])
+        for session in sorted({row["session"] for row in per_shot})
+    )
+    coverage_groups.extend(
+        ("mount", str(mount), [row for row in per_shot if _to_float(row["mount_deg"]) == mount])
+        for mount in sorted({_to_float(row["mount_deg"]) for row in per_shot})
+    )
+    coverage_groups.extend(
+        ("club", club, [row for row in per_shot if row["club"] == club])
+        for club in sorted({str(row["club"]) for row in per_shot})
+    )
+    coverage_groups.extend(
+        [
+            ("subset", "non_driver", [row for row in per_shot if row["club"] != "driver"]),
+            ("subset", "7iron_only", [row for row in per_shot if row["club"] == "7-iron"]),
+            ("subset", "18deg_only", [row for row in per_shot if _to_float(row["mount_deg"]) == 18.0]),
+        ]
+    )
+    for group_type, group, rows in coverage_groups:
+        errors = [_to_float(row["candidate_oracle_abs_err_deg"]) for row in rows]
+        if not errors:
+            continue
+        coverage_rows.append(
+            {
+                "group_type": group_type,
+                "group": group,
+                "shots": len(errors),
+                "candidate_oracle_mae_deg": _mae(errors),
+                "within_1deg": sum(1 for err in errors if err <= 1.0),
+                "within_2deg": sum(1 for err in errors if err <= 2.0),
+                "within_3deg": sum(1 for err in errors if err <= 3.0),
+                "within_5deg": sum(1 for err in errors if err <= 5.0),
+            }
+        )
+    _write_csv(output_dir / "coverage_summary_track_candidate_ranker.csv", coverage_rows)
+
+    worst = sorted(
+        per_shot,
+        key=lambda row: _to_float(row["learned_error_abs_err_deg"]),
+        reverse=True,
+    )[:20]
+    _write_csv(output_dir / "top20_worst_learned_error.csv", worst)
+    _write_csv(output_dir / "learned_rank_top_weights.csv", weight_rows)
+
+    report = output_dir / "track_candidate_ranker_report.md"
+    with report.open("w") as f:
+        f.write("# Track Candidate Ranker Report\n\n")
+        f.write("Offline analysis only. TrackMan is used for labels/evaluation; runtime features only are used for scoring.\n\n")
+        f.write("## Overall\n\n")
+        f.write("| strategy | n | MAE | Bias | RMSE | P90 abs | <=8deg | retention |\n")
+        f.write("|---|---:|---:|---:|---:|---:|---:|---:|\n")
+        for row in overall:
+            f.write(
+                f"| {row['strategy']} | {int(row['n'])} | {row['mae_deg']:.3f} | "
+                f"{row['bias_deg']:.3f} | {row['rmse_deg']:.3f} | {row['p90_abs_deg']:.3f} | "
+                f"{int(row['retained_le8'])} | {row['retention_pct']:.1f}% |\n"
+            )
+        f.write("\n## By Session MAE\n\n")
+        f.write("| session | shots | fixed | geom_v5 | manual_track | learned_error | learned_pairwise | candidate_oracle |\n")
+        f.write("|---|---:|---:|---:|---:|---:|---:|---:|\n")
+        for row in session_rows:
+            f.write(
+                f"| {row['session']} | {row['shots']} | {row['fixed_mae_deg']:.3f} | "
+                f"{row['geom_v5_mae_deg']:.3f} | {row['manual_track_mae_deg']:.3f} | "
+                f"{row['learned_error_mae_deg']:.3f} | {row['learned_pairwise_mae_deg']:.3f} | "
+                f"{row['candidate_oracle_mae_deg']:.3f} |\n"
+            )
+        f.write("\n## Interpretation Notes\n\n")
+        f.write("- `candidate_oracle` is the TM-selected ceiling for this candidate cache.\n")
+        f.write("- `manual_track` is a hand-built TM-free score using support, nearby support, confidence, consistency, and plausibility.\n")
+        f.write("- `learned_error` is leave-one-session-out: each held-out session is scored by a ridge model trained to predict negative candidate absolute error on the other sessions.\n")
+        f.write("- `learned_pairwise` is leave-one-session-out: each held-out session is scored by a pairwise ranker trained on the other sessions.\n")
+        f.write("- If `candidate_oracle` is high, the right answer is missing from this candidate pool or geometry assumptions are wrong.\n")
+        f.write("\n## Candidate Coverage\n\n")
+        f.write("| group | shots | oracle MAE | <=1deg | <=2deg | <=3deg | <=5deg |\n")
+        f.write("|---|---:|---:|---:|---:|---:|---:|\n")
+        for row in coverage_rows:
+            if row["group_type"] not in {"overall", "subset", "mount"}:
+                continue
+            f.write(
+                f"| {row['group_type']}:{row['group']} | {row['shots']} | "
+                f"{row['candidate_oracle_mae_deg']:.3f} | {row['within_1deg']} | "
+                f"{row['within_2deg']} | {row['within_3deg']} | {row['within_5deg']} |\n"
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    root = Path("~/Desktop/openflight_sessions").expanduser()
+    parser.add_argument(
+        "--per-shot-csv",
+        type=Path,
+        default=root / "_analysis_geometry_candidate_selector_v5_cached/per_shot_geometry_candidate_selector_v5.csv",
+    )
+    parser.add_argument(
+        "--bucket-csv",
+        type=Path,
+        default=root / "_analysis_geometry_candidate_selector/bucket_geometry_candidate_selector.csv",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=root / "_analysis_track_candidate_ranker_cached",
+    )
+    parser.add_argument("--error-ridge-lambda", type=float, default=1.0)
+    parser.add_argument("--pairwise-ridge-lambda", type=float, default=5.0)
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    shot_rows = load_shot_rows(args.per_shot_csv)
+    by_shot = load_candidate_rows(args.bucket_csv, shot_rows)
+    candidates = enrich_candidates(shot_rows, by_shot)
+    learned_error, error_weights = run_loso_error_ranker(
+        candidates,
+        ridge_lambda=args.error_ridge_lambda,
+    )
+    learned_pairwise, pairwise_weights = run_loso_pairwise_ranker(
+        candidates,
+        ridge_lambda=args.pairwise_ridge_lambda,
+    )
+    per_shot = build_per_shot_output(
+        shot_rows,
+        candidates,
+        learned_error,
+        learned_pairwise,
+    )
+
+    _write_csv(args.output_dir / "candidate_rows_track_candidate_ranker.csv", candidates)
+    _write_csv(args.output_dir / "per_shot_track_candidate_ranker.csv", per_shot)
+    write_summaries(args.output_dir, per_shot, error_weights + pairwise_weights)
+
+    print(f"Wrote {args.output_dir}")
+    print(f"- {args.output_dir / 'track_candidate_ranker_report.md'}")
+    print(f"- {args.output_dir / 'per_shot_track_candidate_ranker.csv'}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add offline analysis scripts for K-LD7 timing-aware candidate sweeps, effective-offset geometry candidates, and TM-labeled candidate ranking
- document the effective-offset finding and candidate-oracle interpretation for PR review
- keep generated session outputs and broader experimental scripts out of the PR

## Validation
- uv run --no-sync ruff check scripts/analysis/timing_candidate_sweep.py scripts/analysis/geometry_candidate_selector.py scripts/analysis/track_candidate_ranker.py