### PR TITLE
Add club-selection screen on app load

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,6 +7,7 @@ import { DebugPanel } from './components/DebugPanel';
 import { CameraFeed } from './components/CameraFeed';
 import { ConnectionStatus } from './components/ConnectionStatus';
 import { ClubPicker } from './components/ClubPicker';
+import { ClubSelectScreen } from './components/ClubSelectScreen';
 import { BallDetectionIndicator } from './components/BallDetectionIndicator';
 import { DisplayMode } from './components/DisplayMode';
 import {
@@ -84,6 +85,10 @@ function AppContent() {
 
   const [currentView, setCurrentView] = useState<View>('live');
   const [selectedClub, setSelectedClub] = useState('driver');
+  // Shown on every app load so the user confirms their club before the first
+  // shot (skippable, keeps the default). The /display route returns early
+  // below, so this interstitial never appears in the passive TV view.
+  const [showClubSelect, setShowClubSelect] = useState(true);
   const [showShutdown, setShowShutdown] = useState(false);
   const { isLaunchDaddyMode, isExploding, triggerExplosion, handleSecretTap } = useLaunchDaddy();
   const { unitSystem, setUnitSystem } = useUnitPreference();
@@ -116,6 +121,17 @@ function AppContent() {
 
   return (
     <div className={`app ${isLaunchDaddyMode ? 'app--launch-daddy' : ''} ${isExploding ? 'app--exploding' : ''}`}>
+      {showClubSelect && (
+        <ClubSelectScreen
+          selectedClub={selectedClub}
+          onSelect={(club) => {
+            handleClubChange(club);
+            setShowClubSelect(false);
+          }}
+          onSkip={() => setShowClubSelect(false)}
+        />
+      )}
+
       {/* Launch Daddy Overlay */}
       <LaunchDaddyOverlay />
       <LaunchDaddySecretIndicator />

--- a/ui/src/components/ClubPicker.tsx
+++ b/ui/src/components/ClubPicker.tsx
@@ -1,35 +1,6 @@
 import { useState } from 'react';
+import { ALL_CLUBS, CLUBS_BY_TYPE } from '../data/clubs';
 import './ClubPicker.css';
-
-const CLUBS_BY_TYPE = {
-  Irons: [
-    { id: '2-iron', label: '2i' },
-    { id: '3-iron', label: '3i' },
-    { id: '4-iron', label: '4i' },
-    { id: '5-iron', label: '5i' },
-    { id: '6-iron', label: '6i' },
-    { id: '7-iron', label: '7i' },
-    { id: '8-iron', label: '8i' },
-    { id: '9-iron', label: '9i' },
-    { id: 'pw', label: 'PW' },
-    { id: 'gw', label: 'GW' },
-    { id: 'sw', label: 'SW' },
-    { id: 'lw', label: 'LW' },
-  ],
-  Hybrids: [
-    { id: '3-hybrid', label: '3H' },
-    { id: '5-hybrid', label: '5H' },
-    { id: '7-hybrid', label: '7H' },
-    { id: '9-hybrid', label: '9H' },
-  ],
-  Woods: [
-    { id: 'driver', label: 'DR' },
-    { id: '3-wood', label: '3W' },
-    { id: '5-wood', label: '5W' },
-    { id: '7-wood', label: '7W' },
-  ],
-};
-const ALL_CLUBS = Object.values(CLUBS_BY_TYPE).flat();
 
 interface ClubPickerProps {
   selectedClub: string;

--- a/ui/src/components/ClubSelectScreen.css
+++ b/ui/src/components/ClubSelectScreen.css
@@ -1,0 +1,124 @@
+/* Club Select Screen - full-screen interstitial shown on app load */
+.club-select {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-lg);
+  background: rgba(0, 0, 0, 0.85);
+  animation: club-select-fade-in 0.2s ease;
+  overflow-y: auto;
+}
+
+@keyframes club-select-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.club-select__panel {
+  width: 100%;
+  max-width: 480px;
+  background: var(--color-bg-elevated);
+  border: 1px solid rgba(212, 175, 55, 0.2);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  box-shadow:
+    0 10px 40px rgba(0, 0, 0, 0.5),
+    0 0 0 1px rgba(212, 175, 55, 0.1);
+}
+
+.club-select__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 1.75rem;
+  color: var(--color-gold);
+  text-align: center;
+}
+
+.club-select__subtitle {
+  margin: var(--space-xs) 0 var(--space-lg);
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.club-select__section {
+  margin-bottom: var(--space-md);
+}
+
+.club-select__section-title {
+  display: block;
+  font-size: 0.625rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  margin-bottom: var(--space-sm);
+}
+
+.club-select__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-sm);
+}
+
+.club-select__option {
+  padding: var(--space-sm);
+  background: var(--color-bg-card);
+  border: 1px solid rgba(245, 240, 230, 0.08);
+  border-radius: var(--radius-sm);
+  color: var(--color-cream);
+  font-family: var(--font-display);
+  font-size: 1.125rem;
+  font-weight: 400;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  min-height: 52px;
+}
+
+.club-select__option:hover {
+  background: var(--color-bg-hover);
+  border-color: rgba(245, 240, 230, 0.15);
+}
+
+.club-select__option:active {
+  transform: scale(0.95);
+}
+
+.club-select__option--selected {
+  background: rgba(212, 175, 55, 0.15);
+  border-color: var(--color-gold);
+  color: var(--color-gold);
+  box-shadow: 0 0 12px rgba(212, 175, 55, 0.2);
+}
+
+.club-select__skip {
+  display: block;
+  width: 100%;
+  margin-top: var(--space-lg);
+  padding: var(--space-md);
+  background: transparent;
+  border: 1px solid rgba(245, 240, 230, 0.15);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  min-height: 48px;
+}
+
+.club-select__skip:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-cream);
+}
+
+.club-select__skip:active {
+  transform: scale(0.98);
+}

--- a/ui/src/components/ClubSelectScreen.css
+++ b/ui/src/components/ClubSelectScreen.css
@@ -6,10 +6,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--space-lg);
+  padding: var(--space-md);
   background: rgba(0, 0, 0, 0.85);
   animation: club-select-fade-in 0.2s ease;
-  overflow-y: auto;
 }
 
 @keyframes club-select-fade-in {
@@ -22,35 +21,78 @@
 }
 
 .club-select__panel {
+  position: relative;
   width: 100%;
-  max-width: 480px;
+  max-width: 460px;
+  /* Never exceed the viewport; scroll internally on short screens (7" kiosk)
+     so the top/bottom can't get clipped by the centered overlay. */
+  max-height: 100%;
+  overflow-y: auto;
   background: var(--color-bg-elevated);
   border: 1px solid rgba(212, 175, 55, 0.2);
   border-radius: var(--radius-lg);
-  padding: var(--space-lg);
+  padding: var(--space-md) var(--space-lg);
   box-shadow:
     0 10px 40px rgba(0, 0, 0, 0.5),
     0 0 0 1px rgba(212, 175, 55, 0.1);
 }
 
+.club-select__close {
+  position: absolute;
+  top: var(--space-sm);
+  right: var(--space-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.club-select__close svg {
+  width: 22px;
+  height: 22px;
+}
+
+.club-select__close:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-cream);
+}
+
+.club-select__close:active {
+  transform: scale(0.92);
+}
+
 .club-select__title {
   margin: 0;
+  /* Leave room for the corner X so the centered title can't collide with it. */
+  padding: 0 var(--space-xl);
   font-family: var(--font-display);
   font-weight: 400;
-  font-size: 1.75rem;
+  font-size: 1.375rem;
   color: var(--color-gold);
   text-align: center;
 }
 
 .club-select__subtitle {
-  margin: var(--space-xs) 0 var(--space-lg);
-  font-size: 0.875rem;
+  margin: var(--space-xs) 0 var(--space-md);
+  font-size: 0.8125rem;
   color: var(--text-muted);
   text-align: center;
 }
 
 .club-select__section {
-  margin-bottom: var(--space-md);
+  margin-bottom: var(--space-sm);
+}
+
+.club-select__section:last-child {
+  margin-bottom: 0;
 }
 
 .club-select__section-title {
@@ -60,27 +102,27 @@
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.15em;
-  margin-bottom: var(--space-sm);
+  margin-bottom: var(--space-xs);
 }
 
 .club-select__grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: var(--space-sm);
+  gap: var(--space-xs);
 }
 
 .club-select__option {
-  padding: var(--space-sm);
+  padding: var(--space-xs);
   background: var(--color-bg-card);
   border: 1px solid rgba(245, 240, 230, 0.08);
   border-radius: var(--radius-sm);
   color: var(--color-cream);
   font-family: var(--font-display);
-  font-size: 1.125rem;
+  font-size: 1rem;
   font-weight: 400;
   cursor: pointer;
   transition: all var(--transition-fast);
-  min-height: 52px;
+  min-height: 44px;
 }
 
 .club-select__option:hover {
@@ -97,28 +139,4 @@
   border-color: var(--color-gold);
   color: var(--color-gold);
   box-shadow: 0 0 12px rgba(212, 175, 55, 0.2);
-}
-
-.club-select__skip {
-  display: block;
-  width: 100%;
-  margin-top: var(--space-lg);
-  padding: var(--space-md);
-  background: transparent;
-  border: 1px solid rgba(245, 240, 230, 0.15);
-  border-radius: var(--radius-sm);
-  color: var(--text-muted);
-  font-size: 0.875rem;
-  cursor: pointer;
-  transition: all var(--transition-fast);
-  min-height: 48px;
-}
-
-.club-select__skip:hover {
-  background: var(--color-bg-hover);
-  color: var(--color-cream);
-}
-
-.club-select__skip:active {
-  transform: scale(0.98);
 }

--- a/ui/src/components/ClubSelectScreen.test.tsx
+++ b/ui/src/components/ClubSelectScreen.test.tsx
@@ -1,0 +1,36 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { ALL_CLUBS } from '../data/clubs';
+import { ClubSelectScreen } from './ClubSelectScreen';
+
+const noop = () => {};
+
+describe('ClubSelectScreen', () => {
+  it('renders every club option', () => {
+    const html = renderToString(<ClubSelectScreen selectedClub="driver" onSelect={noop} onSkip={noop} />);
+    for (const club of ALL_CLUBS) {
+      expect(html).toContain(`>${club.label}</button>`);
+    }
+  });
+
+  it('renders the category headings', () => {
+    const html = renderToString(<ClubSelectScreen selectedClub="driver" onSelect={noop} onSkip={noop} />);
+    expect(html).toContain('Irons');
+    expect(html).toContain('Hybrids');
+    expect(html).toContain('Woods');
+  });
+
+  it('marks the selected club with the selected modifier class', () => {
+    const html = renderToString(<ClubSelectScreen selectedClub="7-iron" onSelect={noop} onSkip={noop} />);
+    // The 7-iron button carries the selected modifier...
+    expect(html).toMatch(/club-select__option club-select__option--selected[^>]*>7i</);
+    // ...and exactly one option is selected.
+    expect(html.match(/club-select__option--selected/g)).toHaveLength(1);
+  });
+
+  it('labels the skip button with the current club', () => {
+    const html = renderToString(<ClubSelectScreen selectedClub="driver" onSelect={noop} onSkip={noop} />);
+    expect(html).toContain('Skip');
+    expect(html).toContain('DR');
+  });
+});

--- a/ui/src/components/ClubSelectScreen.test.tsx
+++ b/ui/src/components/ClubSelectScreen.test.tsx
@@ -28,9 +28,9 @@ describe('ClubSelectScreen', () => {
     expect(html.match(/club-select__option--selected/g)).toHaveLength(1);
   });
 
-  it('labels the skip button with the current club', () => {
+  it('renders a close (dismiss) button instead of a skip button', () => {
     const html = renderToString(<ClubSelectScreen selectedClub="driver" onSelect={noop} onSkip={noop} />);
-    expect(html).toContain('Skip');
-    expect(html).toContain('DR');
+    expect(html).toContain('aria-label="Close club selection"');
+    expect(html).not.toContain('Skip');
   });
 });

--- a/ui/src/components/ClubSelectScreen.tsx
+++ b/ui/src/components/ClubSelectScreen.tsx
@@ -1,0 +1,50 @@
+import { ALL_CLUBS, CLUBS_BY_TYPE } from '../data/clubs';
+import './ClubSelectScreen.css';
+
+interface ClubSelectScreenProps {
+  /** Currently selected club id; pre-highlighted on the grid. */
+  selectedClub: string;
+  /** Called with the chosen club id when the user picks a club. */
+  onSelect: (club: string) => void;
+  /** Called when the user starts without changing the current club. */
+  onSkip: () => void;
+}
+
+/**
+ * Full-screen interstitial shown on app load so the user confirms which club
+ * they're hitting before the first shot. Dismissible via Skip, which keeps the
+ * current (default) club.
+ */
+export function ClubSelectScreen({ selectedClub, onSelect, onSkip }: ClubSelectScreenProps) {
+  const selectedLabel = ALL_CLUBS.find((c) => c.id === selectedClub)?.label ?? 'DR';
+
+  return (
+    <div className="club-select" role="dialog" aria-modal="true" aria-label="Select your club">
+      <div className="club-select__panel">
+        <h1 className="club-select__title">Select your club</h1>
+        <p className="club-select__subtitle">Choose the club you're hitting to start your session.</p>
+
+        {Object.entries(CLUBS_BY_TYPE).map(([type, clubs]) => (
+          <div className="club-select__section" key={type}>
+            <span className="club-select__section-title">{type}</span>
+            <div className="club-select__grid">
+              {clubs.map((club) => (
+                <button
+                  key={club.id}
+                  className={`club-select__option ${selectedClub === club.id ? 'club-select__option--selected' : ''}`}
+                  onClick={() => onSelect(club.id)}
+                >
+                  {club.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+
+        <button className="club-select__skip" onClick={onSkip}>
+          Skip — keep {selectedLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/ClubSelectScreen.tsx
+++ b/ui/src/components/ClubSelectScreen.tsx
@@ -1,4 +1,4 @@
-import { ALL_CLUBS, CLUBS_BY_TYPE } from '../data/clubs';
+import { CLUBS_BY_TYPE } from '../data/clubs';
 import './ClubSelectScreen.css';
 
 interface ClubSelectScreenProps {
@@ -6,21 +6,32 @@ interface ClubSelectScreenProps {
   selectedClub: string;
   /** Called with the chosen club id when the user picks a club. */
   onSelect: (club: string) => void;
-  /** Called when the user starts without changing the current club. */
+  /** Called when the user dismisses (X) without changing the current club. */
   onSkip: () => void;
 }
 
 /**
  * Full-screen interstitial shown on app load so the user confirms which club
- * they're hitting before the first shot. Dismissible via Skip, which keeps the
- * current (default) club.
+ * they're hitting before the first shot. Dismissible via the X in the corner,
+ * which keeps the current (default) club.
  */
 export function ClubSelectScreen({ selectedClub, onSelect, onSkip }: ClubSelectScreenProps) {
-  const selectedLabel = ALL_CLUBS.find((c) => c.id === selectedClub)?.label ?? 'DR';
-
   return (
     <div className="club-select" role="dialog" aria-modal="true" aria-label="Select your club">
       <div className="club-select__panel">
+        <button className="club-select__close" onClick={onSkip} aria-label="Close club selection">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
+        </button>
+
         <h1 className="club-select__title">Select your club</h1>
         <p className="club-select__subtitle">Choose the club you're hitting to start your session.</p>
 
@@ -40,10 +51,6 @@ export function ClubSelectScreen({ selectedClub, onSelect, onSkip }: ClubSelectS
             </div>
           </div>
         ))}
-
-        <button className="club-select__skip" onClick={onSkip}>
-          Skip — keep {selectedLabel}
-        </button>
       </div>
     </div>
   );

--- a/ui/src/data/clubs.test.ts
+++ b/ui/src/data/clubs.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { ALL_CLUBS, CLUBS_BY_TYPE } from './clubs';
+
+describe('clubs data', () => {
+  it('flattens every grouped club into ALL_CLUBS', () => {
+    const grouped = Object.values(CLUBS_BY_TYPE).flat();
+    expect(ALL_CLUBS).toHaveLength(grouped.length);
+    expect(ALL_CLUBS).toEqual(grouped);
+  });
+
+  it('includes the driver default with a DR label', () => {
+    const driver = ALL_CLUBS.find((c) => c.id === 'driver');
+    expect(driver).toBeDefined();
+    expect(driver?.label).toBe('DR');
+  });
+
+  it('has unique club ids', () => {
+    const ids = ALL_CLUBS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/ui/src/data/clubs.ts
+++ b/ui/src/data/clubs.ts
@@ -1,0 +1,37 @@
+export interface Club {
+  id: string;
+  label: string;
+}
+
+// Clubs grouped by type. Object insertion order is preserved and drives the
+// display order in both the ClubPicker dropdown and the ClubSelectScreen.
+export const CLUBS_BY_TYPE: Record<string, Club[]> = {
+  Irons: [
+    { id: '2-iron', label: '2i' },
+    { id: '3-iron', label: '3i' },
+    { id: '4-iron', label: '4i' },
+    { id: '5-iron', label: '5i' },
+    { id: '6-iron', label: '6i' },
+    { id: '7-iron', label: '7i' },
+    { id: '8-iron', label: '8i' },
+    { id: '9-iron', label: '9i' },
+    { id: 'pw', label: 'PW' },
+    { id: 'gw', label: 'GW' },
+    { id: 'sw', label: 'SW' },
+    { id: 'lw', label: 'LW' },
+  ],
+  Hybrids: [
+    { id: '3-hybrid', label: '3H' },
+    { id: '5-hybrid', label: '5H' },
+    { id: '7-hybrid', label: '7H' },
+    { id: '9-hybrid', label: '9H' },
+  ],
+  Woods: [
+    { id: 'driver', label: 'DR' },
+    { id: '3-wood', label: '3W' },
+    { id: '5-wood', label: '5W' },
+    { id: '7-wood', label: '7W' },
+  ],
+};
+
+export const ALL_CLUBS: Club[] = Object.values(CLUBS_BY_TYPE).flat();


### PR DESCRIPTION
## What

Adds a full-screen club-selection screen that appears on every app load,
before the live view, so the user confirms which club they're hitting
before the first shot — the same flow TrackMan and other launch monitors
use.

## Why

The selected club feeds the shot calculations — carry/distance estimation
uses per-club optimal launch angles (see `estimate_carry_distance`), so the
club is an input to the data, not just a label. On load the app defaults to
Driver, and it's easy to start hitting without switching it, which silently
skews every estimate until you notice. Prompting for the club up front makes
it an intentional choice and avoids inaccurate readings.

## Behavior

- Shows on every app load; pre-highlights the current club (Driver default).
- Dismissible via an X in the top-right corner, which keeps the current
  club — so it never blocks you from just starting.
- Picking a club sends the existing `set_club` event and updates the
  header `ClubPicker`, then reveals the live view.
- Kiosk-only: the passive `/display` TV route returns early before this
  screen renders, so it never appears there.
- Sized to fit small screens (7" kiosk @ 800x480) with internal scroll as
  a fallback so the top/bottom can't be clipped.

## Implementation notes

- Extracted the club list out of `ClubPicker` into a shared
  `ui/src/data/clubs.ts` so the picker and the new screen share one source
  of truth (DRY).
- No server changes: `set_club` already exists, and dismissing keeps the
  default (Driver), which already matches the server default — no desync.

## Testing

- New tests follow the repo's `renderToString` convention (no new deps):
  shared club data + the screen renders all clubs, marks the default, and
  exposes a close button.
- `npm run test` (13 pass), `tsc -b`, and `eslint` all clean.
- Verified manually in mock mode at desktop and 800x480 kiosk resolutions:
  appears on load, club selection + X-dismiss both work, nothing clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
