### PR TITLE
Log processing failures to session JSONL

### DIFF
--- a/docs/kld7-session-review.md
+++ b/docs/kld7-session-review.md
@@ -8,7 +8,7 @@ It is intentionally an **offline empirical review tool**, not a live detector.
 
 For each shot in a session log, the review script:
 
-1. parses `rolling_buffer_capture`, `kld7_buffer`, and `shot_detected` rows by `shot_number`
+1. parses `rolling_buffer_capture`, `kld7_buffer`, `shot_detected`, and `error` rows by `shot_number` or timestamp
 2. re-detects likely club-impact anchors directly from the raw K-LD7 frame buffer
 3. scores outward post-impact `pdat` paths by:
    - timing after impact
@@ -102,6 +102,38 @@ Treat a shot as weak evidence when it:
 - stays almost flat in distance
 - shows only one noisy frame
 - leaves obvious lingering returns after the burst
+
+## Session `error` entries
+
+OpenFlight writes `type: "error"` lines to the same JSONL session file when shot
+processing, K-LD7 streaming, rolling-buffer capture, or radar config updates fail.
+These are separate from Python stderr logs and are useful when reviewing a session
+offline.
+
+Typical fields:
+
+| Field | Meaning |
+|-------|---------|
+| `error` | Short description (e.g. `K-LD7 shot processing failed`) |
+| `context.component` | Subsystem (`server`, `kld7_tracker`, `rolling_buffer_monitor`, …) |
+| `context.stage` | Step within the pipeline (`kld7`, `set_radar_config`, …) |
+| `context.exception_type` | Exception class when one was caught |
+| `context.exception_message` | `str(exception)` |
+
+Quick filter while inspecting a session:
+
+```bash
+grep '"type": "error"' session_logs/session_*.jsonl
+```
+
+In Grafana/Loki (see [observability.md](observability.md)):
+
+```logql
+{app="openflight", log_type="error"}
+```
+
+A burst of `error` rows around a shot often explains missing `kld7_buffer` or
+launch-angle gaps in the review plots.
 
 ## Limits
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -115,6 +115,9 @@ count_over_time({app="openflight", log_type="shot_detected"} [24h])
 
 # Spin detection rate (shots with spin > 0)
 count_over_time({app="openflight", log_type="shot_detected"} | json | spin_rpm > 0 [24h])
+
+# Processing failures during a session
+{app="openflight", log_type="error"}
 ```
 
 ## How It Works
@@ -131,6 +134,7 @@ OpenFlight writes JSONL files to `~/openflight_sessions/session_<timestamp>_<mod
 | `connection` | Device connected | `device`, `port`, `baud`, `firmware`, `radc_available`, `base_freq` |
 | `trigger_event` | Trigger accepted/rejected | `accepted`, `latency_ms`, `trigger_type` |
 | `rolling_buffer_capture` | Raw I/Q capture | `num_samples`, `sample_rate` |
+| `error` | Processing or hardware failure | `error` (message), `context` (`component`, `stage`, `exception_type`, `exception_message`, …) |
 
 ### Alloy Pipeline
 

--- a/src/openflight/__init__.py
+++ b/src/openflight/__init__.py
@@ -2,8 +2,8 @@
 
 __version__ = "0.2.0"
 
-from .ops243 import OPS243Radar, SpeedUnit, Direction, SpeedReading
-from .launch_monitor import Shot, ClubType, estimate_carry_distance
+from .launch_monitor import ClubType, Shot, estimate_carry_distance
+from .ops243 import Direction, OPS243Radar, SpeedReading, SpeedUnit
 
 __all__ = [
     "OPS243Radar",

--- a/src/openflight/camera/__init__.py
+++ b/src/openflight/camera/__init__.py
@@ -11,10 +11,10 @@ Tracking options:
 
 from .capture import (
     CameraCapture,
-    MockCameraCapture,
     CaptureConfig,
     CapturedFrame,
     CaptureResult,
+    MockCameraCapture,
 )
 from .detector import (
     BallDetector,
@@ -22,18 +22,20 @@ from .detector import (
     DetectorConfig,
 )
 from .launch_angle import (
+    CameraCalibration,
     LaunchAngleCalculator,
     LaunchAngles,
-    CameraCalibration,
 )
+
 try:
     from .tracker import (
         BallTracker,
+        BallTrajectory,
         HybridBallTracker,
         TrackedBall,
-        BallTrajectory,
         TrackerConfig,
     )
+
     _TRACKER_AVAILABLE = True
 except ImportError:
     _TRACKER_AVAILABLE = False

--- a/src/openflight/camera/capture.py
+++ b/src/openflight/camera/capture.py
@@ -5,22 +5,21 @@ Designed for Raspberry Pi HQ Camera with IR illumination,
 capturing frames at 120fps to track ball trajectory.
 """
 
-import time
 import threading
+import time
 from dataclasses import dataclass, field
-from typing import Optional, List, Callable
-from datetime import datetime
+from typing import List, Optional
 
 try:
     from picamera2 import Picamera2
-    from picamera2.encoders import Encoder
-    from picamera2.outputs import CircularOutput
+
     PICAMERA_AVAILABLE = True
 except ImportError:
     PICAMERA_AVAILABLE = False
 
 try:
     import numpy as np
+
     NUMPY_AVAILABLE = True
 except ImportError:
     NUMPY_AVAILABLE = False
@@ -29,6 +28,7 @@ except ImportError:
 @dataclass
 class CaptureConfig:
     """Configuration for camera capture."""
+
     # Resolution - lower = faster framerate
     width: int = 640
     height: int = 480
@@ -44,12 +44,13 @@ class CaptureConfig:
 
     # Exposure settings for IR capture
     exposure_time_us: int = 2000  # 2ms - fast to reduce motion blur
-    analogue_gain: float = 4.0    # Boost for IR sensitivity
+    analogue_gain: float = 4.0  # Boost for IR sensitivity
 
 
 @dataclass
 class CapturedFrame:
     """A single captured frame with metadata."""
+
     data: "np.ndarray"
     timestamp: float
     frame_number: int
@@ -58,6 +59,7 @@ class CapturedFrame:
 @dataclass
 class CaptureResult:
     """Result of a triggered capture sequence."""
+
     frames: List[CapturedFrame] = field(default_factory=list)
     trigger_time: float = 0
     trigger_frame_index: int = 0
@@ -65,12 +67,12 @@ class CaptureResult:
     @property
     def pre_trigger_frames(self) -> List[CapturedFrame]:
         """Frames captured before the trigger."""
-        return self.frames[:self.trigger_frame_index]
+        return self.frames[: self.trigger_frame_index]
 
     @property
     def post_trigger_frames(self) -> List[CapturedFrame]:
         """Frames captured after the trigger."""
-        return self.frames[self.trigger_frame_index:]
+        return self.frames[self.trigger_frame_index :]
 
 
 class CameraCapture:
@@ -117,33 +119,28 @@ class CameraCapture:
             True if started successfully
         """
         if not PICAMERA_AVAILABLE:
-            raise RuntimeError(
-                "picamera2 not available. Install with: pip install picamera2"
-            )
+            raise RuntimeError("picamera2 not available. Install with: pip install picamera2")
 
         try:
             self._camera = Picamera2()
 
             # Configure for high-speed capture
             video_config = self._camera.create_video_configuration(
-                main={"size": (self.config.width, self.config.height),
-                      "format": "RGB888"},
+                main={"size": (self.config.width, self.config.height), "format": "RGB888"},
                 controls={
                     "FrameRate": self.config.framerate,
                     "ExposureTime": self.config.exposure_time_us,
                     "AnalogueGain": self.config.analogue_gain,
                     # Disable auto-exposure for consistent frames
                     "AeEnable": False,
-                }
+                },
             )
             self._camera.configure(video_config)
             self._camera.start()
 
             # Start capture thread
             self._running = True
-            self._capture_thread = threading.Thread(
-                target=self._capture_loop, daemon=True
-            )
+            self._capture_thread = threading.Thread(target=self._capture_loop, daemon=True)
             self._capture_thread.start()
 
             return True
@@ -173,9 +170,7 @@ class CameraCapture:
                 timestamp = time.time()
 
                 frame = CapturedFrame(
-                    data=frame_data,
-                    timestamp=timestamp,
-                    frame_number=self._frame_count
+                    data=frame_data, timestamp=timestamp, frame_number=self._frame_count
                 )
                 self._frame_count += 1
 
@@ -220,9 +215,7 @@ class CameraCapture:
                 break
 
         return CaptureResult(
-            frames=frames,
-            trigger_time=trigger_time,
-            trigger_frame_index=trigger_frame_index
+            frames=frames, trigger_time=trigger_time, trigger_frame_index=trigger_frame_index
         )
 
     def capture_single(self) -> Optional[CapturedFrame]:
@@ -236,11 +229,7 @@ class CameraCapture:
             return None
 
         frame_data = self._camera.capture_array()
-        return CapturedFrame(
-            data=frame_data,
-            timestamp=time.time(),
-            frame_number=self._frame_count
-        )
+        return CapturedFrame(data=frame_data, timestamp=time.time(), frame_number=self._frame_count)
 
     @property
     def is_running(self) -> bool:
@@ -283,15 +272,11 @@ class MockCameraCapture:
 
         frames = []
         trigger_time = time.time()
-        total_frames = (self.config.pre_trigger_frames +
-                        self.config.post_trigger_frames)
+        total_frames = self.config.pre_trigger_frames + self.config.post_trigger_frames
 
         for i in range(total_frames):
             # Create synthetic frame with a "ball" that moves
-            frame_data = np.zeros(
-                (self.config.height, self.config.width, 3),
-                dtype=np.uint8
-            )
+            frame_data = np.zeros((self.config.height, self.config.width, 3), dtype=np.uint8)
 
             # Simulate ball moving up and away (shrinking)
             if i >= self.config.pre_trigger_frames:
@@ -303,23 +288,23 @@ class MockCameraCapture:
 
                 if 0 <= cy < self.config.height and radius > 0:
                     # Draw white circle (simulating IR-lit ball)
-                    y, x = np.ogrid[:self.config.height, :self.config.width]
-                    mask = (x - cx)**2 + (y - cy)**2 <= radius**2
+                    y, x = np.ogrid[: self.config.height, : self.config.width]
+                    mask = (x - cx) ** 2 + (y - cy) ** 2 <= radius**2
                     frame_data[mask] = [255, 255, 255]
 
             timestamp = trigger_time + (i - self.config.pre_trigger_frames) / self.config.framerate
-            frames.append(CapturedFrame(
-                data=frame_data,
-                timestamp=timestamp,
-                frame_number=self._frame_count + i
-            ))
+            frames.append(
+                CapturedFrame(
+                    data=frame_data, timestamp=timestamp, frame_number=self._frame_count + i
+                )
+            )
 
         self._frame_count += total_frames
 
         return CaptureResult(
             frames=frames,
             trigger_time=trigger_time,
-            trigger_frame_index=self.config.pre_trigger_frames
+            trigger_frame_index=self.config.pre_trigger_frames,
         )
 
     def capture_single(self) -> Optional[CapturedFrame]:
@@ -327,15 +312,8 @@ class MockCameraCapture:
         if not NUMPY_AVAILABLE:
             return None
 
-        frame_data = np.zeros(
-            (self.config.height, self.config.width, 3),
-            dtype=np.uint8
-        )
-        return CapturedFrame(
-            data=frame_data,
-            timestamp=time.time(),
-            frame_number=self._frame_count
-        )
+        frame_data = np.zeros((self.config.height, self.config.width, 3), dtype=np.uint8)
+        return CapturedFrame(data=frame_data, timestamp=time.time(), frame_number=self._frame_count)
 
     @property
     def is_running(self) -> bool:

--- a/src/openflight/camera/detector.py
+++ b/src/openflight/camera/detector.py
@@ -6,11 +6,12 @@ viewed from behind the tee.
 """
 
 from dataclasses import dataclass
-from typing import Optional, List, Tuple
+from typing import List, Optional, Tuple
 
 try:
     import cv2
     import numpy as np
+
     CV2_AVAILABLE = True
 except ImportError:
     CV2_AVAILABLE = False
@@ -21,6 +22,7 @@ from .capture import CapturedFrame
 @dataclass
 class DetectedBall:
     """A detected golf ball in a frame."""
+
     # Center position in pixels
     x: float
     y: float
@@ -43,27 +45,28 @@ class DetectedBall:
     @property
     def area(self) -> float:
         """Approximate ball area in pixels."""
-        return 3.14159 * self.radius ** 2
+        return 3.14159 * self.radius**2
 
 
 @dataclass
 class DetectorConfig:
     """Configuration for ball detection."""
+
     # Brightness threshold for IR ball (0-255)
     brightness_threshold: int = 200
 
     # Expected ball radius range in pixels (at various distances)
-    min_radius: int = 5      # Ball far away
-    max_radius: int = 50     # Ball close to camera
+    min_radius: int = 5  # Ball far away
+    max_radius: int = 50  # Ball close to camera
 
     # Circle detection parameters
-    hough_dp: float = 1.2           # Inverse ratio of accumulator resolution
-    hough_min_dist: int = 50        # Min distance between detected circles
-    hough_param1: int = 50          # Canny edge detection threshold
-    hough_param2: int = 20          # Circle detection threshold (lower = more circles)
+    hough_dp: float = 1.2  # Inverse ratio of accumulator resolution
+    hough_min_dist: int = 50  # Min distance between detected circles
+    hough_param1: int = 50  # Canny edge detection threshold
+    hough_param2: int = 20  # Circle detection threshold (lower = more circles)
 
     # Filtering
-    min_confidence: float = 0.5     # Minimum confidence to accept detection
+    min_confidence: float = 0.5  # Minimum confidence to accept detection
 
 
 class BallDetector:
@@ -89,9 +92,7 @@ class BallDetector:
             config: Detection configuration, uses defaults if None
         """
         if not CV2_AVAILABLE:
-            raise RuntimeError(
-                "OpenCV not available. Install with: pip install opencv-python"
-            )
+            raise RuntimeError("OpenCV not available. Install with: pip install opencv-python")
         self.config = config or DetectorConfig()
 
     def detect(self, frame: CapturedFrame) -> Optional[DetectedBall]:
@@ -111,12 +112,7 @@ class BallDetector:
             gray = frame.data
 
         # Apply threshold to isolate bright ball (IR illuminated)
-        _, thresh = cv2.threshold(
-            gray,
-            self.config.brightness_threshold,
-            255,
-            cv2.THRESH_BINARY
-        )
+        _, thresh = cv2.threshold(gray, self.config.brightness_threshold, 255, cv2.THRESH_BINARY)
 
         # Apply slight blur to reduce noise
         blurred = cv2.GaussianBlur(thresh, (5, 5), 0)
@@ -130,7 +126,7 @@ class BallDetector:
             param1=self.config.hough_param1,
             param2=self.config.hough_param2,
             minRadius=self.config.min_radius,
-            maxRadius=self.config.max_radius
+            maxRadius=self.config.max_radius,
         )
 
         if circles is None:
@@ -158,7 +154,7 @@ class BallDetector:
             radius=float(r),
             confidence=best_confidence,
             frame_number=frame.frame_number,
-            timestamp=frame.timestamp
+            timestamp=frame.timestamp,
         )
 
     def _calculate_confidence(self, gray: "np.ndarray", x: int, y: int, r: int) -> float:
@@ -214,9 +210,7 @@ class BallDetector:
         return [self.detect(frame) for frame in frames]
 
     def detect_with_tracking(
-        self,
-        frames: List[CapturedFrame],
-        expected_direction: str = "up_and_away"
+        self, frames: List[CapturedFrame], expected_direction: str = "up_and_away"
     ) -> List[Optional[DetectedBall]]:
         """
         Detect ball with trajectory-based tracking.
@@ -244,8 +238,7 @@ class BallDetector:
                     # Detection doesn't match expected trajectory
                     # Try to find ball in predicted region
                     detection = self._detect_in_region(
-                        frame,
-                        self._predict_position(prev_detection, expected_direction)
+                        frame, self._predict_position(prev_detection, expected_direction)
                     )
 
             detections.append(detection)
@@ -254,12 +247,7 @@ class BallDetector:
 
         return detections
 
-    def _validate_trajectory(
-        self,
-        prev: DetectedBall,
-        curr: DetectedBall,
-        direction: str
-    ) -> bool:
+    def _validate_trajectory(self, prev: DetectedBall, curr: DetectedBall, direction: str) -> bool:
         """Validate that current detection follows expected trajectory."""
         if direction == "up_and_away":
             # Ball should move up (y decreases in image coords)
@@ -271,11 +259,7 @@ class BallDetector:
 
         return True
 
-    def _predict_position(
-        self,
-        prev: DetectedBall,
-        direction: str
-    ) -> Tuple[int, int, int, int]:
+    def _predict_position(self, prev: DetectedBall, direction: str) -> Tuple[int, int, int, int]:
         """
         Predict search region for next frame.
 
@@ -292,27 +276,23 @@ class BallDetector:
                 max(0, pred_x - search_size // 2),
                 max(0, pred_y - search_size // 2),
                 search_size,
-                search_size
+                search_size,
             )
 
         return (0, 0, 640, 480)
 
     def _detect_in_region(
-        self,
-        frame: CapturedFrame,
-        region: Tuple[int, int, int, int]
+        self, frame: CapturedFrame, region: Tuple[int, int, int, int]
     ) -> Optional[DetectedBall]:
         """Detect ball within a specific region of the frame."""
         x, y, w, h = region
 
         # Extract region
-        roi = frame.data[y:y+h, x:x+w]
+        roi = frame.data[y : y + h, x : x + w]
 
         # Create temporary frame for ROI
         roi_frame = CapturedFrame(
-            data=roi,
-            timestamp=frame.timestamp,
-            frame_number=frame.frame_number
+            data=roi, timestamp=frame.timestamp, frame_number=frame.frame_number
         )
 
         detection = self.detect(roi_frame)

--- a/src/openflight/camera/launch_angle.py
+++ b/src/openflight/camera/launch_angle.py
@@ -5,12 +5,13 @@ Calculates vertical and horizontal launch angles from detected
 ball positions across multiple frames.
 """
 
-from dataclasses import dataclass
-from typing import Optional, List, Tuple
 import math
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
 
 try:
     import numpy as np
+
     NUMPY_AVAILABLE = True
 except ImportError:
     NUMPY_AVAILABLE = False
@@ -19,7 +20,8 @@ from .detector import DetectedBall
 
 # Optional import for TrackedBall/BallTrajectory integration
 try:
-    from .tracker import TrackedBall, BallTrajectory
+    from .tracker import BallTrajectory
+
     TRACKER_AVAILABLE = True
 except ImportError:
     TRACKER_AVAILABLE = False
@@ -28,12 +30,13 @@ except ImportError:
 @dataclass
 class CameraCalibration:
     """Camera calibration parameters for angle calculation."""
+
     # Sensor dimensions
-    sensor_width_mm: float = 6.287    # Pi HQ Camera IMX477 sensor
+    sensor_width_mm: float = 6.287  # Pi HQ Camera IMX477 sensor
     sensor_height_mm: float = 4.712
 
     # Lens focal length in mm
-    focal_length_mm: float = 6.0      # Default wide-angle lens
+    focal_length_mm: float = 6.0  # Default wide-angle lens
 
     # Image resolution
     image_width: int = 640
@@ -42,10 +45,10 @@ class CameraCalibration:
     # Camera position relative to ball (mm)
     # Behind and slightly above tee
     distance_to_ball_mm: float = 2000  # 2 meters behind
-    camera_height_mm: float = 300      # 30cm above ground (tee height ~50mm)
+    camera_height_mm: float = 300  # 30cm above ground (tee height ~50mm)
 
     # Golf ball diameter for size reference
-    ball_diameter_mm: float = 42.67    # Regulation golf ball
+    ball_diameter_mm: float = 42.67  # Regulation golf ball
 
     @property
     def pixels_per_mm_at_ball(self) -> float:
@@ -68,6 +71,7 @@ class CameraCalibration:
 @dataclass
 class LaunchAngles:
     """Calculated launch angles from trajectory."""
+
     # Vertical angle (positive = up)
     vertical_deg: float
 
@@ -147,7 +151,7 @@ class LaunchAngleCalculator:
             return None
 
         # Use only early frames (ball is clearest right after launch)
-        valid = valid[:self.max_frames]
+        valid = valid[: self.max_frames]
 
         # Extract positions
         indices = np.array([v[0] for v in valid])
@@ -180,14 +184,11 @@ class LaunchAngleCalculator:
             initial_x=x0,
             initial_y=y0,
             velocity_x=vx,
-            velocity_y=vy
+            velocity_y=vy,
         )
 
     def _fit_line(
-        self,
-        x: "np.ndarray",
-        y: "np.ndarray",
-        weights: "np.ndarray"
+        self, x: "np.ndarray", y: "np.ndarray", weights: "np.ndarray"
     ) -> Tuple[float, float]:
         """
         Fit weighted linear regression.
@@ -276,7 +277,7 @@ class LaunchAngleCalculator:
         vx: float,
         vy: float,
         x0: float,
-        y0: float
+        y0: float,
     ) -> float:
         """
         Calculate confidence in trajectory fit.
@@ -304,7 +305,7 @@ class LaunchAngleCalculator:
         self,
         detections: List[Optional[DetectedBall]],
         ball_speed_mph: float,
-        framerate: float = 120.0
+        framerate: float = 120.0,
     ) -> Optional[LaunchAngles]:
         """
         Calculate launch angles using radar-measured ball speed.
@@ -330,7 +331,7 @@ class LaunchAngleCalculator:
         if len(valid) < self.min_detections:
             return None
 
-        valid = valid[:self.max_frames]
+        valid = valid[: self.max_frames]
 
         indices = np.array([v[0] for v in valid])
         x_positions = np.array([v[1].x for v in valid])
@@ -361,7 +362,7 @@ class LaunchAngleCalculator:
             initial_x=x0,
             initial_y=y0,
             velocity_x=vx,
-            velocity_y=vy
+            velocity_y=vy,
         )
 
     def estimate_ball_distance(self, ball: DetectedBall) -> float:
@@ -388,9 +389,7 @@ class LaunchAngleCalculator:
 
         # Distance = (actual_size * focal_length * ppm_sensor) / apparent_size_px
         distance = (
-            self.calibration.ball_diameter_mm *
-            self.calibration.focal_length_mm *
-            ppm_sensor
+            self.calibration.ball_diameter_mm * self.calibration.focal_length_mm * ppm_sensor
         ) / ball_diameter_px
 
         return distance
@@ -399,7 +398,7 @@ class LaunchAngleCalculator:
         self,
         trajectory: "BallTrajectory",
         ball_speed_mph: Optional[float] = None,
-        framerate: float = 120.0
+        framerate: float = 120.0,
     ) -> Optional[LaunchAngles]:
         """
         Calculate launch angles from a tracked ball trajectory.
@@ -422,7 +421,7 @@ class LaunchAngleCalculator:
             return None
 
         # Convert TrackedBall positions to format expected by calculate methods
-        positions = trajectory.positions[:self.max_frames]
+        positions = trajectory.positions[: self.max_frames]
 
         indices = np.array([p.frame_number for p in positions])
         x_positions = np.array([p.x for p in positions])
@@ -465,5 +464,5 @@ class LaunchAngleCalculator:
             initial_x=x0,
             initial_y=y0,
             velocity_x=vx,
-            velocity_y=vy
+            velocity_y=vy,
         )

--- a/src/openflight/camera/tracker.py
+++ b/src/openflight/camera/tracker.py
@@ -11,8 +11,8 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 import numpy as np
-from trackers import ByteTrackTracker
 import supervision as sv
+from trackers import ByteTrackTracker
 
 from .capture import CapturedFrame
 from .detector import BallDetector, DetectedBall, DetectorConfig
@@ -23,6 +23,7 @@ logger = logging.getLogger("openflight.camera.tracker")
 @dataclass
 class TrackedBall:
     """A tracked golf ball with persistent ID across frames."""
+
     track_id: int
     x: float
     y: float
@@ -42,13 +43,14 @@ class TrackedBall:
             self.x - self.radius,
             self.y - self.radius,
             self.x + self.radius,
-            self.y + self.radius
+            self.y + self.radius,
         )
 
 
 @dataclass
 class BallTrajectory:
     """Complete trajectory of a tracked ball."""
+
     track_id: int
     positions: List[TrackedBall] = field(default_factory=list)
 
@@ -78,18 +80,22 @@ class BallTrajectory:
 
         # Ball should generally move upward (y decreases in image coords)
         y_positions = [p.y for p in self.positions]
-        y_decreasing = sum(1 for i in range(1, len(y_positions))
-                          if y_positions[i] < y_positions[i-1])
+        y_decreasing = sum(
+            1 for i in range(1, len(y_positions)) if y_positions[i] < y_positions[i - 1]
+        )
 
         # Ball should shrink (moving away from camera)
         radii = [p.radius for p in self.positions]
-        radius_decreasing = sum(1 for i in range(1, len(radii))
-                                if radii[i] <= radii[i-1] * 1.1)  # Allow some tolerance
+        radius_decreasing = sum(
+            1 for i in range(1, len(radii)) if radii[i] <= radii[i - 1] * 1.1
+        )  # Allow some tolerance
 
         # At least 60% of frames should show expected motion
         threshold = 0.6
-        return (y_decreasing / (len(y_positions) - 1) >= threshold and
-                radius_decreasing / (len(radii) - 1) >= threshold)
+        return (
+            y_decreasing / (len(y_positions) - 1) >= threshold
+            and radius_decreasing / (len(radii) - 1) >= threshold
+        )
 
     def get_velocity(self) -> Tuple[float, float]:
         """Calculate average velocity in pixels per frame."""
@@ -109,10 +115,11 @@ class BallTrajectory:
 @dataclass
 class TrackerConfig:
     """Configuration for ball tracking."""
+
     # ByteTrack parameters (v2.1.0+ API)
-    lost_track_buffer: int = 30              # Frames to keep lost tracks (at 120fps = 250ms)
+    lost_track_buffer: int = 30  # Frames to keep lost tracks (at 120fps = 250ms)
     track_activation_threshold: float = 0.7  # Confidence threshold for track activation
-    minimum_iou_threshold: float = 0.1       # Minimum IoU for matching
+    minimum_iou_threshold: float = 0.1  # Minimum IoU for matching
 
     # Trajectory filtering
     min_trajectory_frames: int = 3  # Minimum frames for valid trajectory
@@ -141,7 +148,7 @@ class BallTracker:
     def __init__(
         self,
         detector_config: Optional[DetectorConfig] = None,
-        tracker_config: Optional[TrackerConfig] = None
+        tracker_config: Optional[TrackerConfig] = None,
     ):
         self.detector = BallDetector(detector_config)
         self.config = tracker_config or TrackerConfig()
@@ -184,11 +191,7 @@ class BallTracker:
 
         return self._update_bytetrack(detection, frame)
 
-    def _update_bytetrack(
-        self,
-        detection: DetectedBall,
-        frame: CapturedFrame
-    ) -> List[TrackedBall]:
+    def _update_bytetrack(self, detection: DetectedBall, frame: CapturedFrame) -> List[TrackedBall]:
         """Update tracking using ByteTrack."""
         # Convert detection to supervision format
         # ByteTrack expects bounding boxes as [x1, y1, x2, y2]
@@ -221,7 +224,9 @@ class BallTracker:
                 x=cx,
                 y=cy,
                 radius=radius,
-                confidence=tracked.confidence[i] if tracked.confidence is not None else detection.confidence,
+                confidence=tracked.confidence[i]
+                if tracked.confidence is not None
+                else detection.confidence,
                 frame_number=frame.frame_number,
                 timestamp=frame.timestamp,
             )
@@ -271,8 +276,7 @@ class BallTracker:
             return None
 
         # Filter to valid golf trajectories
-        valid = [t for t in self._trajectories.values()
-                 if t.is_valid_golf_trajectory]
+        valid = [t for t in self._trajectories.values() if t.is_valid_golf_trajectory]
 
         if not valid:
             # Fall back to longest trajectory if none are "valid"
@@ -318,6 +322,7 @@ class YOLOBallDetector:
     def __init__(self, model_path: str = "yolov8n.pt", device: str = "cpu"):
         try:
             from ultralytics import YOLO
+
             self._model = YOLO(model_path)
             self._model.to(device)
             self._available = True

--- a/src/openflight/kld7/serial_io.py
+++ b/src/openflight/kld7/serial_io.py
@@ -44,6 +44,21 @@ _PACKET_CODES = (
 _MAX_STALE_RESPONSE_PACKETS = 3
 
 
+def _serial_port_errors() -> tuple[type[BaseException], ...]:
+    """Exception types raised by pyserial and the OS for port I/O."""
+    errors: list[type[BaseException]] = [OSError]
+    try:
+        import serial as pyserial  # type: ignore[import-not-found]
+
+        errors.append(pyserial.SerialException)
+    except ImportError:
+        pass
+    return tuple(errors)
+
+
+_SERIAL_PORT_ERRORS = _serial_port_errors()
+
+
 def install_robust_read_packet(radar: Any) -> None:
     """Replace ``radar._read_packet`` with a short-read-tolerant version.
 
@@ -70,7 +85,7 @@ def install_robust_read_packet(radar: Any) -> None:
             while remaining > 0:
                 try:
                     chunk = port.read(remaining)
-                except Exception as e:
+                except _SERIAL_PORT_ERRORS as e:
                     raise KLD7Exception(f"Serial read failed: {e}") from e
                 if not chunk:
                     if not buf:
@@ -229,7 +244,7 @@ def _send_gbye_at_3mbaud(port: str, log: Optional[Any] = None) -> None:
                 time.sleep(0.1)
         if log is not None:
             log("[KLD7] Sent GBYE at 3Mbaud to reset prior session")
-    except Exception as e:  # pylint: disable=broad-except
+    except _SERIAL_PORT_ERRORS as e:
         if log is not None:
             log(f"[KLD7] GBYE flush failed: {e}")
 
@@ -279,14 +294,22 @@ def connect_with_recovery(
                     f"(attempt {attempt}/{max_attempts})"
                 )
             return radar
+        except _SERIAL_PORT_ERRORS as e:
+            last_err = e
+            failure_kind = "serial"
         except Exception as e:  # pylint: disable=broad-except
             last_err = e
-            if log is not None:
-                log(f"[KLD7] Connect attempt {attempt}/{max_attempts} failed: {e}")
-            if attempt >= max_attempts:
-                break
-            _send_gbye_at_3mbaud(port, log=log)
-            time.sleep(0.3)
+            failure_kind = "library"
+
+        if log is not None:
+            log(
+                f"[KLD7] Connect attempt {attempt}/{max_attempts} "
+                f"failed ({failure_kind}): {last_err}"
+            )
+        if attempt >= max_attempts:
+            break
+        _send_gbye_at_3mbaud(port, log=log)
+        time.sleep(0.3)
 
     # All attempts failed.
     if last_err is not None:

--- a/src/openflight/kld7/tracker.py
+++ b/src/openflight/kld7/tracker.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Optional
 
 from ..serial_latency import log_usb_serial_latency_timer
+from ..session_logger import log_session_error
 from .radc import RADC_PAYLOAD_BYTES
 from .types import KLD7Angle, KLD7Frame
 
@@ -40,11 +41,7 @@ _RADC_SELECTION_DIAGNOSTIC_KEYS = (
 
 def _radc_selection_diagnostics(best: dict, *, relaxed_retry: bool) -> dict:
     """Return compact, JSON-safe RADC selection details for session replay."""
-    diagnostics = {
-        key: best.get(key)
-        for key in _RADC_SELECTION_DIAGNOSTIC_KEYS
-        if key in best
-    }
+    diagnostics = {key: best.get(key) for key in _RADC_SELECTION_DIAGNOSTIC_KEYS if key in best}
     diagnostics["relaxed_retry"] = relaxed_retry
     return diagnostics
 
@@ -489,6 +486,15 @@ class KLD7Tracker:
                     e,
                     exc_info=True,
                 )
+                log_session_error(
+                    "K-LD7 stream crashed",
+                    component="kld7_tracker",
+                    context={
+                        "orientation": self.orientation,
+                        "frame_count": frame_count,
+                    },
+                    exc=e,
+                )
                 break
 
         if errors >= max_errors:
@@ -497,6 +503,15 @@ class KLD7Tracker:
                 max_errors,
                 reconnects,
                 self.orientation,
+            )
+            log_session_error(
+                "K-LD7 stream gave up after repeated errors",
+                component="kld7_tracker",
+                context={
+                    "orientation": self.orientation,
+                    "max_errors": max_errors,
+                    "reconnects": reconnects,
+                },
             )
 
     def _add_frame(self, frame: KLD7Frame):
@@ -744,6 +759,15 @@ class KLD7Tracker:
             )
         except Exception as e:
             logger.warning("[KLD7] RADC extraction failed: %s", e, exc_info=True)
+            log_session_error(
+                "K-LD7 ball angle RADC extraction failed",
+                component="kld7_tracker",
+                context={
+                    "orientation": self.orientation,
+                    "ball_speed_mph": ball_speed_mph,
+                },
+                exc=e,
+            )
 
         return None
 
@@ -774,6 +798,15 @@ class KLD7Tracker:
                 return result
         except Exception as e:
             logger.debug("[KLD7] Club angle extraction failed: %s", e)
+            log_session_error(
+                "K-LD7 club angle RADC extraction failed",
+                component="kld7_tracker",
+                context={
+                    "orientation": self.orientation,
+                    "club_speed_mph": club_speed_mph,
+                },
+                exc=e,
+            )
 
         return None
 

--- a/src/openflight/kld7/tracker.py
+++ b/src/openflight/kld7/tracker.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Optional
 
 from ..serial_latency import log_usb_serial_latency_timer
-from ..session_logger import log_session_error
 from .radc import RADC_PAYLOAD_BYTES
 from .types import KLD7Angle, KLD7Frame
 
@@ -44,6 +43,19 @@ def _radc_selection_diagnostics(best: dict, *, relaxed_retry: bool) -> dict:
     diagnostics = {key: best.get(key) for key in _RADC_SELECTION_DIAGNOSTIC_KEYS if key in best}
     diagnostics["relaxed_retry"] = relaxed_retry
     return diagnostics
+
+
+def _log_session_error(
+    error: str,
+    *,
+    context: Optional[dict] = None,
+    component: Optional[str] = None,
+    exc: Optional[BaseException] = None,
+) -> None:
+    """Log to session JSONL without importing session_logger at module load."""
+    from ..session_logger import log_session_error
+
+    log_session_error(error, context=context, component=component, exc=exc)
 
 
 def _is_recoverable_stream_error(error: BaseException) -> bool:
@@ -486,7 +498,7 @@ class KLD7Tracker:
                     e,
                     exc_info=True,
                 )
-                log_session_error(
+                _log_session_error(
                     "K-LD7 stream crashed",
                     component="kld7_tracker",
                     context={
@@ -504,7 +516,7 @@ class KLD7Tracker:
                 reconnects,
                 self.orientation,
             )
-            log_session_error(
+            _log_session_error(
                 "K-LD7 stream gave up after repeated errors",
                 component="kld7_tracker",
                 context={
@@ -759,7 +771,7 @@ class KLD7Tracker:
             )
         except Exception as e:
             logger.warning("[KLD7] RADC extraction failed: %s", e, exc_info=True)
-            log_session_error(
+            _log_session_error(
                 "K-LD7 ball angle RADC extraction failed",
                 component="kld7_tracker",
                 context={
@@ -798,7 +810,7 @@ class KLD7Tracker:
                 return result
         except Exception as e:
             logger.debug("[KLD7] Club angle extraction failed: %s", e)
-            log_session_error(
+            _log_session_error(
                 "K-LD7 club angle RADC extraction failed",
                 component="kld7_tracker",
                 context={

--- a/src/openflight/rolling_buffer/monitor.py
+++ b/src/openflight/rolling_buffer/monitor.py
@@ -14,7 +14,7 @@ from typing import Callable, List, Optional
 
 from ..launch_monitor import ClubType, Shot, estimate_carry_distance
 from ..ops243 import OPS243Radar, SpeedReading
-from ..session_logger import get_session_logger
+from ..session_logger import get_session_logger, log_session_error
 from .processor import RollingBufferProcessor
 from .trigger import create_trigger
 from .types import ProcessedCapture
@@ -727,6 +727,12 @@ class RollingBufferMonitor:
 
             except Exception as e:
                 logger.error("[MONITOR] Capture loop error: %s", e, exc_info=True)
+                log_session_error(
+                    "Rolling buffer capture loop error",
+                    component="rolling_buffer_monitor",
+                    context={"trigger_type": self.trigger_type},
+                    exc=e,
+                )
                 time.sleep(1.0)
 
     def _create_shot(self, processed: ProcessedCapture) -> Optional[Shot]:

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -23,7 +23,7 @@ from flask_socketio import SocketIO
 from .launch_monitor import ClubType, Shot
 from .ops243 import Direction, SpeedReading, set_show_raw_readings
 from .rolling_buffer.monitor import estimate_carry_with_spin, get_optimal_spin_for_ball_speed
-from .session_logger import get_session_logger, init_session_logger
+from .session_logger import get_session_logger, init_session_logger, log_session_error
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -992,6 +992,12 @@ def init_kld7(
             return False
     except Exception as e:
         logger.warning("[SERVER] K-LD7 %s initialization failed: %s", orientation, e, exc_info=True)
+        log_session_error(
+            "K-LD7 initialization failed",
+            component="kld7",
+            context={"orientation": orientation},
+            exc=e,
+        )
         return False
 
 
@@ -1398,6 +1404,11 @@ def handle_set_radar_config(data):
     global radar_config  # pylint: disable=global-statement
 
     if not monitor or mock_mode:
+        log_session_error(
+            "Radar config update rejected: radar not connected",
+            component="server",
+            context={"stage": "set_radar_config", "mock_mode": mock_mode},
+        )
         socketio.emit("radar_config_error", {"error": "Radar not connected"})
         return
 
@@ -1449,7 +1460,13 @@ def handle_set_radar_config(data):
         socketio.emit("radar_config", radar_config)
 
     except Exception as e:
-        print(f"Error setting radar config: {e}")
+        logger.warning("[SERVER] Error setting radar config: %s", e, exc_info=True)
+        log_session_error(
+            "Radar config update failed",
+            component="server",
+            context={"stage": "set_radar_config", "requested": data},
+            exc=e,
+        )
         socketio.emit("radar_config_error", {"error": str(e)})
 
 
@@ -1687,6 +1704,16 @@ def on_shot_detected(shot: Shot):
                 logger.info("[SERVER] K-LD7 processing: %.1fms", kld7_ms)
     except Exception as e:
         logger.warning("[SERVER] K-LD7 processing error: %s", e, exc_info=True)
+        log_session_error(
+            "K-LD7 shot processing failed",
+            component="server",
+            context={
+                "stage": "kld7",
+                "ball_speed_mph": shot.ball_speed_mph,
+                "club": shot.club.value,
+            },
+            exc=e,
+        )
 
     # Try to get launch angle from camera BEFORE emitting shot
     # Skip camera for mock shots — they already have simulated launch angle
@@ -1731,6 +1758,12 @@ def on_shot_detected(shot: Shot):
             ball_detection_confidence = 0.0
     except Exception as e:
         logger.warning("[SERVER] Camera processing error: %s", e, exc_info=True)
+        log_session_error(
+            "Camera shot processing failed",
+            component="server",
+            context={"stage": "camera", "ball_speed_mph": shot.ball_speed_mph},
+            exc=e,
+        )
         camera_data = None
 
     # Always emit user-facing launch angles. Radar/camera measurements win;
@@ -1820,6 +1853,12 @@ def on_shot_detected(shot: Shot):
             )
     except Exception as e:
         logger.warning("[SERVER] Failed to log shot: %s", e, exc_info=True)
+        log_session_error(
+            "Session shot logging failed",
+            component="server",
+            context={"stage": "session_log_shot", "ball_speed_mph": shot.ball_speed_mph},
+            exc=e,
+        )
 
     # Emit shot with launch angle data included
     try:
@@ -1839,6 +1878,12 @@ def on_shot_detected(shot: Shot):
         )
     except Exception as e:
         logger.error("[SERVER] Failed to emit shot: %s", e, exc_info=True)
+        log_session_error(
+            "WebSocket shot emit failed",
+            component="server",
+            context={"stage": "emit_shot", "ball_speed_mph": shot.ball_speed_mph},
+            exc=e,
+        )
         return
 
     # Debug logging (optional)

--- a/src/openflight/session_logger.py
+++ b/src/openflight/session_logger.py
@@ -46,7 +46,7 @@ class SessionLogger:
     - shot_detected: A shot was recorded
     - shot_camera: Camera tracking data for a shot
     - config_change: Radar configuration changed
-    - error: Any errors during processing
+    - error: Processing failures (component, context, optional exception metadata)
     """
 
     DEFAULT_LOG_DIR = Path.home() / "openflight_sessions"
@@ -921,6 +921,28 @@ _session_logger: Optional[SessionLogger] = None
 def get_session_logger() -> Optional[SessionLogger]:
     """Get the global session logger instance."""
     return _session_logger
+
+
+def log_session_error(
+    error: str,
+    *,
+    context: Optional[Dict[str, Any]] = None,
+    component: Optional[str] = None,
+    exc: Optional[BaseException] = None,
+) -> None:
+    """Write an error entry to the active session JSONL log, if any."""
+    session = get_session_logger()
+    if session is None:
+        return
+
+    ctx: Dict[str, Any] = dict(context or {})
+    if component:
+        ctx["component"] = component
+    if exc is not None:
+        ctx["exception_type"] = type(exc).__name__
+        ctx["exception_message"] = str(exc)
+
+    session.log_error(error, context=ctx)
 
 
 def init_session_logger(

--- a/tests/test_kld7.py
+++ b/tests/test_kld7.py
@@ -24,6 +24,8 @@ class TestKLD7SerialIO:
     """Tests for low-level K-LD7 serial read recovery helpers."""
 
     def test_robust_read_packet_wraps_serial_read_failures(self, monkeypatch):
+        import serial
+
         fake_kld7 = ModuleType("kld7")
 
         class FakeKLD7Exception(Exception):
@@ -36,10 +38,31 @@ class TestKLD7SerialIO:
 
         class FailingPort:
             def read(self, _size):
-                raise RuntimeError(
+                raise serial.SerialException(
                     "device reports readiness to read but returned no data "
                     "(device disconnected or multiple access on port?)"
                 )
+
+        radar = SimpleNamespace(_port=FailingPort())
+        install_robust_read_packet(radar)
+
+        with pytest.raises(FakeKLD7Exception, match="Serial read failed"):
+            radar._read_packet()
+
+    def test_robust_read_packet_wraps_os_read_failures(self, monkeypatch):
+        fake_kld7 = ModuleType("kld7")
+
+        class FakeKLD7Exception(Exception):
+            pass
+
+        fake_kld7.KLD7Exception = FakeKLD7Exception
+        monkeypatch.setitem(sys.modules, "kld7", fake_kld7)
+
+        from openflight.kld7.serial_io import install_robust_read_packet
+
+        class FailingPort:
+            def read(self, _size):
+                raise OSError(5, "Input/output error")
 
         radar = SimpleNamespace(_port=FailingPort())
         install_robust_read_packet(radar)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -70,6 +70,106 @@ class TestShutdownCleanup:
         assert calls == ["camera", "monitor"]
 
 
+class TestSessionErrorLogging:
+    """Session JSONL should record shot-pipeline failures, not only Python logs."""
+
+    def test_on_shot_detected_logs_kld7_processing_error(self, monkeypatch):
+        logged_errors = []
+
+        class FailingTracker:
+            orientation = "vertical"
+
+            def snapshot_buffer(self, include_radc_payload=False):
+                raise RuntimeError("snapshot failed")
+
+            def get_angle_for_shot(self, **kwargs):
+                return None
+
+            def get_club_angle(self, **kwargs):
+                return None
+
+            def reset(self):
+                return None
+
+        monkeypatch.setattr(server_module, "kld7_vertical", FailingTracker())
+        monkeypatch.setattr(server_module, "kld7_horizontal", None)
+        monkeypatch.setattr(server_module, "camera_tracker", None)
+        monkeypatch.setattr(server_module, "camera_enabled", False)
+        monkeypatch.setattr(server_module, "monitor", None)
+        monkeypatch.setattr(server_module, "debug_mode", False)
+        monkeypatch.setattr(server_module, "get_session_logger", lambda: None)
+        monkeypatch.setattr(
+            server_module,
+            "log_session_error",
+            lambda error, **kwargs: logged_errors.append((error, kwargs)),
+        )
+        monkeypatch.setattr(server_module.socketio, "emit", lambda *args, **kwargs: None)
+
+        shot = Shot(
+            ball_speed_mph=150.0,
+            club_speed_mph=100.0,
+            timestamp=datetime.now(),
+            club=ClubType.DRIVER,
+        )
+        on_shot_detected(shot)
+
+        assert logged_errors
+        assert logged_errors[0][0] == "K-LD7 shot processing failed"
+        assert logged_errors[0][1]["component"] == "server"
+        assert logged_errors[0][1]["context"]["stage"] == "kld7"
+        assert logged_errors[0][1]["exc"].__class__.__name__ == "RuntimeError"
+
+    def test_set_radar_config_logs_failure_to_session(self, monkeypatch):
+        logged_errors = []
+        emitted = []
+
+        class FailingRadar:
+            def set_min_speed_filter(self, _value):
+                raise ValueError("invalid speed")
+
+        class StubMonitor:
+            radar = FailingRadar()
+
+        monkeypatch.setattr(server_module, "monitor", StubMonitor())
+        monkeypatch.setattr(server_module, "mock_mode", False)
+        monkeypatch.setattr(server_module, "radar_config", {"min_speed": 10})
+        monkeypatch.setattr(
+            server_module,
+            "log_session_error",
+            lambda error, **kwargs: logged_errors.append((error, kwargs)),
+        )
+        monkeypatch.setattr(
+            server_module.socketio,
+            "emit",
+            lambda event, payload: emitted.append((event, payload)),
+        )
+        monkeypatch.setattr(server_module, "get_session_logger", lambda: None)
+
+        server_module.handle_set_radar_config({"min_speed": 99})
+
+        assert logged_errors
+        assert logged_errors[0][0] == "Radar config update failed"
+        assert logged_errors[0][1]["context"]["stage"] == "set_radar_config"
+        assert emitted[-1][0] == "radar_config_error"
+
+    def test_set_radar_config_logs_not_connected_to_session(self, monkeypatch):
+        logged_errors = []
+
+        monkeypatch.setattr(server_module, "monitor", None)
+        monkeypatch.setattr(server_module, "mock_mode", True)
+        monkeypatch.setattr(
+            server_module,
+            "log_session_error",
+            lambda error, **kwargs: logged_errors.append((error, kwargs)),
+        )
+        monkeypatch.setattr(server_module.socketio, "emit", lambda *args, **kwargs: None)
+
+        server_module.handle_set_radar_config({"min_speed": 99})
+
+        assert logged_errors
+        assert "not connected" in logged_errors[0][0]
+
+
 class TestKLD7Initialization:
     """Tests for K-LD7 startup wiring."""
 
@@ -1307,9 +1407,7 @@ class TestOnShotDetected:
             "geom_fit_rmse_deg": 0.64,
         }
 
-    def test_near_threshold_vertical_kld7_angle_displays_as_low_confidence_radar(
-        self, monkeypatch
-    ):
+    def test_near_threshold_vertical_kld7_angle_displays_as_low_confidence_radar(self, monkeypatch):
         """A plausible near-threshold radar candidate should show instead of estimate."""
 
         class StubTracker:

--- a/tests/test_session_logger.py
+++ b/tests/test_session_logger.py
@@ -2,8 +2,59 @@
 
 import json
 
+from openflight import session_logger as session_logger_module
 from openflight.kld7.radc import RADC_PAYLOAD_BYTES
-from openflight.session_logger import SessionLogger
+from openflight.session_logger import SessionLogger, log_session_error
+
+
+class TestLogError:
+    """Tests for session error logging."""
+
+    def test_log_error_writes_entry_and_increments_stats(self, tmp_path):
+        logger = SessionLogger(log_dir=tmp_path, enabled=True)
+        logger.start_session(mode="rolling-buffer", trigger_type="sound")
+
+        logger.log_error("capture loop failed", context={"component": "monitor"})
+
+        entry = json.loads(logger.session_path.read_text().strip().split("\n")[-1])
+        assert entry["type"] == "error"
+        assert entry["error"] == "capture loop failed"
+        assert entry["context"] == {"component": "monitor"}
+        assert logger.stats["errors"] == 1
+
+    def test_log_error_skipped_when_disabled(self, tmp_path):
+        logger = SessionLogger(log_dir=tmp_path, enabled=False)
+        logger.log_error("should not write")
+        assert logger.stats["errors"] == 0
+        assert logger.session_path is None
+
+
+class TestLogSessionError:
+    """Tests for the module-level session error helper."""
+
+    def test_log_session_error_delegates_to_global_logger(self, tmp_path, monkeypatch):
+        logger = SessionLogger(log_dir=tmp_path, enabled=True)
+        logger.start_session(mode="mock", trigger_type="manual")
+        monkeypatch.setattr(session_logger_module, "_session_logger", logger)
+
+        log_session_error(
+            "K-LD7 processing failed",
+            component="server",
+            context={"stage": "kld7"},
+            exc=RuntimeError("boom"),
+        )
+
+        entry = json.loads(logger.session_path.read_text().strip().split("\n")[-1])
+        assert entry["type"] == "error"
+        assert entry["error"] == "K-LD7 processing failed"
+        assert entry["context"]["component"] == "server"
+        assert entry["context"]["stage"] == "kld7"
+        assert entry["context"]["exception_type"] == "RuntimeError"
+        assert entry["context"]["exception_message"] == "boom"
+
+    def test_log_session_error_noop_without_global_logger(self, monkeypatch):
+        monkeypatch.setattr(session_logger_module, "_session_logger", None)
+        log_session_error("ignored")  # must not raise
 
 
 class TestLogTriggerDiagnostic:


### PR DESCRIPTION
Wire session error logging across the shot pipeline, K-LD7 tracker, and rolling-buffer monitor. Narrow K-LD7 serial I/O exceptions and document error entries for offline review. Fix ruff import/unused-import issues.

## What does this PR do?

Adds structured **session JSONL error logging** so processing failures are recorded in `~/openflight_sessions/` alongside shots and triggers, not only in Python logs.

- Introduces `log_session_error()` in `session_logger.py` and wires it through:
  - Shot pipeline (`server.py`): K-LD7 processing, camera processing, shot logging, WebSocket emit, radar config updates
  - Rolling buffer monitor capture loop
  - K-LD7 tracker: stream failures, ball/club RADC extraction errors
- Narrows K-LD7 serial I/O handling in `serial_io.py` to `OSError` / `serial.SerialException` where appropriate (read path, GBYE recovery, connect retries).
- Documents the `error` entry type in `docs/observability.md` and `docs/kld7-session-review.md`.
- Includes small **ruff** import/format fixes (required for pre-commit / `make lint`).

Each `error` entry includes a short message, `context` (e.g. `component`, `stage`), and optional exception metadata for offline debugging and Grafana/Loki queries.

## How was this tested?

- `make test` — **566 passed**, 6 skipped (existing numpy warnings in `test_kld7_radc_lib` empty-frame tests).
- `make lint` — ruff, pylint ≥ 9, UI eslint all pass.
- New/updated unit tests:
  - `tests/test_session_logger.py` — `log_error` / `log_session_error`
  - `tests/test_server.py` — K-LD7 failure and `set_radar_config` session logging
  - `tests/test_kld7.py` — serial/OSError wrapping in robust read path
- Verified pre-commit hooks on commit (ruff + ruff-format auto-fix, then re-staged).

Not tested on hardware in this PR (logic-only; mock/server tests cover the wiring).

## Checklist

- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [x] UI builds (`cd ui && npm run build`)
- [x] UI lint passes (`cd ui && npm run lint`)
- [x] Updated docs or CHANGELOG if needed
- [x] No unrelated changes mixed in *(includes minor ruff import fixes in `camera/` and `__init__.py` required for lint/pre-commit; no functional camera changes)*