### PR TITLE
Add K-LD7 geometry analysis and live replay tooling

### DIFF
--- a/docs/kld7-vertical-geometry-selector.md
+++ b/docs/kld7-vertical-geometry-selector.md
@@ -490,3 +490,9 @@ error.
   adjacent frames near the relaxed threshold. Any change should be tested by
   bucket: primary two-frame, timing-recoverable two-frame, one-frame diagnostic,
   and no-signal/clutter.
+- Add local F1B ball-bin diagnostics for range-assisted selection. The current
+  analysis CSV reports the strongest F1B peak and its bin error, but reviewed
+  shots showed that the global F1B peak can land on near-DC/clutter while F1B
+  still has usable SNR at or near the selected F1A/OPS ball bin. Track both the
+  global F1B peak and a local F1B peak constrained around the selected ball bin
+  before using F1B range as a confidence signal for one-frame recovery.

--- a/scripts/analysis/kld7_analysis_tooling.md
+++ b/scripts/analysis/kld7_analysis_tooling.md
@@ -1,0 +1,469 @@
+# K-LD7 Analysis Tooling
+
+This guide covers the K-LD7 offline and live analysis workflow built around:
+
+- `kld7_geometry_selection_report.py`
+- `kld7_live_sync.py`
+- `kld7_timing_shift_visualizer.html`
+
+The goal is to make K-LD7 frame selection visible shot-by-shot so we can answer
+questions that are difficult to see from the kiosk UI alone:
+
+- Which RADC frames were considered?
+- Which frames did the replay selector choose?
+- Did the chosen frames match the OPS ball-speed bin?
+- Did the selected bearings produce a plausible launch angle?
+- Would a small whole-shot timing shift improve the geometry fit?
+- Does F1B range agree with the expected ball position?
+
+This tooling is for analysis and development. It does not replace the live kiosk
+path, but `frames_live.csv` is intended to mirror the current OPS-bin/live-style
+selection logic closely enough to debug production behavior.
+
+## File Roles
+
+`kld7_geometry_selection_report.py`
+
+Builds a report from a saved OpenFlight session JSONL. It extracts K-LD7 RADC
+frames, replays vertical frame selection, writes CSV files, copies the HTML
+visualizer into the report folder, and writes a session summary.
+
+`kld7_live_sync.py`
+
+Polls the Pi over SSH/SCP, pulls the latest session JSONL when new shots appear,
+regenerates the report, and serves the visualizer locally from the generated
+report directory.
+
+`kld7_timing_shift_visualizer.html`
+
+Browser tool for loading `frames.csv` or `frames_live.csv`, selecting a shot and
+up to two frames, and visualizing launch-angle geometry, timing shifts, F1B
+range overlays, and start-position error.
+
+## Generated Files
+
+The report script writes these files:
+
+- `summary.md`: human-readable session summary.
+- `config.json`: report configuration used for the replay.
+- `shots.csv`: broad exploratory selector output, one row per shot.
+- `frames.csv`: broad exploratory frame rows.
+- `shots_live.csv`: live-style replay output, one row per shot.
+- `frames_live.csv`: live-style replay frame rows.
+- `index.html`: copied visualizer.
+
+## `frames.csv` vs `frames_live.csv`
+
+Use `frames_live.csv` when you want to debug what the current production-like
+selector would do.
+
+Use `frames.csv` when you want a broader exploratory view of strong returns,
+including frames or bins the production-style selector may intentionally avoid.
+
+`frames_live.csv` / `shots_live.csv`
+
+- Replays the current OPS-bin/live-style selection logic.
+- Prioritizes the OPS-anchored ball-speed bin.
+- Marks the selected anchor and neighbor frames.
+- Is the right default for validating kiosk behavior.
+- Is the file the live-sync browser URL loads by default.
+
+`frames.csv` / `shots.csv`
+
+- Uses a broader/high-SNR exploratory pass.
+- Can surface clutter, net/screen returns, or alternate strong bins.
+- Is useful when the live selector rejects a shot and you want to inspect what
+  else was present in the RADC data.
+- Can show high-SNR frames that should not necessarily be trusted as ball frames.
+
+In short: start with `frames_live.csv`; use `frames.csv` when you are hunting
+for why something went wrong.
+
+## Offline Workflow
+
+Run this from the repo on your Mac:
+
+```bash
+cd /path/to/openflight
+
+uv run python scripts/analysis/kld7_geometry_selection_report.py \
+  /path/to/openflight_sessions/session_YYYYMMDD_HHMMSS_trackman.jsonl \
+  --angle-offset-deg 2.5 \
+  --ball-distance-ft 5 \
+  --mount-deg 10
+```
+
+The report directory is created next to the session file unless `--output-dir`
+is supplied.
+
+To write to a specific folder:
+
+```bash
+uv run python scripts/analysis/kld7_geometry_selection_report.py \
+  /path/to/session.jsonl \
+  --output-dir /path/to/openflight_sessions/my_report \
+  --angle-offset-deg 2.5 \
+  --ball-distance-ft 5 \
+  --mount-deg 10
+```
+
+Then open the generated `index.html`, or serve that report folder and load:
+
+```text
+index.html?csv=frames_live.csv
+```
+
+## Live Workflow
+
+Use this while the Pi is running the kiosk and writing session logs:
+
+### SSH Prerequisite
+
+Live sync uses your Mac's `ssh` and `scp` commands. The `--pi-host` value is the
+normal SSH destination for the Pi:
+
+```text
+pi-user@pi-host.local
+```
+
+Before running live sync, verify that this works from the Mac:
+
+```bash
+ssh pi-user@pi-host.local
+```
+
+For continuous live polling, passwordless SSH is strongly recommended. Otherwise
+the script can block or repeatedly prompt for a password when it checks for new
+shots. The private key stays on the Mac, usually in:
+
+```text
+~/.ssh/id_ed25519
+```
+
+The matching public key is installed on the Pi in:
+
+```text
+~/.ssh/authorized_keys
+```
+
+If you do not already have an SSH key on the Mac, create one:
+
+```bash
+ssh-keygen -t ed25519 -C "openflight-live-sync"
+```
+
+Then copy the public key to the Pi:
+
+```bash
+ssh-copy-id pi-user@pi-host.local
+```
+
+If `ssh-copy-id` is unavailable on the Mac, use this fallback:
+
+```bash
+cat ~/.ssh/id_ed25519.pub | ssh pi-user@pi-host.local 'mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
+```
+
+Confirm the final connection does not ask for a password:
+
+```bash
+ssh pi-user@pi-host.local 'hostname'
+```
+
+If the Pi hostname does not resolve on the network, use the Pi's IP address
+instead, for example:
+
+```text
+--pi-host pi-user@192.168.1.50
+```
+
+### Run Live Sync
+
+```bash
+cd /path/to/openflight
+
+uv run python scripts/analysis/kld7_live_sync.py \
+  --pi-host pi-user@pi-host.local \
+  --angle-offset-deg 2.5 \
+  --ball-distance-ft 5 \
+  --mount-deg 10 \
+  --serve-port 8765
+```
+
+Open:
+
+```text
+http://127.0.0.1:8765/index.html?csv=frames_live.csv&auto=1
+```
+
+The live sync script:
+
+1. Finds the newest session JSONL on the Pi.
+2. Checks whether the shot count changed.
+3. Copies the session to the Mac.
+4. Regenerates `frames_live.csv`, `shots_live.csv`, and related files.
+5. Serves the report directory on the requested port.
+
+The visualizer auto-reloads the CSV and selects the newest shot when `auto=1`.
+
+For a one-time pull and report generation:
+
+```bash
+uv run python scripts/analysis/kld7_live_sync.py \
+  --pi-host pi-user@pi-host.local \
+  --angle-offset-deg 2.5 \
+  --ball-distance-ft 5 \
+  --mount-deg 10 \
+  --once
+```
+
+## Important Configuration
+
+`--angle-offset-deg`
+
+K-LD7 boresight/electrical-zero correction. In kiosk geometry mode, the current
+field default is positive `2.5` degrees. The corrected bearing is:
+
+```text
+corrected_bearing = raw_kld7_angle + angle_offset_deg
+```
+
+`--ball-distance-ft`
+
+Distance from the radar face to the ball at address. This is critical for
+geometry fitting. If the ball was moved from 5 ft to 4 ft, generate a separate
+report or pass the correct distance for that session.
+
+`--mount-deg`
+
+Physical vertical radar mount tilt. Field default has been `10` degrees.
+
+`--ball-above-radar-ft`
+
+Vertical ball offset relative to the radar. Use this when the ball is known to
+be above or below the radar face and you want that modeled explicitly.
+
+`--report-arg`
+
+Passes extra options from live sync to the report script. Repeat it for multiple
+options:
+
+```bash
+uv run python scripts/analysis/kld7_live_sync.py \
+  --pi-host pi-user@pi-host.local \
+  --angle-offset-deg 2.5 \
+  --ball-distance-ft 5 \
+  --mount-deg 10 \
+  --report-arg=--clock-error-ms \
+  --report-arg=20
+```
+
+## Visualizer Basics
+
+The visualizer loads one CSV at a time. The normal live URL is:
+
+```text
+index.html?csv=frames_live.csv&auto=1
+```
+
+Useful controls:
+
+- Shot dropdown: selects the shot to inspect.
+- Frame list: click up to two frames.
+- Shift controls: moves both selected frames by the same millisecond offset.
+- Range overlay: toggles F1B range markers.
+- Angle offset input: applies a display/replay bearing offset in the browser.
+
+The visualizer intentionally shifts both selected frames together because the
+timing concern is a per-shot alignment error, not independent per-frame drift.
+
+## Visualizer Metrics
+
+New Launch Angle
+
+The primary geometry-fit result for the currently selected frame or frames. This
+is the candidate angle to compare against TrackMan or the kiosk output.
+
+Launch From Ball To Frame 2
+
+The simple one-frame launch angle from the known ball position to frame 2. This
+is useful when only one good frame exists, but it is sensitive to timing.
+
+Free-Start 2-Frame Line
+
+The line through frame 1 and frame 2 without forcing the line to start at the
+known ball position. This helps show whether the selected frames imply a launch
+line that crosses the floor before or after the ball.
+
+Start Position Error
+
+Where the free-start line crosses ball height relative to the configured ball
+position. A large start-position error suggests timing, frame selection, or range
+issues.
+
+Frame 1 Miss
+
+How far frame 1 is from the ball-to-frame-2 line. This is a quick visual cue for
+whether the selected frames agree with the same trajectory.
+
+Corrected Times
+
+The selected frame timestamps after applying the current whole-shot shift.
+
+Frame Distances
+
+The physics distance from ball speed and corrected time:
+
+```text
+distance_from_ball = ball_speed * corrected_time
+```
+
+F1B Ranges
+
+Range derived from F1B phase for the selected frame or frames. Treat this as a
+diagnostic, not a final source of truth, until the F1B local-ball-bin selection
+path is fully validated.
+
+Range Delta
+
+Difference between F1B range and the speed/time-derived frame distance. Large
+deltas can indicate timing error, F1B clutter, wrong range unwrap, or a frame
+that is not actually the ball.
+
+## Reading Frame Rows
+
+Important columns:
+
+- `shot_number`: shot index from the session.
+- `frame_index`: K-LD7 frame number within the shot window.
+- `t_ms`: frame time relative to impact.
+- `expected_bin`: OPS-derived expected K-LD7 Doppler bin.
+- `peak_bin`: selected K-LD7 bin for that frame.
+- `bin_error`: absolute difference between expected and selected bins.
+- `speed_mph`: speed implied by the selected K-LD7 bin.
+- `snr`: selected-bin signal-to-noise ratio.
+- `angle_centroid_deg`: centroid bearing before browser offset handling.
+- `bearing_deg`: bearing with configured offset applied by the report.
+- `f1b_range_ft`: F1B phase-derived range estimate.
+- `f1b_same_bin_snr`: F1B SNR at the selected F1A/F2A bin.
+- `f1b_peak_bin_error`: current F1B peak error diagnostic.
+- `selection_role`: `anchor`, `neighbor`, or blank.
+- `status`: `selected`, `rejected`, or `invalid`.
+- `reasons`: why a frame was not selected.
+
+## F1B Range Caveats
+
+F1B range has been useful, but the current CSV can still report a global F1B peak
+that is not near the ball-speed bin. A frame can show a scary
+`f1b_peak_bin_error` while still having good local F1B support at the selected
+ball bin.
+
+When evaluating F1B, prefer this order:
+
+1. Is the main selected `peak_bin` close to the OPS `expected_bin`?
+2. Is `f1b_same_bin_snr` decent at that selected ball bin?
+3. Are nearby F1B bins around the selected ball bin coherent?
+4. Does `f1b_range_ft` make physical sense for ball speed and `t_ms`?
+5. Is the global F1B peak near DC/clutter, net/screen, or another non-ball
+   return?
+
+A follow-up improvement is to add explicit local F1B ball-bin columns so the CSV
+distinguishes global F1B peaks from local ball-bin F1B support.
+
+## TrackMan Test Workflow
+
+For TrackMan comparison sessions:
+
+1. Start the kiosk with geometry and raw RADC logging.
+2. Start `kld7_live_sync.py` on the Mac.
+3. Open the visualizer with `frames_live.csv&auto=1`.
+4. Hit shots and record TrackMan launch angle, ball speed, horizontal direction,
+   curve, carry side, and club.
+5. For each shot, compare TrackMan launch to:
+   - logged kiosk launch
+   - New Launch Angle
+   - one-frame angle
+   - best whole-shot shift within a practical bound
+   - F1B range consistency
+6. Categorize each shot as:
+   - clean 2-frame geometry
+   - 2-frame geometry recoverable by small timing shift
+   - one-frame geometry
+   - one-frame plus F1B range candidate
+   - rejected due to bin/SNR/clutter
+   - estimated/no usable radar frame
+
+The current hypothesis to test is whether two-frame shots can consistently use a
+small whole-shot shift to minimize geometry error, and whether one-frame shots
+can be validated or rejected with F1B range.
+
+## Common Gotchas
+
+Wrong ball distance
+
+If `--ball-distance-ft` does not match the setup, all geometry fits shift. A 4 ft
+setup analyzed as 5 ft can make otherwise good frames look wrong.
+
+Wrong angle offset
+
+The kiosk geometry default is positive `2.5` degrees. If the report and kiosk use
+different offsets, browser angles will not match logged angles.
+
+Frame timing from old sessions
+
+Older sessions may have pre-OPS-clock timing behavior. Timing conclusions from
+those sessions should be separated from newer sessions.
+
+Single-frame angles are easy to fit
+
+With one frame, a timing shift can make the launch angle look better, but there
+is less evidence than with a two-frame fit. Treat one-frame recoveries as lower
+confidence unless F1B range supports them.
+
+High SNR can be clutter
+
+The strongest bin is not always the ball. Net/screen returns, near-field clutter,
+or club returns can have high SNR. Bin error, timing, rising trajectory, and F1B
+range all matter.
+
+## Quick Command Reference
+
+Live:
+
+```bash
+cd /path/to/openflight
+uv run python scripts/analysis/kld7_live_sync.py \
+  --pi-host pi-user@pi-host.local \
+  --angle-offset-deg 2.5 \
+  --ball-distance-ft 5 \
+  --mount-deg 10 \
+  --serve-port 8765
+```
+
+Browser:
+
+```text
+http://127.0.0.1:8765/index.html?csv=frames_live.csv&auto=1
+```
+
+Offline:
+
+```bash
+cd /path/to/openflight
+uv run python scripts/analysis/kld7_geometry_selection_report.py \
+  /path/to/session.jsonl \
+  --angle-offset-deg 2.5 \
+  --ball-distance-ft 5 \
+  --mount-deg 10
+```
+
+One-time Pi sync:
+
+```bash
+uv run python scripts/analysis/kld7_live_sync.py \
+  --pi-host pi-user@pi-host.local \
+  --angle-offset-deg 2.5 \
+  --ball-distance-ft 5 \
+  --mount-deg 10 \
+  --once
+```

--- a/scripts/analysis/kld7_geometry_selection_report.py
+++ b/scripts/analysis/kld7_geometry_selection_report.py
@@ -1,0 +1,1610 @@
+#!/usr/bin/env python
+"""Offline K-LD7 RADC frame-selection and range-assisted geometry report.
+
+This tool is intentionally more verbose and more configurable than the live
+selector. It is for answering "what frames could we have used?" from a session
+JSONL that contains raw K-LD7 RADC payloads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import json
+import math
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from openflight.kld7.geometry import (
+    GEOM_BALL_ABOVE_RADAR_FT,
+    GEOM_FLIGHT_T_MAX_S,
+    GEOM_PAIR_SINGLE_FRAME_FALLBACK_RMSE_DEG,
+    MPH_TO_FTS,
+    fit_launch_angle_geometric,
+    fit_launch_angle_single_frame_geometric,
+)
+from openflight.kld7.radc import (
+    OPS_ANCHORED_PEAK_MIN_SNR,
+    RADC_PAYLOAD_BYTES,
+    _centroid_angle_for_peak,
+    _find_peak_in_bands,
+    _find_peak_near_expected_bin,
+    _peak_neighborhood_indices,
+    _phase_coherence_for_peak,
+    ball_bin_range_from_speed,
+    bin_to_velocity_kmh,
+    circular_bin_distance,
+    compute_fft_complex,
+    expected_ball_bin_from_speed,
+    parse_radc_payload,
+    per_bin_angle_deg,
+    spectrum_from_channel_ffts,
+    to_complex_iq,
+)
+
+
+@dataclass(frozen=True)
+class ReportConfig:
+    orientation: str = "vertical"
+    ball_distance_ft: float = 5.0
+    mount_deg: float = 10.0
+    angle_offset_deg: float = 2.5
+    ball_above_radar_ft: float = GEOM_BALL_ABOVE_RADAR_FT
+    fft_size: int = 2048
+    max_speed_kmh: float = 100.0
+    dc_mask_bins: int = 8
+    speed_tolerance_mph: float = 25.0
+    spectrum_source: str = "f1a"
+    centroid_floor_frac: float = 0.5
+    report_time_min_ms: float = -80.0
+    report_time_max_ms: float = 170.0
+    report_bin_error_max: int = 220
+    ops_bin_outlier_tol: int = 25
+    ops_anchored_peak_min_snr: float = OPS_ANCHORED_PEAK_MIN_SNR
+    anchor_time_min_ms: float = 20.0
+    anchor_time_max_ms: float = 100.0
+    anchor_snr_min: float = 5.0
+    anchor_bin_error_max: int = 50
+    neighbor_time_min_ms: float = 0.0
+    neighbor_time_max_ms: float = 125.0
+    neighbor_snr_min: float = 3.0
+    neighbor_bin_error_max: int = 80
+    early_neighbor_time_max_ms: float = 20.0
+    early_neighbor_bin_error_max: int = 175
+    neighbor_frame_gap: int = 2
+    min_rising_deg: float = 0.0
+    max_selected_frames: int = 2
+    clock_error_ms: float = 20.0
+    shift_step_ms: float = 1.0
+    sensitivity_ms: float = 10.0
+    kld7_range_m: float = 5.0
+    f1b_range_bias_ft: float = 0.0
+    f1b_phase_mode: str = "f1b_minus_f1a"
+    range_unwrap_bin_error_max: int = 80
+    range_unwrap_snr_min: float = 3.0
+    range_unwrap_backtrack_ft: float = 0.75
+
+    @property
+    def unambiguous_range_ft(self) -> float:
+        return self.kld7_range_m * 3.28084
+
+
+@dataclass
+class FrameReport:
+    shot_number: int
+    frame_index: int
+    timestamp: float
+    t_ms: float
+    expected_bin: int | None = None
+    peak_bin: int | None = None
+    peak_source: str = ""
+    bin_error: int | None = None
+    speed_mph: float | None = None
+    speed_error_mph: float | None = None
+    peak_magnitude: float | None = None
+    noise_floor: float | None = None
+    snr: float | None = None
+    snr_db: float | None = None
+    angle_peak_deg: float | None = None
+    angle_centroid_deg: float | None = None
+    bearing_deg: float | None = None
+    elevation_deg: float | None = None
+    phase_coherence: float | None = None
+    peak_width_bins: int | None = None
+    f1b_phase_rad: float | None = None
+    f1b_range_raw_ft: float | None = None
+    f1b_range_ft: float | None = None
+    f1b_range_unwrapped_ft: float | None = None
+    f1b_range_unwrap_count: int = 0
+    f1b_same_bin_snr: float | None = None
+    f1b_peak_bin: int | None = None
+    f1b_peak_bin_error: int | None = None
+    anchored_peak_bin: int | None = None
+    anchored_bin_error: int | None = None
+    anchored_speed_mph: float | None = None
+    anchored_snr: float | None = None
+    anchored_bearing_deg: float | None = None
+    broad_peak_bin: int | None = None
+    broad_bin_error: int | None = None
+    broad_speed_mph: float | None = None
+    broad_snr: float | None = None
+    broad_bearing_deg: float | None = None
+    peak_selectable: bool = True
+    selection_role: str = ""
+    status: str = "invalid"
+    reasons: list[str] = field(default_factory=list)
+
+    @property
+    def selectable(self) -> bool:
+        return (
+            self.peak_selectable
+            and self.peak_bin is not None
+            and self.bin_error is not None
+            and self.snr is not None
+        )
+
+
+@dataclass(frozen=True)
+class FitResult:
+    shift_ms: float
+    launch_angle_deg: float | None
+    bearing_rmse_deg: float | None
+    range_rmse_ft: float | None
+    range_residuals_ft: list[float]
+    frame_count: int
+    method: str
+
+    @property
+    def score(self) -> float:
+        if self.launch_angle_deg is None:
+            return math.inf
+        if self.range_rmse_ft is not None:
+            return self.range_rmse_ft
+        if self.bearing_rmse_deg is not None:
+            return self.bearing_rmse_deg
+        return math.inf
+
+
+@dataclass
+class ShotReport:
+    shot_number: int
+    ball_speed_mph: float | None
+    impact_timestamp: float | None
+    impact_timestamp_source: str
+    logged_launch_angle_deg: float | None
+    logged_angle_source: str | None
+    logged_ball_angle_deg: float | None
+    logged_ball_angle_confidence: float | None
+    logged_ball_angle_accepted: bool | None
+    logged_ball_angle_selection_reason: str | None
+    logged_ball_angle_num_frames: int | None
+    logged_radc_selection_available: bool
+    logged_radc_estimator: str | None
+    logged_radc_selection_path: str | None
+    logged_radc_selected_frame_indices: list[int]
+    logged_radc_selected_t_ms: list[float]
+    logged_radc_selected_bin_errors: list[int | None]
+    logged_radc_fit_rmse_deg: float | None
+    frame_count: int
+    considered_frame_count: int
+    selected_frame_indices: list[int]
+    selection_method: str
+    selection_notes: list[str]
+    nominal_fit: FitResult | None
+    best_range_fit: FitResult | None
+    minus_sensitivity_fit: FitResult | None
+    plus_sensitivity_fit: FitResult | None
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _decode_radc(frame: dict[str, Any]) -> bytes | None:
+    raw = frame.get("radc")
+    if isinstance(raw, bytes):
+        return raw if len(raw) == RADC_PAYLOAD_BYTES else None
+    radc_b64 = frame.get("radc_b64")
+    if not isinstance(radc_b64, str):
+        return None
+    try:
+        decoded = base64.b64decode(radc_b64, validate=True)
+    except ValueError:
+        return None
+    return decoded if len(decoded) == RADC_PAYLOAD_BYTES else None
+
+
+def _mph_from_bin(bin_index: int, config: ReportConfig) -> float:
+    velocity_kmh = bin_to_velocity_kmh(bin_index, config.fft_size, config.max_speed_kmh)
+    return (2.0 * config.max_speed_kmh + velocity_kmh) / 1.609
+
+
+def _format_float(value: float | None, digits: int = 2) -> str:
+    if value is None:
+        return ""
+    return f"{value:.{digits}f}"
+
+
+def _f1b_phase_range_ft(
+    f1a_fft: np.ndarray,
+    f1b_fft: np.ndarray,
+    spectrum: np.ndarray,
+    peak_bin: int,
+    peak_val: float,
+    peak_band: tuple[int, int] | None,
+    config: ReportConfig,
+) -> tuple[float, float, float]:
+    indices = _peak_neighborhood_indices(
+        spectrum,
+        peak_bin,
+        peak_val,
+        peak_band,
+        half_width=4,
+        floor_frac=None,
+    )
+    weights = np.maximum(spectrum[indices], 0.0)
+    if float(np.sum(weights)) <= 0:
+        weights = np.ones_like(weights)
+    if config.f1b_phase_mode == "f1a_minus_f1b":
+        cross = np.sum(weights * f1a_fft[indices] * np.conj(f1b_fft[indices]))
+    else:
+        cross = np.sum(weights * f1b_fft[indices] * np.conj(f1a_fft[indices]))
+    phase = float(np.angle(cross))
+    raw_range_ft = (phase % (2.0 * math.pi)) / (2.0 * math.pi) * config.unambiguous_range_ft
+    return phase, raw_range_ft, raw_range_ft - config.f1b_range_bias_ft
+
+
+def _predicted_range_ft(
+    launch_angle_deg: float,
+    flight_time_s: float,
+    ball_speed_mph: float,
+    config: ReportConfig,
+) -> float:
+    v_fts = ball_speed_mph * MPH_TO_FTS
+    alpha_rad = math.radians(launch_angle_deg)
+    x_ft = config.ball_distance_ft + v_fts * math.cos(alpha_rad) * flight_time_s
+    y_ft = config.ball_above_radar_ft + v_fts * math.sin(alpha_rad) * flight_time_s
+    return math.hypot(x_ft, y_ft)
+
+
+def _load_session_rows(
+    session_path: Path,
+) -> tuple[dict[int, dict[str, Any]], dict[tuple[int, str], dict[str, Any]]]:
+    shots: dict[int, dict[str, Any]] = {}
+    buffers: dict[tuple[int, str], dict[str, Any]] = {}
+    with session_path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    f"Invalid JSON on line {line_number} of {session_path}: {error.msg}"
+                ) from error
+            row_type = row.get("type")
+            shot_number = row.get("shot_number")
+            if shot_number is None:
+                continue
+            shot_number = int(shot_number)
+            if row_type == "shot_detected":
+                shots[shot_number] = row
+            elif row_type == "kld7_buffer":
+                orientation = str(row.get("orientation") or "")
+                if orientation:
+                    buffers[(shot_number, orientation)] = row
+    return shots, buffers
+
+
+def _impact_timestamp(
+    shot: dict[str, Any] | None,
+    buffer_entry: dict[str, Any],
+) -> tuple[float | None, str]:
+    if shot:
+        impact = _to_float(shot.get("impact_timestamp"))
+        if impact is not None:
+            return impact, "shot_detected.impact_timestamp"
+    shot_timestamp = _to_float(buffer_entry.get("shot_timestamp"))
+    if shot_timestamp is not None:
+        return shot_timestamp, "kld7_buffer.shot_timestamp"
+    return None, "missing"
+
+
+def _coerce_int_list(value: Any) -> list[int]:
+    if not isinstance(value, list):
+        return []
+    result: list[int] = []
+    for item in value:
+        try:
+            result.append(int(item))
+        except (TypeError, ValueError):
+            continue
+    return result
+
+
+def _coerce_float_list(value: Any) -> list[float]:
+    if not isinstance(value, list):
+        return []
+    result: list[float] = []
+    for item in value:
+        try:
+            result.append(float(item))
+        except (TypeError, ValueError):
+            continue
+    return result
+
+
+def _coerce_optional_int_list(value: Any) -> list[int | None]:
+    if not isinstance(value, list):
+        return []
+    result: list[int | None] = []
+    for item in value:
+        if item is None:
+            result.append(None)
+            continue
+        try:
+            result.append(int(item))
+        except (TypeError, ValueError):
+            result.append(None)
+    return result
+
+
+def _to_int(value: Any) -> int | None:
+    numeric = _to_float(value)
+    return int(numeric) if numeric is not None else None
+
+
+def _logged_ball_angle_selection(buffer_entry: dict[str, Any]) -> dict[str, Any]:
+    ball_angle = buffer_entry.get("ball_angle")
+    if not isinstance(ball_angle, dict):
+        return {
+            "logged_ball_angle_deg": None,
+            "logged_ball_angle_confidence": None,
+            "logged_ball_angle_accepted": None,
+            "logged_ball_angle_selection_reason": None,
+            "logged_ball_angle_num_frames": None,
+            "logged_radc_selection_available": False,
+            "logged_radc_estimator": None,
+            "logged_radc_selection_path": None,
+            "logged_radc_selected_frame_indices": [],
+            "logged_radc_selected_t_ms": [],
+            "logged_radc_selected_bin_errors": [],
+            "logged_radc_fit_rmse_deg": None,
+        }
+
+    radc_selection = ball_angle.get("radc_selection")
+    if not isinstance(radc_selection, dict):
+        radc_selection = {}
+
+    return {
+        "logged_ball_angle_deg": _to_float(
+            ball_angle.get("vertical_deg") or ball_angle.get("horizontal_deg")
+        ),
+        "logged_ball_angle_confidence": _to_float(ball_angle.get("confidence")),
+        "logged_ball_angle_accepted": (
+            bool(ball_angle.get("accepted")) if "accepted" in ball_angle else None
+        ),
+        "logged_ball_angle_selection_reason": ball_angle.get("selection_reason"),
+        "logged_ball_angle_num_frames": _to_int(ball_angle.get("num_frames")),
+        "logged_radc_selection_available": bool(radc_selection),
+        "logged_radc_estimator": radc_selection.get("estimator"),
+        "logged_radc_selection_path": radc_selection.get("selection_path"),
+        "logged_radc_selected_frame_indices": _coerce_int_list(
+            radc_selection.get("selected_frame_indices")
+        ),
+        "logged_radc_selected_t_ms": _coerce_float_list(radc_selection.get("selected_t_ms")),
+        "logged_radc_selected_bin_errors": _coerce_optional_int_list(
+            radc_selection.get("selected_bin_errors")
+        ),
+        "logged_radc_fit_rmse_deg": _to_float(radc_selection.get("geom_fit_rmse_deg")),
+    }
+
+
+def extract_frame_report(
+    shot_number: int,
+    frame_index: int,
+    frame: dict[str, Any],
+    impact_timestamp: float,
+    ball_speed_mph: float,
+    config: ReportConfig,
+) -> FrameReport:
+    timestamp = float(frame["timestamp"])
+    report = FrameReport(
+        shot_number=shot_number,
+        frame_index=frame_index,
+        timestamp=timestamp,
+        t_ms=(timestamp - impact_timestamp) * 1000.0,
+    )
+    radc = _decode_radc(frame)
+    if radc is None:
+        report.reasons.append("missing_or_invalid_radc")
+        return report
+
+    try:
+        channels = parse_radc_payload(radc)
+    except ValueError:
+        report.reasons.append("invalid_radc_payload")
+        return report
+
+    f1a_fft = compute_fft_complex(
+        to_complex_iq(channels["f1a_i"], channels["f1a_q"]),
+        fft_size=config.fft_size,
+        dc_mask_bins=config.dc_mask_bins,
+    )
+    f2a_fft = compute_fft_complex(
+        to_complex_iq(channels["f2a_i"], channels["f2a_q"]),
+        fft_size=config.fft_size,
+        dc_mask_bins=config.dc_mask_bins,
+    )
+    f1b_fft = compute_fft_complex(
+        to_complex_iq(channels["f1b_i"], channels["f1b_q"]),
+        fft_size=config.fft_size,
+        dc_mask_bins=config.dc_mask_bins,
+    )
+    spectrum = spectrum_from_channel_ffts(
+        f1a_fft,
+        f2a_fft,
+        f1b_fft,
+        source=config.spectrum_source,
+    )
+    expected_bin = expected_ball_bin_from_speed(
+        ball_speed_mph,
+        config.fft_size,
+        config.max_speed_kmh,
+    )
+    bands = ball_bin_range_from_speed(
+        ball_speed_mph,
+        config.speed_tolerance_mph,
+        config.fft_size,
+        config.max_speed_kmh,
+    )
+    anchored_peak_bin, anchored_peak_val, anchored_peak_band = _find_peak_near_expected_bin(
+        spectrum,
+        bands,
+        expected_bin,
+        config.ops_bin_outlier_tol,
+        config.fft_size,
+    )
+    broad_peak_bin, broad_peak_val, broad_peak_band = _find_peak_in_bands(
+        spectrum,
+        tuple(bands),
+    )
+    positive = spectrum[spectrum > 0]
+    noise_floor = float(np.median(positive)) if positive.size else 0.0
+    report.expected_bin = expected_bin
+    report.noise_floor = noise_floor
+    angles = per_bin_angle_deg(f1a_fft, f2a_fft)
+
+    def describe_peak(
+        peak_bin: int | None,
+        peak_val: float,
+        peak_band: tuple[int, int] | None,
+    ) -> dict[str, float | int | None] | None:
+        if peak_bin is None or peak_val <= 0:
+            return None
+        centroid_angle, peak_width = _centroid_angle_for_peak(
+            angles,
+            spectrum,
+            peak_bin,
+            peak_val,
+            peak_band,
+            config.centroid_floor_frac,
+        )
+        phase_coherence = _phase_coherence_for_peak(
+            f1a_fft,
+            f2a_fft,
+            spectrum,
+            peak_bin,
+            peak_val,
+            peak_band,
+            coherence_bins=4,
+        )
+        speed_mph = _mph_from_bin(peak_bin, config)
+        snr = float(peak_val / noise_floor) if noise_floor > 0 else 0.0
+        return {
+            "peak_bin": int(peak_bin),
+            "peak_val": float(peak_val),
+            "bin_error": circular_bin_distance(peak_bin, expected_bin, config.fft_size),
+            "speed_mph": speed_mph,
+            "speed_error_mph": speed_mph - ball_speed_mph,
+            "snr": snr,
+            "snr_db": float(10.0 * math.log10(snr)) if snr > 0 else 0.0,
+            "angle_peak_deg": float(angles[peak_bin]),
+            "angle_centroid_deg": float(centroid_angle),
+            "bearing_deg": float(centroid_angle + config.angle_offset_deg),
+            "elevation_deg": float(centroid_angle + config.angle_offset_deg + config.mount_deg),
+            "phase_coherence": phase_coherence,
+            "peak_width_bins": int(peak_width),
+        }
+
+    anchored = describe_peak(anchored_peak_bin, anchored_peak_val, anchored_peak_band)
+    broad = describe_peak(broad_peak_bin, broad_peak_val, broad_peak_band)
+    if anchored is not None:
+        report.anchored_peak_bin = int(anchored["peak_bin"])
+        report.anchored_bin_error = int(anchored["bin_error"])
+        report.anchored_speed_mph = float(anchored["speed_mph"])
+        report.anchored_snr = float(anchored["snr"])
+        report.anchored_bearing_deg = float(anchored["bearing_deg"])
+    if broad is not None:
+        report.broad_peak_bin = int(broad["peak_bin"])
+        report.broad_bin_error = int(broad["bin_error"])
+        report.broad_speed_mph = float(broad["speed_mph"])
+        report.broad_snr = float(broad["snr"])
+        report.broad_bearing_deg = float(broad["bearing_deg"])
+
+    if anchored is None:
+        report.reasons.append("no_ops_anchored_peak")
+        return report
+
+    peak_bin = int(anchored["peak_bin"])
+    peak_val = float(anchored["peak_val"])
+    peak_band = anchored_peak_band
+    anchored_snr = float(anchored["snr"])
+    if anchored_snr < config.neighbor_snr_min:
+        peak_source = "ops_anchored_low_snr"
+    elif anchored_snr >= config.ops_anchored_peak_min_snr:
+        peak_source = "ops_anchored"
+    else:
+        peak_source = "ops_anchored_weak"
+    f1b_phase, f1b_range_raw_ft, f1b_range_ft = _f1b_phase_range_ft(
+        f1a_fft,
+        f1b_fft,
+        spectrum,
+        peak_bin,
+        peak_val,
+        peak_band,
+        config,
+    )
+
+    f1b_mag = np.abs(f1b_fft)
+    f1b_peak_bin, _, _ = _find_peak_near_expected_bin(
+        f1b_mag,
+        bands,
+        expected_bin,
+        config.report_bin_error_max,
+        config.fft_size,
+    )
+    f1b_positive = f1b_mag[f1b_mag > 0]
+    f1b_noise = float(np.median(f1b_positive)) if f1b_positive.size else 0.0
+
+    snr = anchored_snr
+    report.peak_bin = int(peak_bin)
+    report.peak_source = peak_source
+    report.bin_error = int(anchored["bin_error"])
+    report.speed_mph = float(anchored["speed_mph"])
+    report.speed_error_mph = float(anchored["speed_error_mph"])
+    report.peak_magnitude = float(peak_val)
+    report.snr = snr
+    report.snr_db = float(anchored["snr_db"])
+    report.angle_peak_deg = float(anchored["angle_peak_deg"])
+    report.angle_centroid_deg = float(anchored["angle_centroid_deg"])
+    report.bearing_deg = float(anchored["bearing_deg"])
+    report.elevation_deg = float(anchored["elevation_deg"])
+    report.phase_coherence = (
+        float(anchored["phase_coherence"]) if anchored["phase_coherence"] is not None else None
+    )
+    report.peak_width_bins = int(anchored["peak_width_bins"])
+    report.f1b_phase_rad = f1b_phase
+    report.f1b_range_raw_ft = f1b_range_raw_ft
+    report.f1b_range_ft = f1b_range_ft
+    report.f1b_same_bin_snr = float(f1b_mag[peak_bin] / f1b_noise) if f1b_noise > 0 else None
+    report.f1b_peak_bin = int(f1b_peak_bin) if f1b_peak_bin is not None else None
+    report.f1b_peak_bin_error = (
+        circular_bin_distance(int(f1b_peak_bin), peak_bin, config.fft_size)
+        if f1b_peak_bin is not None
+        else None
+    )
+    if snr < config.neighbor_snr_min:
+        report.peak_selectable = False
+        report.reasons.append("ops_anchored_snr_too_low")
+        return report
+    report.status = "candidate"
+    return report
+
+
+def _anchor_failure_reasons(frame: FrameReport, config: ReportConfig) -> list[str]:
+    reasons: list[str] = []
+    if not frame.selectable:
+        return list(frame.reasons) or ["not_selectable"]
+    if not (config.anchor_time_min_ms <= frame.t_ms <= config.anchor_time_max_ms):
+        reasons.append("outside_anchor_time_window")
+    if frame.snr is not None and frame.snr < config.anchor_snr_min:
+        reasons.append("anchor_snr_too_low")
+    if frame.bin_error is not None and frame.bin_error > config.anchor_bin_error_max:
+        reasons.append("anchor_bin_error_too_large")
+    return reasons
+
+
+def _neighbor_bin_limit(frame: FrameReport, config: ReportConfig) -> int:
+    if frame.t_ms <= config.early_neighbor_time_max_ms:
+        return config.early_neighbor_bin_error_max
+    return config.neighbor_bin_error_max
+
+
+def _neighbor_failure_reasons(
+    frame: FrameReport,
+    anchor: FrameReport,
+    config: ReportConfig,
+) -> list[str]:
+    reasons: list[str] = []
+    if not frame.selectable:
+        return list(frame.reasons) or ["not_selectable"]
+    if not (config.neighbor_time_min_ms <= frame.t_ms <= config.neighbor_time_max_ms):
+        reasons.append("outside_neighbor_time_window")
+    if abs(frame.frame_index - anchor.frame_index) > config.neighbor_frame_gap:
+        reasons.append("not_adjacent_enough")
+    if frame.snr is not None and frame.snr < config.neighbor_snr_min:
+        reasons.append("neighbor_snr_too_low")
+    if frame.bin_error is not None and frame.bin_error > _neighbor_bin_limit(frame, config):
+        reasons.append("neighbor_bin_error_too_large")
+    first, second = (frame, anchor) if frame.t_ms < anchor.t_ms else (anchor, frame)
+    if (
+        first.bearing_deg is not None
+        and second.bearing_deg is not None
+        and second.bearing_deg < first.bearing_deg + config.min_rising_deg
+    ):
+        reasons.append("not_rising")
+    return reasons
+
+
+def select_candidate_frames(
+    frames: list[FrameReport],
+    config: ReportConfig,
+) -> tuple[list[FrameReport], list[str]]:
+    notes: list[str] = []
+    for frame in frames:
+        frame.selection_role = ""
+        if frame.selectable:
+            frame.status = "candidate"
+
+    primary_passed = [
+        frame
+        for frame in frames
+        if frame.selectable
+        and config.anchor_time_min_ms <= frame.t_ms <= config.anchor_time_max_ms
+        and frame.bin_error is not None
+        and frame.bin_error <= config.anchor_bin_error_max
+        and frame.snr is not None
+        and frame.snr >= config.neighbor_snr_min
+    ]
+    early_context = [
+        frame
+        for frame in frames
+        if frame.selectable
+        and config.neighbor_time_min_ms <= frame.t_ms < config.early_neighbor_time_max_ms
+        and frame.bin_error is not None
+        and frame.bin_error <= config.anchor_bin_error_max
+        and frame.snr is not None
+        and frame.snr >= config.neighbor_snr_min
+    ]
+
+    anchor_pool = [
+        frame
+        for frame in primary_passed
+        if frame.peak_source != "ops_anchored_weak"
+        and frame.snr is not None
+        and frame.snr >= config.anchor_snr_min
+    ]
+    if not anchor_pool:
+        notes.append("no_anchor_frame")
+        for frame in frames:
+            if frame.selectable:
+                frame.status = "rejected"
+                frame.reasons = list(
+                    dict.fromkeys(frame.reasons + _anchor_failure_reasons(frame, config))
+                )
+        return [], notes
+
+    anchor = sorted(
+        anchor_pool,
+        key=lambda frame: (
+            frame.bin_error if frame.bin_error is not None else 99999,
+            -(frame.snr or 0.0),
+            -(-1.0 if frame.phase_coherence is None else frame.phase_coherence),
+        ),
+    )[0]
+    anchor.selection_role = "anchor"
+
+    def valid_rising_pair(
+        first: FrameReport,
+        second: FrameReport,
+    ) -> tuple[FrameReport, FrameReport] | None:
+        partner = first if second is anchor else second
+        partner_snr = partner.snr or 0.0
+        if partner.peak_source == "ops_anchored_weak":
+            min_partner_snr = config.neighbor_snr_min
+        else:
+            min_partner_snr = max(config.neighbor_snr_min, 0.5 * (anchor.snr or 0.0))
+        if partner_snr < min_partner_snr:
+            partner.reasons = list(dict.fromkeys(partner.reasons + ["neighbor_snr_too_low"]))
+            return None
+        if (
+            first.bearing_deg is None
+            or second.bearing_deg is None
+            or second.bearing_deg < first.bearing_deg + config.min_rising_deg
+        ):
+            partner.reasons = list(dict.fromkeys(partner.reasons + ["not_rising"]))
+            return None
+        return first, second
+
+    def find_neighbor_pair(pool: list[FrameReport]) -> tuple[FrameReport, FrameReport] | None:
+        by_frame = sorted(pool, key=lambda frame: frame.frame_index)
+        try:
+            anchor_pos = by_frame.index(anchor)
+        except ValueError:
+            return None
+        if anchor_pos > 0:
+            pair = valid_rising_pair(by_frame[anchor_pos - 1], anchor)
+            if pair is not None:
+                return pair
+        if anchor_pos + 1 < len(by_frame):
+            pair = valid_rising_pair(anchor, by_frame[anchor_pos + 1])
+            if pair is not None:
+                return pair
+        return None
+
+    pair = find_neighbor_pair(primary_passed)
+    if pair is None and early_context:
+        pair = find_neighbor_pair(primary_passed + early_context)
+
+    selected = sorted(pair if pair is not None else [anchor], key=lambda frame: frame.t_ms)
+    if len(selected) == 1:
+        notes.append("anchor_only_no_rising_neighbor")
+    else:
+        notes.append(f"selected_{len(selected)}_frames")
+    for frame in selected:
+        if frame is not anchor:
+            frame.selection_role = "neighbor"
+        frame.status = "selected"
+        frame.reasons = []
+    selected_ids = {id(frame) for frame in selected}
+    for frame in frames:
+        if id(frame) in selected_ids or not frame.selectable:
+            continue
+        frame.status = "rejected"
+        frame.reasons = list(
+            dict.fromkeys(
+                frame.reasons
+                + _anchor_failure_reasons(frame, config)
+                + _neighbor_failure_reasons(frame, anchor, config)
+            )
+        )
+    return selected, notes
+
+
+def _broad_high_snr_frame(
+    frame: FrameReport,
+    ball_speed_mph: float,
+    config: ReportConfig,
+) -> FrameReport:
+    """Return a frame view whose primary peak is the broad strongest in-band peak."""
+    out = replace(frame, reasons=list(frame.reasons))
+    out.selection_role = ""
+    out.status = "invalid"
+    out.peak_selectable = True
+    out.f1b_phase_rad = None
+    out.f1b_range_raw_ft = None
+    out.f1b_range_ft = None
+    out.f1b_range_unwrapped_ft = None
+    out.f1b_range_unwrap_count = 0
+    out.f1b_same_bin_snr = None
+    out.f1b_peak_bin = None
+    out.f1b_peak_bin_error = None
+
+    if (
+        frame.broad_peak_bin is None
+        or frame.broad_bin_error is None
+        or frame.broad_speed_mph is None
+        or frame.broad_snr is None
+        or frame.broad_bearing_deg is None
+    ):
+        out.peak_selectable = False
+        out.reasons = list(dict.fromkeys(out.reasons + ["no_broad_peak"]))
+        return out
+
+    out.peak_bin = frame.broad_peak_bin
+    out.peak_source = "broad_high_snr"
+    out.bin_error = frame.broad_bin_error
+    out.speed_mph = frame.broad_speed_mph
+    out.speed_error_mph = frame.broad_speed_mph - ball_speed_mph
+    out.peak_magnitude = None
+    out.snr = frame.broad_snr
+    out.snr_db = float(10.0 * math.log10(frame.broad_snr)) if frame.broad_snr > 0 else 0.0
+    out.angle_peak_deg = None
+    out.angle_centroid_deg = frame.broad_bearing_deg - config.angle_offset_deg
+    out.bearing_deg = frame.broad_bearing_deg
+    out.elevation_deg = frame.broad_bearing_deg + config.mount_deg
+    out.phase_coherence = None
+    out.peak_width_bins = None
+    out.reasons = []
+
+    if frame.broad_snr < config.neighbor_snr_min:
+        out.peak_selectable = False
+        out.reasons.append("broad_snr_too_low")
+        return out
+
+    out.status = "candidate"
+    return out
+
+
+def broad_high_snr_frames(
+    frames: list[FrameReport],
+    ball_speed_mph: float,
+    config: ReportConfig,
+) -> list[FrameReport]:
+    """Return frame rows for the older broad/high-SNR exploratory selector."""
+    return [_broad_high_snr_frame(frame, ball_speed_mph, config) for frame in frames]
+
+
+def select_high_snr_candidate_frames(
+    frames: list[FrameReport],
+    config: ReportConfig,
+) -> tuple[list[FrameReport], list[str]]:
+    """Select broad/high-SNR frames without using OPS bin error as the primary gate."""
+    notes: list[str] = []
+    for frame in frames:
+        frame.selection_role = ""
+        if frame.selectable:
+            frame.status = "candidate"
+
+    candidates = [
+        frame
+        for frame in frames
+        if frame.selectable
+        and config.neighbor_time_min_ms <= frame.t_ms <= config.neighbor_time_max_ms
+        and frame.snr is not None
+        and frame.snr >= config.neighbor_snr_min
+    ]
+    anchor_pool = [
+        frame
+        for frame in candidates
+        if config.anchor_time_min_ms <= frame.t_ms <= config.anchor_time_max_ms
+        and frame.snr is not None
+        and frame.snr >= config.anchor_snr_min
+    ]
+    if not anchor_pool:
+        notes.append("no_high_snr_anchor_frame")
+        for frame in frames:
+            if frame.selectable:
+                frame.status = "rejected"
+                frame.reasons = list(
+                    dict.fromkeys(frame.reasons + ["outside_high_snr_anchor_selection"])
+                )
+        return [], notes
+
+    anchor = sorted(
+        anchor_pool,
+        key=lambda frame: (
+            -(frame.snr or 0.0),
+            abs(frame.t_ms - (config.anchor_time_min_ms + config.anchor_time_max_ms) / 2.0),
+            frame.bin_error if frame.bin_error is not None else 99999,
+        ),
+    )[0]
+    anchor.selection_role = "anchor"
+
+    valid_pairs: list[tuple[float, FrameReport, FrameReport]] = []
+    for partner in candidates:
+        if partner is anchor:
+            continue
+        if abs(partner.frame_index - anchor.frame_index) > config.neighbor_frame_gap:
+            continue
+        first, second = (partner, anchor) if partner.t_ms < anchor.t_ms else (anchor, partner)
+        if first.bearing_deg is None or second.bearing_deg is None:
+            partner.reasons = list(dict.fromkeys(partner.reasons + ["missing_bearing"]))
+            continue
+        if second.bearing_deg < first.bearing_deg + config.min_rising_deg:
+            partner.reasons = list(dict.fromkeys(partner.reasons + ["not_rising"]))
+            continue
+        valid_pairs.append((min(first.snr or 0.0, second.snr or 0.0), first, second))
+
+    if valid_pairs:
+        _, first, second = sorted(
+            valid_pairs,
+            key=lambda item: (
+                -item[0],
+                abs(item[1].frame_index - item[2].frame_index),
+                item[1].frame_index,
+            ),
+        )[0]
+        selected = [first, second]
+        notes.append("selected_2_frames_high_snr")
+    else:
+        selected = [anchor]
+        notes.append("anchor_only_high_snr_no_rising_neighbor")
+
+    selected = sorted(selected, key=lambda frame: frame.t_ms)
+    for frame in selected:
+        if frame is not anchor:
+            frame.selection_role = "neighbor"
+        frame.status = "selected"
+        frame.reasons = []
+    selected_ids = {id(frame) for frame in selected}
+    for frame in frames:
+        if id(frame) in selected_ids or not frame.selectable:
+            continue
+        frame.status = "rejected"
+        if not frame.reasons:
+            frame.reasons = ["not_selected_by_high_snr_selector"]
+    return selected, notes
+
+
+def _range_for_fit(frame: FrameReport) -> float | None:
+    if frame.f1b_range_unwrapped_ft is not None:
+        return frame.f1b_range_unwrapped_ft
+    return frame.f1b_range_ft
+
+
+def unwrap_f1b_ranges(frames: list[FrameReport], config: ReportConfig) -> None:
+    """Add a modulo-unwrapped F1B range estimate to eligible frame rows.
+
+    RADC FSK range is phase-derived, so it is expected to wrap at the
+    unambiguous range for the active K-LD7 range setting. This is still an
+    analysis assumption: only unwrap frames that are close enough to the OPS
+    Doppler bin and have enough SNR to plausibly be the same ball target.
+    """
+    period = config.unambiguous_range_ft
+    previous_unwrapped: float | None = None
+    for frame in sorted(frames, key=lambda candidate: candidate.t_ms):
+        frame.f1b_range_unwrapped_ft = frame.f1b_range_ft
+        frame.f1b_range_unwrap_count = 0
+        if (
+            frame.f1b_range_ft is None
+            or frame.bin_error is None
+            or frame.bin_error > config.range_unwrap_bin_error_max
+            or frame.snr is None
+            or frame.snr < config.range_unwrap_snr_min
+        ):
+            continue
+
+        unwrapped = frame.f1b_range_ft
+        wraps = 0
+        if frame.t_ms >= config.anchor_time_min_ms:
+            while unwrapped < config.ball_distance_ft - config.range_unwrap_backtrack_ft:
+                unwrapped += period
+                wraps += 1
+        if previous_unwrapped is not None:
+            while unwrapped < previous_unwrapped - config.range_unwrap_backtrack_ft:
+                unwrapped += period
+                wraps += 1
+        frame.f1b_range_unwrapped_ft = unwrapped
+        frame.f1b_range_unwrap_count = wraps
+        previous_unwrapped = unwrapped
+
+
+def fit_selected_frames(
+    selected: list[FrameReport],
+    ball_speed_mph: float,
+    shift_ms: float,
+    config: ReportConfig,
+) -> FitResult:
+    per_frame = []
+    for frame in selected:
+        if frame.bearing_deg is None or frame.snr is None:
+            continue
+        t_s = (frame.t_ms + shift_ms) / 1000.0
+        per_frame.append((t_s, frame.bearing_deg, max(frame.snr * frame.snr, 1.0)))
+
+    launch_angle: float | None = None
+    bearing_rmse: float | None = None
+    method = "none"
+    if len(per_frame) >= 2:
+        geom = fit_launch_angle_geometric(
+            per_frame,
+            ball_speed_mph,
+            config.ball_distance_ft,
+            config.mount_deg,
+            config.ball_above_radar_ft,
+        )
+        if geom is not None:
+            launch_angle, bearing_rmse, _ = geom
+            method = "geometry_2plus_frame"
+    elif len(per_frame) == 1:
+        single = fit_launch_angle_single_frame_geometric(
+            per_frame[0],
+            ball_speed_mph,
+            config.ball_distance_ft,
+            config.mount_deg,
+            config.ball_above_radar_ft,
+        )
+        if single is not None:
+            launch_angle, bearing_rmse = single
+            method = "geometry_single_frame"
+
+    residuals: list[float] = []
+    if launch_angle is not None:
+        for frame in selected:
+            range_ft = _range_for_fit(frame)
+            if range_ft is None:
+                continue
+            t_s = (frame.t_ms + shift_ms) / 1000.0
+            if t_s <= 0:
+                continue
+            predicted = _predicted_range_ft(launch_angle, t_s, ball_speed_mph, config)
+            residuals.append(predicted - range_ft)
+    range_rmse = (
+        math.sqrt(sum(resid * resid for resid in residuals) / len(residuals)) if residuals else None
+    )
+    return FitResult(
+        shift_ms=round(float(shift_ms), 3),
+        launch_angle_deg=launch_angle,
+        bearing_rmse_deg=bearing_rmse,
+        range_rmse_ft=range_rmse,
+        range_residuals_ft=residuals,
+        frame_count=len(per_frame),
+        method=method,
+    )
+
+
+def apply_high_rmse_single_frame_fallback(
+    selected: list[FrameReport],
+    ball_speed_mph: float,
+    config: ReportConfig,
+    notes: list[str],
+) -> list[FrameReport]:
+    if len(selected) < 2:
+        return selected
+    nominal = fit_selected_frames(selected, ball_speed_mph, 0.0, config)
+    if (
+        nominal.bearing_rmse_deg is None
+        or nominal.bearing_rmse_deg <= GEOM_PAIR_SINGLE_FRAME_FALLBACK_RMSE_DEG
+    ):
+        return selected
+
+    strong_in_flight = [
+        frame
+        for frame in selected
+        if frame.peak_source != "ops_anchored_weak"
+        and 0.0 < frame.t_ms / 1000.0 <= GEOM_FLIGHT_T_MAX_S
+    ]
+    if not strong_in_flight:
+        notes.append("high_rmse_pair_no_single_frame_fallback")
+        return selected
+
+    single = min(
+        strong_in_flight,
+        key=lambda frame: (
+            frame.t_ms,
+            frame.bin_error if frame.bin_error is not None else 99999,
+            -(frame.snr or 0.0),
+        ),
+    )
+    notes.append(f"high_rmse_pair_fallback_to_single_frame({nominal.bearing_rmse_deg:.2f}deg)")
+    for frame in selected:
+        if frame is single:
+            frame.selection_role = "anchor"
+            frame.status = "selected"
+            frame.reasons = []
+        else:
+            frame.selection_role = ""
+            frame.status = "rejected"
+            frame.reasons = list(dict.fromkeys(frame.reasons + ["high_rmse_pair_fallback"]))
+    return [single]
+
+
+def best_range_shift_fit(
+    selected: list[FrameReport],
+    ball_speed_mph: float,
+    config: ReportConfig,
+) -> FitResult | None:
+    if not selected:
+        return None
+    step = max(config.shift_step_ms, 0.1)
+    shifts = np.arange(-config.clock_error_ms, config.clock_error_ms + step / 2.0, step)
+    fits = [fit_selected_frames(selected, ball_speed_mph, float(shift), config) for shift in shifts]
+    valid = [fit for fit in fits if fit.launch_angle_deg is not None]
+    if not valid:
+        return None
+    return min(valid, key=lambda fit: (fit.score, abs(fit.shift_ms)))
+
+
+def analyze_shot(
+    shot_number: int,
+    shot: dict[str, Any] | None,
+    buffer_entry: dict[str, Any],
+    config: ReportConfig,
+) -> tuple[ShotReport, list[FrameReport]]:
+    ball_speed = _to_float((shot or {}).get("ball_speed_mph"))
+    impact_ts, impact_source = _impact_timestamp(shot, buffer_entry)
+    logged_selection = _logged_ball_angle_selection(buffer_entry)
+    raw_frames = buffer_entry.get("frames") or []
+    if ball_speed is None or impact_ts is None:
+        report = ShotReport(
+            shot_number=shot_number,
+            ball_speed_mph=ball_speed,
+            impact_timestamp=impact_ts,
+            impact_timestamp_source=impact_source,
+            logged_launch_angle_deg=_to_float((shot or {}).get("launch_angle_vertical")),
+            logged_angle_source=(shot or {}).get("launch_angle_vertical_source"),
+            **logged_selection,
+            frame_count=len(raw_frames),
+            considered_frame_count=0,
+            selected_frame_indices=[],
+            selection_method="missing_ball_speed_or_impact_timestamp",
+            selection_notes=[],
+            nominal_fit=None,
+            best_range_fit=None,
+            minus_sensitivity_fit=None,
+            plus_sensitivity_fit=None,
+        )
+        return report, []
+
+    frames: list[FrameReport] = []
+    for frame_index, frame in enumerate(raw_frames):
+        timestamp = _to_float(frame.get("timestamp"))
+        if timestamp is None:
+            continue
+        t_ms = (timestamp - impact_ts) * 1000.0
+        if not (config.report_time_min_ms <= t_ms <= config.report_time_max_ms):
+            continue
+        frames.append(
+            extract_frame_report(
+                shot_number,
+                frame_index,
+                frame,
+                impact_ts,
+                ball_speed,
+                config,
+            )
+        )
+
+    unwrap_f1b_ranges(frames, config)
+    selected, notes = select_candidate_frames(frames, config)
+    selected = apply_high_rmse_single_frame_fallback(
+        selected,
+        ball_speed,
+        config,
+        notes,
+    )
+    nominal = fit_selected_frames(selected, ball_speed, 0.0, config) if selected else None
+    best = best_range_shift_fit(selected, ball_speed, config)
+    minus = (
+        fit_selected_frames(selected, ball_speed, -config.sensitivity_ms, config)
+        if selected
+        else None
+    )
+    plus = (
+        fit_selected_frames(selected, ball_speed, config.sensitivity_ms, config)
+        if selected
+        else None
+    )
+    method = "no_selection"
+    if selected:
+        method = "anchor_only" if len(selected) == 1 else f"{len(selected)}_frame_selection"
+    report = ShotReport(
+        shot_number=shot_number,
+        ball_speed_mph=ball_speed,
+        impact_timestamp=impact_ts,
+        impact_timestamp_source=impact_source,
+        logged_launch_angle_deg=_to_float((shot or {}).get("launch_angle_vertical")),
+        logged_angle_source=(shot or {}).get("launch_angle_vertical_source"),
+        **logged_selection,
+        frame_count=len(raw_frames),
+        considered_frame_count=len(frames),
+        selected_frame_indices=[frame.frame_index for frame in selected],
+        selection_method=method,
+        selection_notes=notes,
+        nominal_fit=nominal,
+        best_range_fit=best,
+        minus_sensitivity_fit=minus,
+        plus_sensitivity_fit=plus,
+    )
+    return report, frames
+
+
+def analyze_high_snr_variant(
+    live_report: ShotReport,
+    live_frames: list[FrameReport],
+    config: ReportConfig,
+) -> tuple[ShotReport, list[FrameReport]]:
+    if live_report.ball_speed_mph is None or live_report.impact_timestamp is None:
+        return (
+            replace(
+                live_report,
+                selected_frame_indices=[],
+                selection_method="missing_ball_speed_or_impact_timestamp",
+                selection_notes=[],
+                nominal_fit=None,
+                best_range_fit=None,
+                minus_sensitivity_fit=None,
+                plus_sensitivity_fit=None,
+            ),
+            [],
+        )
+
+    frames = broad_high_snr_frames(live_frames, live_report.ball_speed_mph, config)
+    selected, notes = select_high_snr_candidate_frames(frames, config)
+    selected = apply_high_rmse_single_frame_fallback(
+        selected,
+        live_report.ball_speed_mph,
+        config,
+        notes,
+    )
+    nominal = (
+        fit_selected_frames(selected, live_report.ball_speed_mph, 0.0, config) if selected else None
+    )
+    best = best_range_shift_fit(selected, live_report.ball_speed_mph, config)
+    minus = (
+        fit_selected_frames(
+            selected,
+            live_report.ball_speed_mph,
+            -config.sensitivity_ms,
+            config,
+        )
+        if selected
+        else None
+    )
+    plus = (
+        fit_selected_frames(
+            selected,
+            live_report.ball_speed_mph,
+            config.sensitivity_ms,
+            config,
+        )
+        if selected
+        else None
+    )
+    method = "no_selection"
+    if selected:
+        method = "anchor_only_high_snr" if len(selected) == 1 else "2_frame_high_snr"
+    return (
+        replace(
+            live_report,
+            selected_frame_indices=[frame.frame_index for frame in selected],
+            selection_method=method,
+            selection_notes=notes,
+            nominal_fit=nominal,
+            best_range_fit=best,
+            minus_sensitivity_fit=minus,
+            plus_sensitivity_fit=plus,
+        ),
+        frames,
+    )
+
+
+def _fit_dict(prefix: str, fit: FitResult | None) -> dict[str, Any]:
+    if fit is None:
+        return {
+            f"{prefix}_shift_ms": None,
+            f"{prefix}_launch_angle_deg": None,
+            f"{prefix}_bearing_rmse_deg": None,
+            f"{prefix}_range_rmse_ft": None,
+            f"{prefix}_method": None,
+        }
+    return {
+        f"{prefix}_shift_ms": fit.shift_ms,
+        f"{prefix}_launch_angle_deg": fit.launch_angle_deg,
+        f"{prefix}_bearing_rmse_deg": fit.bearing_rmse_deg,
+        f"{prefix}_range_rmse_ft": fit.range_rmse_ft,
+        f"{prefix}_method": fit.method,
+    }
+
+
+def _join_values(values: list[Any]) -> str:
+    return " ".join("" if value is None else str(value) for value in values)
+
+
+def _logged_radc_csv_value(report: ShotReport, value: Any) -> Any:
+    if report.logged_radc_selection_available:
+        return value
+    if report.logged_ball_angle_deg is not None or report.logged_ball_angle_num_frames is not None:
+        return "not_logged_in_session"
+    return ""
+
+
+def _shot_csv_row(report: ShotReport) -> dict[str, Any]:
+    logged_radc_selected_frame_indices = _join_values(report.logged_radc_selected_frame_indices)
+    logged_radc_selected_t_ms = _join_values(report.logged_radc_selected_t_ms)
+    logged_radc_selected_bin_errors = _join_values(report.logged_radc_selected_bin_errors)
+    row: dict[str, Any] = {
+        "shot_number": report.shot_number,
+        "ball_speed_mph": report.ball_speed_mph,
+        "logged_launch_angle_deg": report.logged_launch_angle_deg,
+        "logged_angle_source": report.logged_angle_source,
+        "logged_ball_angle_deg": report.logged_ball_angle_deg,
+        "logged_ball_angle_confidence": report.logged_ball_angle_confidence,
+        "logged_ball_angle_accepted": report.logged_ball_angle_accepted,
+        "logged_ball_angle_selection_reason": report.logged_ball_angle_selection_reason,
+        "logged_ball_angle_num_frames": report.logged_ball_angle_num_frames,
+        "logged_radc_selection_available": report.logged_radc_selection_available,
+        "logged_radc_estimator": _logged_radc_csv_value(report, report.logged_radc_estimator),
+        "logged_radc_selection_path": _logged_radc_csv_value(
+            report, report.logged_radc_selection_path
+        ),
+        "logged_radc_selected_frame_indices": _logged_radc_csv_value(
+            report, logged_radc_selected_frame_indices
+        ),
+        "logged_radc_selected_t_ms": _logged_radc_csv_value(report, logged_radc_selected_t_ms),
+        "logged_radc_selected_bin_errors": _logged_radc_csv_value(
+            report, logged_radc_selected_bin_errors
+        ),
+        "logged_radc_fit_rmse_deg": _logged_radc_csv_value(report, report.logged_radc_fit_rmse_deg),
+        "impact_timestamp_source": report.impact_timestamp_source,
+        "frame_count": report.frame_count,
+        "considered_frame_count": report.considered_frame_count,
+        "selected_frame_indices": " ".join(map(str, report.selected_frame_indices)),
+        "selection_method": report.selection_method,
+        "selection_notes": ";".join(report.selection_notes),
+    }
+    row.update(_fit_dict("nominal", report.nominal_fit))
+    row.update(_fit_dict("range_best", report.best_range_fit))
+    row.update(_fit_dict("minus_10ms", report.minus_sensitivity_fit))
+    row.update(_fit_dict("plus_10ms", report.plus_sensitivity_fit))
+    return row
+
+
+def _frame_csv_row(frame: FrameReport) -> dict[str, Any]:
+    row = asdict(frame)
+    row["reasons"] = ";".join(frame.reasons)
+    return row
+
+
+def _fieldnames_for_rows(rows: list[dict[str, Any]]) -> list[str]:
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    return fieldnames
+
+
+def _write_csv(
+    path: Path,
+    rows: list[dict[str, Any]],
+    *,
+    fieldnames: list[str] | None = None,
+) -> None:
+    if fieldnames is None:
+        fieldnames = _fieldnames_for_rows(rows)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_reports(
+    session_path: Path,
+    output_dir: Path,
+    config: ReportConfig,
+    shot_reports: list[ShotReport],
+    frame_reports: list[FrameReport],
+    live_shot_reports: list[ShotReport],
+    live_frame_reports: list[FrameReport],
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    config_path = output_dir / "config.json"
+    config_path.write_text(json.dumps(asdict(config), indent=2, sort_keys=True) + "\n")
+    _write_csv(output_dir / "shots.csv", [_shot_csv_row(report) for report in shot_reports])
+    _write_csv(output_dir / "frames.csv", [_frame_csv_row(frame) for frame in frame_reports])
+    _write_csv(
+        output_dir / "shots_live.csv",
+        [_shot_csv_row(report) for report in live_shot_reports],
+    )
+    _write_csv(
+        output_dir / "frames_live.csv",
+        [_frame_csv_row(frame) for frame in live_frame_reports],
+    )
+
+    lines = [
+        f"# K-LD7 Geometry Selection Report: `{session_path.name}`",
+        "",
+        "Generated files: `shots.csv`, `frames.csv`, `shots_live.csv`, "
+        "`frames_live.csv`, `config.json`.",
+        "",
+        "`frames.csv`/`shots.csv` use the broad/high-SNR exploratory selector. "
+        "`frames_live.csv`/`shots_live.csv` use the current OPS-bin/live-style replay.",
+        "",
+        "`Logged KLD7 frames` is populated only for sessions that recorded "
+        "`ball_angle.radc_selection.selected_frame_indices`; older sessions keep "
+        "the logged KLD7 angle and frame count but not exact frame IDs.",
+        "",
+        "| Shot | Ball mph | Logged KLD7 | Logged KLD7 frames | Replay selected | Method | Nominal | Range-best | Notes |",
+        "|---:|---:|---:|---|---|---|---:|---:|---|",
+    ]
+    for report in shot_reports:
+        logged_kld7 = _format_float(report.logged_ball_angle_deg, 1)
+        if logged_kld7 and report.logged_ball_angle_num_frames is not None:
+            logged_kld7 = f"{logged_kld7} ({report.logged_ball_angle_num_frames}f)"
+        elif report.logged_ball_angle_num_frames is not None:
+            logged_kld7 = f"({report.logged_ball_angle_num_frames}f)"
+        logged_frames = _join_values(report.logged_radc_selected_frame_indices)
+        if not logged_frames and report.logged_ball_angle_num_frames is not None:
+            logged_frames = "not logged"
+        nominal = _format_float(
+            report.nominal_fit.launch_angle_deg if report.nominal_fit else None,
+            1,
+        )
+        best = _format_float(
+            report.best_range_fit.launch_angle_deg if report.best_range_fit else None,
+            1,
+        )
+        best_shift = f" @ {report.best_range_fit.shift_ms:+.0f}ms" if report.best_range_fit else ""
+        lines.append(
+            "| "
+            f"{report.shot_number} | "
+            f"{_format_float(report.ball_speed_mph, 1)} | "
+            f"{logged_kld7} | "
+            f"{logged_frames} | "
+            f"{' '.join(map(str, report.selected_frame_indices))} | "
+            f"{report.selection_method} | "
+            f"{nominal} | "
+            f"{best}{best_shift} | "
+            f"{'; '.join(report.selection_notes)} |"
+        )
+    (output_dir / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def analyze_session(
+    session_path: Path,
+    config: ReportConfig,
+) -> tuple[list[ShotReport], list[FrameReport], list[ShotReport], list[FrameReport]]:
+    if not session_path.exists():
+        raise ValueError(f"Session file not found: {session_path}")
+    shots, buffers = _load_session_rows(session_path)
+    shot_reports: list[ShotReport] = []
+    frame_reports: list[FrameReport] = []
+    live_shot_reports: list[ShotReport] = []
+    live_frame_reports: list[FrameReport] = []
+    for shot_number in sorted(set(shots) | {key[0] for key in buffers}):
+        buffer_entry = buffers.get((shot_number, config.orientation))
+        if buffer_entry is None:
+            continue
+        live_shot_report, live_frames = analyze_shot(
+            shot_number,
+            shots.get(shot_number),
+            buffer_entry,
+            config,
+        )
+        shot_report, frames = analyze_high_snr_variant(
+            live_shot_report,
+            live_frames,
+            config,
+        )
+        shot_reports.append(shot_report)
+        frame_reports.extend(frames)
+        live_shot_reports.append(live_shot_report)
+        live_frame_reports.extend(live_frames)
+    if not shot_reports:
+        raise ValueError(
+            f"{session_path} has no {config.orientation!r} kld7_buffer rows to analyze"
+        )
+    return shot_reports, frame_reports, live_shot_reports, live_frame_reports
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build an offline K-LD7 RADC frame-selection and geometry report."
+    )
+    parser.add_argument("session", type=Path, help="OpenFlight session JSONL path")
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--orientation", default="vertical", choices=["vertical", "horizontal"])
+    parser.add_argument("--ball-distance-ft", type=float, default=5.0)
+    parser.add_argument("--mount-deg", type=float, default=10.0)
+    parser.add_argument("--angle-offset-deg", type=float, default=2.5)
+    parser.add_argument("--ball-above-radar-ft", type=float, default=GEOM_BALL_ABOVE_RADAR_FT)
+    parser.add_argument("--speed-tolerance-mph", type=float, default=25.0)
+    parser.add_argument("--spectrum-source", default="f1a")
+    parser.add_argument("--dc-mask-bins", type=int, default=8)
+    parser.add_argument("--centroid-floor-frac", type=float, default=0.5)
+    parser.add_argument("--report-time-min-ms", type=float, default=-80.0)
+    parser.add_argument("--report-time-max-ms", type=float, default=170.0)
+    parser.add_argument("--report-bin-error-max", type=int, default=220)
+    parser.add_argument("--ops-bin-outlier-tol", type=int, default=25)
+    parser.add_argument(
+        "--ops-anchored-peak-min-snr", type=float, default=OPS_ANCHORED_PEAK_MIN_SNR
+    )
+    parser.add_argument("--anchor-time-min-ms", type=float, default=20.0)
+    parser.add_argument("--anchor-time-max-ms", type=float, default=100.0)
+    parser.add_argument("--anchor-snr-min", type=float, default=5.0)
+    parser.add_argument("--anchor-bin-error-max", type=int, default=50)
+    parser.add_argument("--neighbor-time-min-ms", type=float, default=0.0)
+    parser.add_argument("--neighbor-time-max-ms", type=float, default=125.0)
+    parser.add_argument("--neighbor-snr-min", type=float, default=3.0)
+    parser.add_argument("--neighbor-bin-error-max", type=int, default=80)
+    parser.add_argument("--early-neighbor-time-max-ms", type=float, default=20.0)
+    parser.add_argument("--early-neighbor-bin-error-max", type=int, default=175)
+    parser.add_argument("--neighbor-frame-gap", type=int, default=2)
+    parser.add_argument("--min-rising-deg", type=float, default=0.0)
+    parser.add_argument("--max-selected-frames", type=int, default=2)
+    parser.add_argument("--clock-error-ms", type=float, default=20.0)
+    parser.add_argument("--shift-step-ms", type=float, default=1.0)
+    parser.add_argument("--sensitivity-ms", type=float, default=10.0)
+    parser.add_argument("--kld7-range-m", type=float, default=5.0)
+    parser.add_argument("--f1b-range-bias-ft", type=float, default=0.0)
+    parser.add_argument(
+        "--f1b-phase-mode",
+        choices=["f1b_minus_f1a", "f1a_minus_f1b"],
+        default="f1b_minus_f1a",
+    )
+    parser.add_argument("--range-unwrap-bin-error-max", type=int, default=80)
+    parser.add_argument("--range-unwrap-snr-min", type=float, default=3.0)
+    parser.add_argument("--range-unwrap-backtrack-ft", type=float, default=0.75)
+    return parser
+
+
+def config_from_args(args: argparse.Namespace) -> ReportConfig:
+    return ReportConfig(
+        orientation=args.orientation,
+        ball_distance_ft=args.ball_distance_ft,
+        mount_deg=args.mount_deg,
+        angle_offset_deg=args.angle_offset_deg,
+        ball_above_radar_ft=args.ball_above_radar_ft,
+        speed_tolerance_mph=args.speed_tolerance_mph,
+        spectrum_source=args.spectrum_source,
+        dc_mask_bins=args.dc_mask_bins,
+        centroid_floor_frac=args.centroid_floor_frac,
+        report_time_min_ms=args.report_time_min_ms,
+        report_time_max_ms=args.report_time_max_ms,
+        report_bin_error_max=args.report_bin_error_max,
+        ops_bin_outlier_tol=args.ops_bin_outlier_tol,
+        ops_anchored_peak_min_snr=args.ops_anchored_peak_min_snr,
+        anchor_time_min_ms=args.anchor_time_min_ms,
+        anchor_time_max_ms=args.anchor_time_max_ms,
+        anchor_snr_min=args.anchor_snr_min,
+        anchor_bin_error_max=args.anchor_bin_error_max,
+        neighbor_time_min_ms=args.neighbor_time_min_ms,
+        neighbor_time_max_ms=args.neighbor_time_max_ms,
+        neighbor_snr_min=args.neighbor_snr_min,
+        neighbor_bin_error_max=args.neighbor_bin_error_max,
+        early_neighbor_time_max_ms=args.early_neighbor_time_max_ms,
+        early_neighbor_bin_error_max=args.early_neighbor_bin_error_max,
+        neighbor_frame_gap=args.neighbor_frame_gap,
+        min_rising_deg=args.min_rising_deg,
+        max_selected_frames=args.max_selected_frames,
+        clock_error_ms=args.clock_error_ms,
+        shift_step_ms=args.shift_step_ms,
+        sensitivity_ms=args.sensitivity_ms,
+        kld7_range_m=args.kld7_range_m,
+        f1b_range_bias_ft=args.f1b_range_bias_ft,
+        f1b_phase_mode=args.f1b_phase_mode,
+        range_unwrap_bin_error_max=args.range_unwrap_bin_error_max,
+        range_unwrap_snr_min=args.range_unwrap_snr_min,
+        range_unwrap_backtrack_ft=args.range_unwrap_backtrack_ft,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    config = config_from_args(args)
+    output_dir = args.output_dir or (
+        args.session.parent / f"{args.session.stem}_kld7_geometry_report"
+    )
+    shot_reports, frame_reports, live_shot_reports, live_frame_reports = analyze_session(
+        args.session,
+        config,
+    )
+    write_reports(
+        args.session,
+        output_dir,
+        config,
+        shot_reports,
+        frame_reports,
+        live_shot_reports,
+        live_frame_reports,
+    )
+    selected = sum(1 for report in shot_reports if report.selected_frame_indices)
+    multi = sum(1 for report in shot_reports if len(report.selected_frame_indices) >= 2)
+    live_selected = sum(1 for report in live_shot_reports if report.selected_frame_indices)
+    live_multi = sum(1 for report in live_shot_reports if len(report.selected_frame_indices) >= 2)
+    print(
+        f"Analyzed {len(shot_reports)} shots "
+        f"(high-SNR: {selected} selected, {multi} with 2+ frames; "
+        f"live-style: {live_selected} selected, {live_multi} with 2+ frames)"
+    )
+    print(f"Report written to: {output_dir}")
+    print(f"Summary: {output_dir / 'summary.md'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analysis/kld7_live_sync.py
+++ b/scripts/analysis/kld7_live_sync.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python
+"""Live-sync K-LD7 frame reports from a Pi session log.
+
+The Pi should stay focused on kiosk capture. This helper runs on the Mac,
+polls the Pi over SSH for the newest session log, SCPs it only when the shot
+count changes, regenerates the K-LD7 geometry report locally, and optionally
+serves the report directory for the timing visualizer's auto-reload mode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPORT_SCRIPT = REPO_ROOT / "scripts" / "analysis" / "kld7_geometry_selection_report.py"
+VISUALIZER = REPO_ROOT / "scripts" / "analysis" / "kld7_timing_shift_visualizer.html"
+
+
+def _run(command: list[str], *, timeout: float | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+    )
+
+
+def _remote_latest_session(pi_host: str, session_dir: str, connect_timeout: int) -> dict[str, str]:
+    remote_cmd = (
+        "set -e; "
+        f"latest=$(ls -t {session_dir.rstrip('/')}/session_*.jsonl 2>/dev/null | head -n 1); "
+        'if [ -z "$latest" ]; then exit 2; fi; '
+        'shots=$(grep -c \'"type": "shot_detected"\' "$latest" || true); '
+        'size=$(stat -c %s "$latest" 2>/dev/null || wc -c < "$latest"); '
+        'mtime=$(stat -c %Y "$latest" 2>/dev/null || echo 0); '
+        'printf "%s\\t%s\\t%s\\t%s\\n" "$latest" "$shots" "$size" "$mtime"'
+    )
+    result = _run(
+        ["ssh", "-o", f"ConnectTimeout={connect_timeout}", pi_host, remote_cmd],
+        timeout=max(connect_timeout + 5, 10),
+    )
+    parts = result.stdout.strip().split("\t")
+    if len(parts) != 4:
+        raise RuntimeError(f"Unexpected SSH response: {result.stdout!r}")
+    return {
+        "remote_path": parts[0],
+        "shot_count": parts[1],
+        "size": parts[2],
+        "mtime": parts[3],
+    }
+
+
+def _scp_session(pi_host: str, remote_path: str, local_path: Path) -> None:
+    tmp_path = local_path.with_suffix(local_path.suffix + ".tmp")
+    if tmp_path.exists():
+        tmp_path.unlink()
+    _run(["scp", f"{pi_host}:{remote_path}", str(tmp_path)])
+    tmp_path.replace(local_path)
+
+
+def _copy_visualizer(output_dir: Path) -> None:
+    if VISUALIZER.exists():
+        shutil.copy2(VISUALIZER, output_dir / "index.html")
+
+
+def _run_report(args: argparse.Namespace, session_path: Path, output_dir: Path) -> None:
+    command = [
+        sys.executable,
+        str(REPORT_SCRIPT),
+        str(session_path),
+        "--output-dir",
+        str(output_dir),
+        "--orientation",
+        args.orientation,
+        "--ball-distance-ft",
+        str(args.ball_distance_ft),
+        "--mount-deg",
+        str(args.mount_deg),
+        "--angle-offset-deg",
+        str(args.angle_offset_deg),
+        "--ball-above-radar-ft",
+        str(args.ball_above_radar_ft),
+    ]
+    if args.report_arg:
+        command.extend(args.report_arg)
+    _run(command)
+
+
+def _write_state(
+    output_dir: Path,
+    *,
+    pi_host: str,
+    remote_info: dict[str, str],
+    local_session: Path,
+    report_started_at: float,
+) -> None:
+    state = {
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "report_seconds": round(time.time() - report_started_at, 3),
+        "pi_host": pi_host,
+        "remote_session": remote_info["remote_path"],
+        "local_session": str(local_session),
+        "shot_count": int(remote_info["shot_count"]),
+        "remote_size_bytes": int(remote_info["size"]),
+        "remote_mtime": int(remote_info["mtime"]),
+        "frames_live_csv": "frames_live.csv",
+        "shots_live_csv": "shots_live.csv",
+    }
+    (output_dir / "state.json").write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+
+def _serve_directory(output_dir: Path, port: int) -> ThreadingHTTPServer:
+    handler = partial(SimpleHTTPRequestHandler, directory=str(output_dir))
+    server = ThreadingHTTPServer(("127.0.0.1", port), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def sync_once(
+    args: argparse.Namespace, last_key: tuple[str, str, str] | None
+) -> tuple[str, str, str] | None:
+    remote_info = _remote_latest_session(args.pi_host, args.session_dir, args.connect_timeout)
+    key = (remote_info["remote_path"], remote_info["shot_count"], remote_info["size"])
+    shot_count = int(remote_info["shot_count"])
+
+    if shot_count <= 0:
+        print(
+            f"[live-sync] Latest session has no shots yet: {remote_info['remote_path']}",
+            flush=True,
+        )
+        return key
+
+    if key == last_key:
+        return last_key
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    local_session = args.output_dir / Path(remote_info["remote_path"]).name
+    latest_session = args.output_dir / "latest_session.jsonl"
+
+    print(
+        f"[live-sync] Pulling shot_count={shot_count} size={int(remote_info['size']) / 1_000_000:.1f}MB "
+        f"from {remote_info['remote_path']}",
+        flush=True,
+    )
+    report_started_at = time.time()
+    _scp_session(args.pi_host, remote_info["remote_path"], local_session)
+    shutil.copy2(local_session, latest_session)
+    _run_report(args, latest_session, args.output_dir)
+    _copy_visualizer(args.output_dir)
+    _write_state(
+        args.output_dir,
+        pi_host=args.pi_host,
+        remote_info=remote_info,
+        local_session=latest_session,
+        report_started_at=report_started_at,
+    )
+    print(
+        f"[live-sync] Updated {args.output_dir / 'frames_live.csv'} "
+        f"({time.time() - report_started_at:.1f}s)",
+        flush=True,
+    )
+    return key
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="SCP the latest Pi session and regenerate live K-LD7 frame CSVs."
+    )
+    parser.add_argument(
+        "--pi-host",
+        required=True,
+        help="SSH destination for the Pi, for example openflight@openflight.local.",
+    )
+    parser.add_argument("--session-dir", default="~/openflight_sessions")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path.home() / "openflight_sessions" / "live_kld7_report",
+    )
+    parser.add_argument("--interval", type=float, default=2.0)
+    parser.add_argument("--connect-timeout", type=int, default=8)
+    parser.add_argument("--once", action="store_true", help="Run one sync check and exit.")
+    parser.add_argument("--serve-port", type=int, default=8765)
+    parser.add_argument("--no-serve", action="store_true")
+    parser.add_argument("--orientation", default="vertical", choices=["vertical", "horizontal"])
+    parser.add_argument("--ball-distance-ft", type=float, default=5.0)
+    parser.add_argument("--mount-deg", type=float, default=10.0)
+    parser.add_argument("--angle-offset-deg", type=float, default=0.0)
+    parser.add_argument("--ball-above-radar-ft", type=float, default=-4.0 / 12.0)
+    parser.add_argument(
+        "--report-arg",
+        action="append",
+        default=[],
+        help="Extra argument passed through to kld7_geometry_selection_report.py. Repeat as needed.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_arg_parser().parse_args()
+    args.output_dir = args.output_dir.expanduser().resolve()
+
+    server = None
+    if not args.no_serve:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        _copy_visualizer(args.output_dir)
+        server = _serve_directory(args.output_dir, args.serve_port)
+        print(
+            "[live-sync] Visualizer: "
+            f"http://127.0.0.1:{args.serve_port}/index.html?csv=frames_live.csv&auto=1",
+            flush=True,
+        )
+
+    last_key = None
+    try:
+        while True:
+            try:
+                last_key = sync_once(args, last_key)
+            except subprocess.CalledProcessError as error:
+                message = error.stderr.strip() or error.stdout.strip() or str(error)
+                print(f"[live-sync] Command failed: {message}", file=sys.stderr, flush=True)
+            except Exception as error:
+                print(f"[live-sync] {error}", file=sys.stderr, flush=True)
+
+            if args.once:
+                break
+            time.sleep(max(args.interval, 0.5))
+    finally:
+        if server:
+            server.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analysis/kld7_timing_shift_visualizer.html
+++ b/scripts/analysis/kld7_timing_shift_visualizer.html
@@ -1,0 +1,1602 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>K-LD7 Timing Shift Visualizer</title>
+  <style>
+    :root {
+      --bg: #f5f7fb;
+      --panel: #ffffff;
+      --line: #d7dce5;
+      --text: #172033;
+      --muted: #5e6a7d;
+      --blue: #1d4ed8;
+      --cyan: #0786a8;
+      --violet: #7c3aed;
+      --red: #dc2626;
+      --green: #047857;
+      --orange: #b45309;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    .app {
+      display: grid;
+      grid-template-columns: 360px minmax(0, 1fr);
+      min-height: 100vh;
+    }
+
+    aside {
+      background: var(--panel);
+      border-right: 1px solid var(--line);
+      padding: 18px;
+      overflow: auto;
+    }
+
+    main {
+      min-width: 0;
+      padding: 18px;
+      display: grid;
+      grid-template-rows: auto minmax(360px, 1fr) auto;
+      gap: 12px;
+    }
+
+    h1 {
+      margin: 0 0 14px;
+      font-size: 18px;
+      line-height: 1.25;
+    }
+
+    h2 {
+      margin: 18px 0 8px;
+      font-size: 12px;
+      color: var(--muted);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 9px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    input,
+    select {
+      width: 100%;
+      margin-top: 4px;
+      padding: 8px 9px;
+      border: 1px solid #cfd6e2;
+      border-radius: 6px;
+      color: var(--text);
+      background: #fff;
+      font: inherit;
+      font-size: 13px;
+    }
+
+    input[type="file"] {
+      padding: 7px;
+    }
+
+    .data-status {
+      min-height: 18px;
+      margin: 5px 0 0;
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.35;
+    }
+
+    .frame-list {
+      display: grid;
+      gap: 6px;
+      max-height: 230px;
+      overflow: auto;
+      padding-right: 2px;
+    }
+
+    .frame-row {
+      display: grid;
+      grid-template-columns: 42px 1fr;
+      gap: 8px;
+      height: auto;
+      padding: 8px;
+      border-radius: 7px;
+      text-align: left;
+      font-weight: 600;
+    }
+
+    .frame-row span {
+      display: block;
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 500;
+      line-height: 1.35;
+    }
+
+    .frame-row.selected {
+      border-color: #60a5fa;
+      background: #eff6ff;
+    }
+
+    .frame-row.locked {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    .grid2 {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+    }
+
+    .frame-box {
+      padding: 10px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fbfcff;
+    }
+
+    .graph-shift {
+      position: absolute;
+      top: 12px;
+      left: 12px;
+      z-index: 4;
+      display: grid;
+      grid-template-columns: 34px 72px 34px;
+      gap: 6px;
+      align-items: end;
+      padding: 7px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: rgba(255, 255, 255, 0.95);
+      box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+    }
+
+    .graph-shift label {
+      margin: 0;
+      font-size: 10px;
+      line-height: 1.1;
+      text-align: center;
+    }
+
+    .graph-shift input {
+      margin-top: 3px;
+      padding: 5px 6px;
+      font-size: 12px;
+      text-align: center;
+    }
+
+    .graph-shift button {
+      height: 30px;
+      border-radius: 6px;
+    }
+
+    .range-toggle {
+      grid-column: 1 / -1;
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      margin: 0;
+      padding-top: 2px;
+      color: var(--muted);
+      font-size: 11px;
+      line-height: 1;
+      text-align: left;
+    }
+
+    .range-toggle input {
+      width: auto;
+      margin: 0;
+    }
+
+    .inline-toggle {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      margin: 6px 0 0;
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.2;
+    }
+
+    .inline-toggle input {
+      width: auto;
+      margin: 0;
+    }
+
+    button {
+      height: 36px;
+      border: 1px solid #cfd6e2;
+      border-radius: 7px;
+      background: #fff;
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    button:hover {
+      background: #eef4ff;
+      border-color: #9ebcff;
+    }
+
+    .toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      width: 100%;
+    }
+
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 10px;
+      width: 100%;
+    }
+
+    .metric {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 10px 12px;
+    }
+
+    .metric.primary-result {
+      border: 2px solid var(--blue);
+      background: #eff6ff;
+      box-shadow: 0 8px 22px rgba(29, 78, 216, 0.16);
+    }
+
+    .metric.primary-result .label {
+      color: var(--blue);
+      font-weight: 800;
+    }
+
+    .metric.primary-result .value {
+      color: var(--blue);
+    }
+
+    .metric .label {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 11px;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .legend {
+      flex: 0 0 auto;
+      display: inline-block;
+    }
+
+    .legend-line {
+      width: 24px;
+      height: 0;
+      border-top: 3px solid currentColor;
+    }
+
+    .legend-dashed {
+      border-top-style: dashed;
+    }
+
+    .legend-dot {
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      background: currentColor;
+    }
+
+    .legend-diamond {
+      width: 10px;
+      height: 10px;
+      border: 2px solid currentColor;
+      background: #fff7ed;
+      transform: rotate(45deg);
+    }
+
+    .legend-red {
+      color: var(--red);
+    }
+
+    .legend-green {
+      color: var(--green);
+    }
+
+    .legend-orange {
+      color: var(--orange);
+    }
+
+    .legend-violet {
+      color: var(--violet);
+    }
+
+    .legend-cyan {
+      color: var(--cyan);
+    }
+
+    .legend-pair {
+      display: inline-flex;
+      gap: 4px;
+      align-items: center;
+    }
+
+    .metric .value {
+      margin-top: 3px;
+      font-size: 18px;
+      font-weight: 800;
+      line-height: 1.2;
+    }
+
+    .metric .sub {
+      margin-top: 4px;
+      font-size: 12px;
+      color: var(--muted);
+      line-height: 1.3;
+    }
+
+    .canvas-wrap {
+      position: relative;
+      min-height: 360px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    canvas {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
+    .status {
+      padding: 9px 12px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fff;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.35;
+    }
+
+    .status strong {
+      color: var(--text);
+    }
+
+    @media (max-width: 900px) {
+      .app {
+        grid-template-columns: 1fr;
+      }
+
+      aside {
+        border-right: 0;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .metrics {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <aside>
+      <h1>K-LD7 Timing Shift Visualizer</h1>
+
+      <h2>Data</h2>
+      <label>
+        Upload frames.csv
+        <input id="csvFile" type="file" accept=".csv,text/csv">
+      </label>
+      <label>
+        Auto CSV URL
+        <input id="csvUrl" type="text" placeholder="frames_live.csv">
+      </label>
+      <div class="grid2">
+        <button id="loadCsvUrl" type="button">Load URL</button>
+        <button id="reloadCsvUrl" type="button">Reload</button>
+      </div>
+      <label class="inline-toggle">
+        <input id="autoReloadCsv" type="checkbox">
+        Auto reload latest shot
+      </label>
+      <label>
+        Shot
+        <select id="shotSelect" disabled>
+          <option value="">Upload a frames.csv first</option>
+        </select>
+      </label>
+      <div id="frameList" class="frame-list"></div>
+      <div id="csvStatus" class="data-status">Select up to two frames. One selected frame loads as frame 2.</div>
+
+      <h2>Shot</h2>
+      <div class="grid2">
+        <label>
+          Ball speed mph
+          <input id="ballSpeed" type="number" step="0.1" value="108.3">
+        </label>
+        <label>
+          Ball distance ft
+          <input id="ballDistance" type="number" step="0.1" value="5">
+        </label>
+      </div>
+      <div class="grid2">
+        <label>
+          Net from ball ft
+          <input id="netDistance" type="number" step="0.1" value="10">
+        </label>
+        <label>
+          Mount tilt deg
+          <input id="mountTilt" type="number" step="0.1" value="10">
+        </label>
+      </div>
+      <label>
+        Angle offset deg
+        <input id="angleOffset" type="number" step="0.1" value="2.5">
+      </label>
+      <label>
+        Ball vertical offset ft
+        <input id="ballOffset" type="number" step="0.01" value="-0.333">
+      </label>
+
+      <h2>Frame 1</h2>
+      <div class="frame-box">
+        <div class="grid2">
+          <label>
+            Frame #
+            <input id="frame1Index" type="number" step="1" value="38">
+          </label>
+          <label>
+            Time ms
+            <input id="frame1Time" type="number" step="0.1" value="15.8">
+          </label>
+        </div>
+        <label>
+          Bearing deg
+          <input id="frame1Bearing" type="number" step="0.1" value="-1.1">
+        </label>
+        <label>
+          SNR
+          <input id="frame1Snr" type="number" step="0.1" value="1">
+        </label>
+        <div class="grid2">
+          <label>
+            F1B range ft
+            <input id="frame1Range" type="number" step="0.01">
+          </label>
+          <label>
+            F1B unwrap ft
+            <input id="frame1RangeUnwrapped" type="number" step="0.01">
+          </label>
+        </div>
+        <label>
+          F1B bin error
+          <input id="frame1RangeBinError" type="number" step="1">
+        </label>
+      </div>
+
+      <h2>Frame 2</h2>
+      <div class="frame-box">
+        <div class="grid2">
+          <label>
+            Frame #
+            <input id="frame2Index" type="number" step="1" value="39">
+          </label>
+          <label>
+            Time ms
+            <input id="frame2Time" type="number" step="0.1" value="49.8">
+          </label>
+        </div>
+        <label>
+          Bearing deg
+          <input id="frame2Bearing" type="number" step="0.1" value="5.1">
+        </label>
+        <label>
+          SNR
+          <input id="frame2Snr" type="number" step="0.1" value="1">
+        </label>
+        <div class="grid2">
+          <label>
+            F1B range ft
+            <input id="frame2Range" type="number" step="0.01">
+          </label>
+          <label>
+            F1B unwrap ft
+            <input id="frame2RangeUnwrapped" type="number" step="0.01">
+          </label>
+        </div>
+        <label>
+          F1B bin error
+          <input id="frame2RangeBinError" type="number" step="1">
+        </label>
+      </div>
+
+    </aside>
+
+    <main>
+      <div class="toolbar">
+        <div class="metrics">
+          <div class="metric">
+            <div class="label"><span class="legend legend-line legend-red"></span>Launch From Ball To Frame 2</div>
+            <div id="launchMetric" class="value">-</div>
+            <div id="launchSub" class="sub">-</div>
+          </div>
+          <div class="metric">
+            <div class="label"><span class="legend legend-line legend-dashed legend-green"></span>Free-Start 2-Frame Line</div>
+            <div id="nominalMetric" class="value">-</div>
+            <div id="nominalSub" class="sub">-</div>
+          </div>
+          <div class="metric primary-result">
+            <div class="label">New Launch Angle</div>
+            <div id="geometryMetric" class="value">-</div>
+            <div id="geometrySub" class="sub">-</div>
+          </div>
+          <div class="metric">
+            <div class="label">Start Position Error</div>
+            <div id="startErrorMetric" class="value">-</div>
+            <div id="startErrorSub" class="sub">-</div>
+          </div>
+          <div class="metric">
+            <div class="label"><span class="legend legend-line legend-dashed legend-orange"></span>Frame 1 Miss</div>
+            <div id="missMetric" class="value">-</div>
+            <div id="missSub" class="sub">-</div>
+          </div>
+          <div class="metric">
+            <div class="label">Corrected Times</div>
+            <div id="timesMetric" class="value">-</div>
+            <div id="timesSub" class="sub">-</div>
+          </div>
+          <div class="metric">
+            <div class="label">
+              <span class="legend-pair">
+                <span class="legend legend-dot legend-violet"></span>
+                <span class="legend legend-dot legend-cyan"></span>
+              </span>
+              Frame Distances
+            </div>
+            <div id="distanceMetric" class="value">-</div>
+            <div id="distanceSub" class="sub">-</div>
+          </div>
+          <div class="metric">
+            <div class="label"><span class="legend legend-diamond legend-orange"></span>F1B Ranges</div>
+            <div id="rangeMetric" class="value">-</div>
+            <div id="rangeSub" class="sub">-</div>
+          </div>
+          <div class="metric">
+            <div class="label"><span class="legend legend-line legend-dashed legend-orange"></span>Range Delta</div>
+            <div id="rangeDeltaMetric" class="value">-</div>
+            <div id="rangeDeltaSub" class="sub">-</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="canvas-wrap">
+        <div id="graphShift" class="graph-shift">
+          <button id="minus" type="button">-</button>
+          <label>
+            Shift ms
+            <input id="shiftMs" type="number" step="1" value="0">
+          </label>
+          <button id="plus" type="button">+</button>
+          <label class="range-toggle">
+            <input id="showRange" type="checkbox" checked>
+            Range overlay
+          </label>
+        </div>
+        <canvas id="viz"></canvas>
+      </div>
+
+      <div id="status" class="status"></div>
+    </main>
+  </div>
+
+  <script>
+    const MPH_TO_FPS = 1.46667;
+    const ids = [
+      "ballSpeed",
+      "ballDistance",
+      "netDistance",
+      "mountTilt",
+      "angleOffset",
+      "ballOffset",
+      "frame1Index",
+      "frame1Time",
+      "frame1Bearing",
+      "frame1Snr",
+      "frame1Range",
+      "frame1RangeUnwrapped",
+      "frame1RangeBinError",
+      "frame2Index",
+      "frame2Time",
+      "frame2Bearing",
+      "frame2Snr",
+      "frame2Range",
+      "frame2RangeUnwrapped",
+      "frame2RangeBinError",
+      "shiftMs",
+    ];
+    const inputs = Object.fromEntries(ids.map((id) => [id, document.getElementById(id)]));
+    const canvas = document.getElementById("viz");
+    const ctx = canvas.getContext("2d");
+    const csvFile = document.getElementById("csvFile");
+    const csvUrl = document.getElementById("csvUrl");
+    const loadCsvUrl = document.getElementById("loadCsvUrl");
+    const reloadCsvUrl = document.getElementById("reloadCsvUrl");
+    const autoReloadCsv = document.getElementById("autoReloadCsv");
+    const shotSelect = document.getElementById("shotSelect");
+    const frameList = document.getElementById("frameList");
+    const csvStatus = document.getElementById("csvStatus");
+    const showRange = document.getElementById("showRange");
+    let framesByShot = new Map();
+    let selectedFrameKeys = [];
+    let latestCsvText = "";
+    let autoReloadTimer = null;
+
+    function value(id) {
+      const parsed = Number(inputs[id].value);
+      return Number.isFinite(parsed) ? parsed : 0;
+    }
+
+    function optionalValue(id) {
+      const raw = inputs[id].value.trim();
+      if (raw === "") return null;
+      const parsed = Number(raw);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    function degToRad(deg) {
+      return (deg * Math.PI) / 180;
+    }
+
+    function radToDeg(rad) {
+      return (rad * 180) / Math.PI;
+    }
+
+    function fmt(value, digits = 1) {
+      return Number.isFinite(value) ? value.toFixed(digits) : "-";
+    }
+
+    function parseCsv(text) {
+      const rows = [];
+      let row = [];
+      let cell = "";
+      let inQuotes = false;
+      for (let i = 0; i < text.length; i += 1) {
+        const char = text[i];
+        const next = text[i + 1];
+        if (char === '"') {
+          if (inQuotes && next === '"') {
+            cell += '"';
+            i += 1;
+          } else {
+            inQuotes = !inQuotes;
+          }
+        } else if (char === "," && !inQuotes) {
+          row.push(cell);
+          cell = "";
+        } else if ((char === "\n" || char === "\r") && !inQuotes) {
+          if (char === "\r" && next === "\n") i += 1;
+          row.push(cell);
+          if (row.some((value) => value !== "")) rows.push(row);
+          row = [];
+          cell = "";
+        } else {
+          cell += char;
+        }
+      }
+      row.push(cell);
+      if (row.some((value) => value !== "")) rows.push(row);
+      if (!rows.length) return [];
+      const headers = rows[0].map((header) => header.trim());
+      return rows.slice(1).map((values) => {
+        const record = {};
+        headers.forEach((header, index) => {
+          record[header] = values[index] ?? "";
+        });
+        return record;
+      });
+    }
+
+    function numericCell(row, key) {
+      const parsed = Number(row[key]);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    function firstNumericCell(row, keys) {
+      for (const key of keys) {
+        const value = numericCell(row, key);
+        if (value !== null) return value;
+      }
+      return null;
+    }
+
+    function rangeCell(row) {
+      return firstNumericCell(row, ["f1b_range_ft", "range_ft", "range_m_ft"]);
+    }
+
+    function unwrappedRangeCell(row) {
+      return firstNumericCell(row, ["f1b_range_unwrapped_ft", "range_unwrapped_ft"]);
+    }
+
+    function rangeBinErrorCell(row) {
+      return firstNumericCell(row, ["f1b_peak_bin_error", "range_bin_error"]);
+    }
+
+    function displayBearingCell(row) {
+      const rawBearing = numericCell(row, "angle_centroid_deg");
+      if (rawBearing !== null) return rawBearing + value("angleOffset");
+      return numericCell(row, "bearing_deg");
+    }
+
+    function frameKey(row) {
+      return `${row.shot_number}:${row.frame_index}`;
+    }
+
+    function selectedRowsForShot() {
+      const rows = framesByShot.get(shotSelect.value) || [];
+      const selected = new Set(selectedFrameKeys);
+      return rows.filter((row) => selected.has(frameKey(row)));
+    }
+
+    function setInputValue(id, value, digits = 1) {
+      inputs[id].value = value === null || value === undefined ? "" : String(Number(value).toFixed(digits));
+    }
+
+    function setFrameInputs(prefix, row) {
+      if (!row) {
+        inputs[`${prefix}Index`].value = "";
+        inputs[`${prefix}Time`].value = "";
+        inputs[`${prefix}Bearing`].value = "";
+        inputs[`${prefix}Snr`].value = "1";
+        inputs[`${prefix}Range`].value = "";
+        inputs[`${prefix}RangeUnwrapped`].value = "";
+        inputs[`${prefix}RangeBinError`].value = "";
+        return;
+      }
+      inputs[`${prefix}Index`].value = row.frame_index;
+      setInputValue(`${prefix}Time`, numericCell(row, "t_ms"), 1);
+      setInputValue(`${prefix}Bearing`, displayBearingCell(row), 2);
+      setInputValue(`${prefix}Snr`, numericCell(row, "snr") ?? 1, 1);
+      setInputValue(`${prefix}Range`, rangeCell(row), 2);
+      setInputValue(`${prefix}RangeUnwrapped`, unwrappedRangeCell(row), 2);
+      setInputValue(`${prefix}RangeBinError`, rangeBinErrorCell(row), 0);
+    }
+
+    function applySelectedFrames() {
+      const selected = selectedRowsForShot().sort(
+        (a, b) => Number(a.frame_index) - Number(b.frame_index),
+      );
+      if (selected.length === 0) {
+        setFrameInputs("frame1", null);
+        setFrameInputs("frame2", null);
+        return;
+      }
+      if (selected.length === 1) {
+        setFrameInputs("frame1", null);
+        setFrameInputs("frame2", selected[0]);
+      } else {
+        setFrameInputs("frame1", selected[0]);
+        setFrameInputs("frame2", selected[1]);
+      }
+
+      const speeds = selected
+        .map((row) => numericCell(row, "speed_mph"))
+        .filter((speed) => speed !== null);
+      if (speeds.length) {
+        const averageSpeed = speeds.reduce((sum, speed) => sum + speed, 0) / speeds.length;
+        setInputValue("ballSpeed", averageSpeed, 1);
+      }
+    }
+
+    function describeFrame(row) {
+      const parts = [
+        `${fmt(numericCell(row, "t_ms"), 1)} ms`,
+        `${fmt(displayBearingCell(row), 2)} deg`,
+      ];
+      const speed = numericCell(row, "speed_mph");
+      const snr = numericCell(row, "snr");
+      const binError = numericCell(row, "bin_error");
+      const range = rangeCell(row);
+      const unwrappedRange = unwrappedRangeCell(row);
+      const rangeBinError = rangeBinErrorCell(row);
+      if (speed !== null) parts.push(`${fmt(speed, 1)} mph`);
+      if (snr !== null) parts.push(`SNR ${fmt(snr, 1)}`);
+      if (binError !== null) parts.push(`bin ${binError}`);
+      if (range !== null) parts.push(`F1B ${fmt(range, 1)} ft`);
+      if (range !== null && unwrappedRange !== null && Math.abs(unwrappedRange - range) > 0.05) {
+        parts.push(`unwrap ${fmt(unwrappedRange, 1)} ft`);
+      }
+      if (rangeBinError !== null) parts.push(`F1B bin ${rangeBinError}`);
+      if (row.status) parts.push(row.status);
+      return parts.join(" | ");
+    }
+
+    function renderFrameList() {
+      const rows = framesByShot.get(shotSelect.value) || [];
+      const selected = new Set(selectedFrameKeys);
+      frameList.textContent = "";
+      for (const row of rows) {
+        const key = frameKey(row);
+        const isSelected = selected.has(key);
+        const canPlace = numericCell(row, "t_ms") !== null && displayBearingCell(row) !== null;
+        const locked = !isSelected && selected.size >= 2;
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = `frame-row${isSelected ? " selected" : ""}${locked ? " locked" : ""}`;
+        button.innerHTML = `<strong>F${row.frame_index}</strong><span>${describeFrame(row)}</span>`;
+        button.addEventListener("click", () => {
+          if (!canPlace) {
+            csvStatus.textContent = `Frame ${row.frame_index} is missing t_ms or angle data.`;
+            return;
+          }
+          if (isSelected) {
+            selectedFrameKeys = selectedFrameKeys.filter((item) => item !== key);
+          } else if (selectedFrameKeys.length < 2) {
+            selectedFrameKeys.push(key);
+          } else {
+            csvStatus.textContent = "Only two frames can be selected. Deselect one first.";
+            return;
+          }
+          applySelectedFrames();
+          renderFrameList();
+          render();
+        });
+        frameList.appendChild(button);
+      }
+      const selectedRows = selectedRowsForShot();
+      csvStatus.textContent = selectedRows.length
+        ? `Selected ${selectedRows.map((row) => `F${row.frame_index}`).join(" and ")}.`
+        : "Select up to two frames. One selected frame loads as frame 2.";
+    }
+
+    function selectDefaultFramesForShot() {
+      const rows = framesByShot.get(shotSelect.value) || [];
+      const selectedRows = rows
+        .filter((row) => row.status === "selected")
+        .sort((a, b) => Number(a.frame_index) - Number(b.frame_index))
+        .slice(0, 2);
+      selectedFrameKeys = selectedRows.map(frameKey);
+      applySelectedFrames();
+      renderFrameList();
+      render();
+    }
+
+    function loadFramesCsv(text, options = {}) {
+      const previousShot = shotSelect.value;
+      const rows = parseCsv(text).filter((row) => row.shot_number && row.frame_index);
+      framesByShot = new Map();
+      for (const row of rows) {
+        const shot = row.shot_number;
+        if (!framesByShot.has(shot)) framesByShot.set(shot, []);
+        framesByShot.get(shot).push(row);
+      }
+      for (const shotRows of framesByShot.values()) {
+        shotRows.sort((a, b) => Number(a.frame_index) - Number(b.frame_index));
+      }
+      const shots = [...framesByShot.keys()].sort((a, b) => Number(a) - Number(b));
+      shotSelect.innerHTML = "";
+      if (!shots.length) {
+        shotSelect.disabled = true;
+        shotSelect.innerHTML = '<option value="">No frames found</option>';
+        frameList.textContent = "";
+        csvStatus.textContent = "Could not find shot_number and frame_index columns.";
+        return;
+      }
+      for (const shot of shots) {
+        const option = document.createElement("option");
+        option.value = shot;
+        option.textContent = `Shot ${shot}`;
+        shotSelect.appendChild(option);
+      }
+      shotSelect.disabled = false;
+      if (options.preferLatest) {
+        shotSelect.value = shots[shots.length - 1];
+      } else if (previousShot && shots.includes(previousShot)) {
+        shotSelect.value = previousShot;
+      } else {
+        shotSelect.value = shots[0];
+      }
+      csvStatus.textContent = `Loaded ${rows.length} frames across ${shots.length} shots.`;
+      selectDefaultFramesForShot();
+    }
+
+    async function loadFramesCsvFromUrl(options = {}) {
+      const url = csvUrl.value.trim();
+      if (!url) {
+        csvStatus.textContent = "Enter a CSV URL first.";
+        return;
+      }
+      const cacheBustedUrl = `${url}${url.includes("?") ? "&" : "?"}_=${Date.now()}`;
+      const response = await fetch(cacheBustedUrl, { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error(`${response.status} ${response.statusText}`);
+      }
+      const text = await response.text();
+      if (options.skipIfUnchanged && text === latestCsvText) return;
+      latestCsvText = text;
+      loadFramesCsv(text, { preferLatest: options.preferLatest ?? autoReloadCsv.checked });
+      csvStatus.textContent += ` Auto-loaded ${url} at ${new Date().toLocaleTimeString()}.`;
+    }
+
+    function updateAutoReloadTimer() {
+      if (autoReloadTimer) {
+        clearInterval(autoReloadTimer);
+        autoReloadTimer = null;
+      }
+      if (!autoReloadCsv.checked) return;
+      autoReloadTimer = setInterval(() => {
+        loadFramesCsvFromUrl({ preferLatest: true, skipIfUnchanged: true }).catch((error) => {
+          csvStatus.textContent = `Auto reload failed: ${error.message}`;
+        });
+      }, 2500);
+    }
+
+    function pointOnBearingAtFlightDistance(bearingDeg, timeMs, params) {
+      if (!Number.isFinite(bearingDeg) || !Number.isFinite(timeMs)) {
+        return {
+          ok: false,
+          reason: "not_configured",
+          tSec: null,
+          flightDistance: null,
+        };
+      }
+      const tSec = timeMs / 1000;
+      const signedFlightDistance = params.ballSpeed * MPH_TO_FPS * tSec;
+      const phi = degToRad(bearingDeg + params.mountTilt);
+      const x = params.ballDistance + signedFlightDistance;
+      const y = Math.tan(phi) * x;
+      const distanceAlongRay = Math.hypot(x, y);
+      return {
+        ok: true,
+        x,
+        y,
+        distanceAlongRay,
+        tSec,
+        flightDistance: signedFlightDistance,
+        flightDistanceAbs: Math.abs(signedFlightDistance),
+        isPreImpact: tSec < 0,
+        physicalBearingDeg: bearingDeg + params.mountTilt,
+      };
+    }
+
+    function pointOnBearingAtMeasuredRange(frame, params) {
+      if (
+        frame.bearingDeg === null ||
+        !Number.isFinite(frame.bearingDeg)
+      ) {
+        return { ok: false, reason: "not_configured" };
+      }
+
+      const hasUnwrapped = Number.isFinite(frame.rangeUnwrappedFt) && frame.rangeUnwrappedFt > 0;
+      const preferredRange = hasUnwrapped ? frame.rangeUnwrappedFt : frame.rangeFt;
+      if (!Number.isFinite(preferredRange) || preferredRange <= 0) {
+        return { ok: false, reason: "range_not_available" };
+      }
+
+      const phi = degToRad(frame.bearingDeg + params.mountTilt);
+      return {
+        ok: true,
+        x: preferredRange * Math.cos(phi),
+        y: preferredRange * Math.sin(phi),
+        rangeFt: preferredRange,
+        rawRangeFt: frame.rangeFt,
+        unwrappedRangeFt: frame.rangeUnwrappedFt,
+        rangeBinError: frame.rangeBinError,
+        rangeSource: hasUnwrapped ? "unwrapped" : "raw",
+      };
+    }
+
+    function rangeDelta(point, rangePoint) {
+      if (!point.ok || !rangePoint.ok || !Number.isFinite(point.distanceAlongRay)) return null;
+      return rangePoint.rangeFt - point.distanceAlongRay;
+    }
+
+    function signedPointLineDistance(point, lineA, lineB) {
+      const vx = lineB.x - lineA.x;
+      const vy = lineB.y - lineA.y;
+      const wx = point.x - lineA.x;
+      const wy = point.y - lineA.y;
+      const len = Math.hypot(vx, vy);
+      if (len <= 0) return 0;
+      return (vx * wy - vy * wx) / len;
+    }
+
+    function projectionAlongLine(point, lineA, lineB) {
+      const vx = lineB.x - lineA.x;
+      const vy = lineB.y - lineA.y;
+      const wx = point.x - lineA.x;
+      const wy = point.y - lineA.y;
+      const len2 = vx * vx + vy * vy;
+      if (len2 <= 0) return { x: lineA.x, y: lineA.y };
+      const u = (wx * vx + wy * vy) / len2;
+      return { x: lineA.x + u * vx, y: lineA.y + u * vy, u };
+    }
+
+    function freeStartLine(p1, p2, params) {
+      if (!p1.ok || !p2.ok) return null;
+      const dx = p2.x - p1.x;
+      const dy = p2.y - p1.y;
+      if (Math.abs(dx) < 1e-6 || Math.abs(dy) < 1e-6) return null;
+      const slope = dy / dx;
+      return {
+        launchDeg: radToDeg(Math.atan2(dy, dx)),
+        slope,
+        xAtBallHeight: p1.x + (params.ballOffset - p1.y) / slope,
+        yAtKnownBall: p1.y + slope * (params.ballDistance - p1.x),
+      };
+    }
+
+    function getParams() {
+      const shiftMs = value("shiftMs");
+      const frame1Time = optionalValue("frame1Time");
+      const frame2Time = optionalValue("frame2Time");
+      return {
+        ballSpeed: value("ballSpeed"),
+        ballDistance: value("ballDistance"),
+        netDistance: value("netDistance"),
+        mountTilt: value("mountTilt"),
+        ballOffset: value("ballOffset"),
+        showRange: showRange.checked,
+        shiftMs,
+        frame1: {
+          index: optionalValue("frame1Index"),
+          rawTimeMs: frame1Time,
+          timeMs: frame1Time === null ? null : frame1Time + shiftMs,
+          bearingDeg: optionalValue("frame1Bearing"),
+          snr: optionalValue("frame1Snr") ?? 1,
+          rangeFt: optionalValue("frame1Range"),
+          rangeUnwrappedFt: optionalValue("frame1RangeUnwrapped"),
+          rangeBinError: optionalValue("frame1RangeBinError"),
+        },
+        frame2: {
+          index: optionalValue("frame2Index"),
+          rawTimeMs: frame2Time,
+          timeMs: frame2Time === null ? null : frame2Time + shiftMs,
+          bearingDeg: optionalValue("frame2Bearing"),
+          snr: optionalValue("frame2Snr") ?? 1,
+          rangeFt: optionalValue("frame2Range"),
+          rangeUnwrappedFt: optionalValue("frame2RangeUnwrapped"),
+          rangeBinError: optionalValue("frame2RangeBinError"),
+        },
+      };
+    }
+
+    function predictedBearingDeg(launchDeg, timeMs, params) {
+      const tSec = timeMs / 1000;
+      const alpha = degToRad(launchDeg);
+      const speedFps = params.ballSpeed * MPH_TO_FPS;
+      const x = params.ballDistance + speedFps * Math.cos(alpha) * tSec;
+      const y = params.ballOffset + speedFps * Math.sin(alpha) * tSec;
+      return radToDeg(Math.atan2(y, x)) - params.mountTilt;
+    }
+
+    function geometryFit(params) {
+      const frames = [params.frame1, params.frame2]
+        .filter((frame) => (
+          frame.timeMs !== null &&
+          Number.isFinite(frame.timeMs) &&
+          frame.timeMs > 0 &&
+          frame.timeMs <= 150 &&
+          frame.bearingDeg !== null &&
+          Number.isFinite(frame.bearingDeg)
+        ))
+        .map((frame) => ({
+          ...frame,
+          weight: Math.max(frame.snr * frame.snr, 1),
+        }));
+      if (!frames.length) return null;
+
+      let best = null;
+      for (let launchDeg = 0; launchDeg <= 45.0001; launchDeg += 0.1) {
+        let weightedError = 0;
+        let weightSum = 0;
+        for (const frame of frames) {
+          const predicted = predictedBearingDeg(launchDeg, frame.timeMs, params);
+          const residual = frame.bearingDeg - predicted;
+          weightedError += frame.weight * residual * residual;
+          weightSum += frame.weight;
+        }
+        const rmse = Math.sqrt(weightedError / weightSum);
+        if (!best || rmse < best.rmse) {
+          best = {
+            launchDeg,
+            rmse,
+            frameCount: frames.length,
+          };
+        }
+      }
+      return best;
+    }
+
+    function resizeCanvas() {
+      const rect = canvas.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = Math.max(1, Math.round(rect.width * dpr));
+      canvas.height = Math.max(1, Math.round(rect.height * dpr));
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+
+    function buildScale(params, p1, p2, freeLine, r1, r2) {
+      const screenX = params.ballDistance + params.netDistance;
+      const xs = [0, params.ballDistance, screenX];
+      const ys = [0, params.ballOffset];
+      if (p1.ok) {
+        xs.push(p1.x);
+        ys.push(p1.y);
+      } else if (p1.closest) {
+        xs.push(p1.closest.x);
+        ys.push(p1.closest.y);
+      }
+      if (p2.ok) {
+        xs.push(p2.x);
+        ys.push(p2.y);
+      } else if (p2.closest) {
+        xs.push(p2.closest.x);
+        ys.push(p2.closest.y);
+      }
+      if (freeLine) {
+        xs.push(freeLine.xAtBallHeight);
+        ys.push(freeLine.yAtKnownBall);
+      }
+      if (params.showRange && r1.ok) {
+        xs.push(r1.x);
+        ys.push(r1.y);
+      }
+      if (params.showRange && r2.ok) {
+        xs.push(r2.x);
+        ys.push(r2.y);
+      }
+      const minX = Math.min(-0.8, ...xs) - 0.2;
+      const maxX = Math.max(screenX + 0.8, ...xs) + 0.4;
+      const minY = Math.min(-1.0, ...ys) - 0.3;
+      const maxY = Math.max(3.5, ...ys) + 0.6;
+      const pad = 42;
+      const width = canvas.clientWidth;
+      const height = canvas.clientHeight;
+      const sx = (width - pad * 2) / (maxX - minX);
+      const sy = (height - pad * 2) / (maxY - minY);
+      const scale = Math.min(sx, sy);
+      const usedW = (maxX - minX) * scale;
+      const ox = (width - usedW) / 2 - minX * scale;
+      const oy = pad + maxY * scale;
+      return {
+        x: (worldX) => ox + worldX * scale,
+        y: (worldY) => oy - worldY * scale,
+        scale,
+        minX,
+        maxX,
+        minY,
+        maxY,
+      };
+    }
+
+    function drawText(text, x, y, color = "#172033", align = "left") {
+      ctx.fillStyle = color;
+      ctx.textAlign = align;
+      ctx.textBaseline = "middle";
+      ctx.font = "12px Inter, system-ui, sans-serif";
+      ctx.fillText(text, x, y);
+    }
+
+    function draw(params, p1, p2, freeLine, r1, r2) {
+      resizeCanvas();
+      const width = canvas.clientWidth;
+      const height = canvas.clientHeight;
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, width, height);
+      const scale = buildScale(params, p1, p2, freeLine, r1, r2);
+      const screenX = params.ballDistance + params.netDistance;
+      const ball = { x: params.ballDistance, y: params.ballOffset };
+
+      ctx.strokeStyle = "#e5e7eb";
+      ctx.lineWidth = 1;
+      for (let x = Math.ceil(scale.minX); x <= Math.floor(scale.maxX); x += 1) {
+        ctx.beginPath();
+        ctx.moveTo(scale.x(x), scale.y(scale.minY));
+        ctx.lineTo(scale.x(x), scale.y(scale.maxY));
+        ctx.stroke();
+      }
+      for (let y = Math.ceil(scale.minY); y <= Math.floor(scale.maxY); y += 1) {
+        ctx.beginPath();
+        ctx.moveTo(scale.x(scale.minX), scale.y(y));
+        ctx.lineTo(scale.x(scale.maxX), scale.y(y));
+        ctx.stroke();
+      }
+
+      ctx.strokeStyle = "#cbd5e1";
+      ctx.setLineDash([4, 4]);
+      ctx.beginPath();
+      ctx.moveTo(scale.x(scale.minX), scale.y(0));
+      ctx.lineTo(scale.x(scale.maxX), scale.y(0));
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      ctx.strokeStyle = "#9ca3af";
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(scale.x(scale.minX), scale.y(params.ballOffset));
+      ctx.lineTo(scale.x(scale.maxX), scale.y(params.ballOffset));
+      ctx.stroke();
+
+      ctx.strokeStyle = "#111827";
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(scale.x(screenX), scale.y(scale.minY));
+      ctx.lineTo(scale.x(screenX), scale.y(scale.maxY));
+      ctx.stroke();
+      drawText("net/screen", scale.x(screenX) + 8, scale.y(scale.maxY) + 16, "#111827");
+
+      ctx.strokeStyle = "#2563eb";
+      ctx.lineWidth = 1.5;
+      ctx.setLineDash([5, 4]);
+      ctx.beginPath();
+      ctx.moveTo(scale.x(params.ballDistance), scale.y(scale.minY));
+      ctx.lineTo(scale.x(params.ballDistance), scale.y(scale.maxY));
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      function drawBearingRay(point, color, label) {
+        const drawable = point.ok ? point : point.closest;
+        if (!drawable) return;
+        ctx.strokeStyle = color;
+        ctx.lineWidth = 1.5;
+        ctx.setLineDash(point.ok ? [2, 3] : [2, 6]);
+        ctx.beginPath();
+        ctx.moveTo(scale.x(0), scale.y(0));
+        ctx.lineTo(scale.x(drawable.x * 1.08), scale.y(drawable.y * 1.08));
+        ctx.stroke();
+        ctx.setLineDash([]);
+        ctx.beginPath();
+        ctx.arc(scale.x(drawable.x), scale.y(drawable.y), 6, 0, Math.PI * 2);
+        if (point.ok) {
+          ctx.fillStyle = color;
+          ctx.fill();
+        } else {
+          ctx.fillStyle = "#ffffff";
+          ctx.fill();
+          ctx.strokeStyle = color;
+          ctx.lineWidth = 2;
+          ctx.stroke();
+        }
+        drawText(
+          point.ok ? label : `${label} closest`,
+          scale.x(drawable.x) + 9,
+          scale.y(drawable.y) - 12,
+          color,
+        );
+      }
+
+      function drawRangePoint(rangePoint, speedPoint, color, label) {
+        if (!rangePoint.ok) return;
+        ctx.strokeStyle = color;
+        ctx.fillStyle = "#fff7ed";
+        ctx.lineWidth = 1.8;
+        if (speedPoint.ok) {
+          ctx.setLineDash([3, 4]);
+          ctx.beginPath();
+          ctx.moveTo(scale.x(speedPoint.x), scale.y(speedPoint.y));
+          ctx.lineTo(scale.x(rangePoint.x), scale.y(rangePoint.y));
+          ctx.stroke();
+          ctx.setLineDash([]);
+        }
+        const x = scale.x(rangePoint.x);
+        const y = scale.y(rangePoint.y);
+        const size = 6;
+        ctx.beginPath();
+        ctx.moveTo(x, y - size);
+        ctx.lineTo(x + size, y);
+        ctx.lineTo(x, y + size);
+        ctx.lineTo(x - size, y);
+        ctx.closePath();
+        ctx.fill();
+        ctx.stroke();
+        drawText(label, x + 9, y + 14, color);
+      }
+
+      if (freeLine) {
+        const yAtScreen = p1.y + freeLine.slope * (screenX - p1.x);
+        const yAtLeft = p1.y + freeLine.slope * (scale.minX - p1.x);
+        ctx.strokeStyle = "#047857";
+        ctx.lineWidth = 2.4;
+        ctx.setLineDash([8, 5]);
+        ctx.beginPath();
+        ctx.moveTo(scale.x(scale.minX), scale.y(yAtLeft));
+        ctx.lineTo(scale.x(screenX), scale.y(yAtScreen));
+        ctx.stroke();
+        ctx.setLineDash([]);
+        drawText(
+          `free-start ${fmt(freeLine.launchDeg, 2)} deg`,
+          scale.x(screenX) - 170,
+          scale.y(yAtScreen) - 14,
+          "#047857",
+        );
+      }
+
+      if (p2.ok) {
+        const dx = p2.x - ball.x;
+        const dy = p2.y - ball.y;
+        const len = Math.hypot(dx, dy);
+        const ux = dx / len;
+        const uy = dy / len;
+        ctx.strokeStyle = "#dc2626";
+        ctx.lineWidth = 2.5;
+        ctx.beginPath();
+        ctx.moveTo(scale.x(ball.x - ux * 0.3), scale.y(ball.y - uy * 0.3));
+        ctx.lineTo(scale.x(screenX), scale.y(ball.y + uy / ux * (screenX - ball.x)));
+        ctx.stroke();
+      }
+
+      drawBearingRay(
+        p1,
+        "#7c3aed",
+        `F${params.frame1.index} ${fmt(params.frame1.timeMs)} ms${p1.isPreImpact ? " pre" : ""}`,
+      );
+      drawBearingRay(
+        p2,
+        "#0786a8",
+        `F${params.frame2.index} ${fmt(params.frame2.timeMs)} ms${p2.isPreImpact ? " pre" : ""}`,
+      );
+      if (params.showRange) {
+        drawRangePoint(
+          r1,
+          p1,
+          params.frame1.rangeBinError !== null && params.frame1.rangeBinError > 50 ? "#dc2626" : "#b45309",
+          `F${params.frame1.index} F1B ${fmt(r1.rangeFt, 1)} ft`,
+        );
+        drawRangePoint(
+          r2,
+          p2,
+          params.frame2.rangeBinError !== null && params.frame2.rangeBinError > 50 ? "#dc2626" : "#b45309",
+          `F${params.frame2.index} F1B ${fmt(r2.rangeFt, 1)} ft`,
+        );
+      }
+
+      ctx.fillStyle = "#111827";
+      ctx.beginPath();
+      ctx.arc(scale.x(0), scale.y(0), 7, 0, Math.PI * 2);
+      ctx.fill();
+      drawText("K-LD7 radar", scale.x(0) + 9, scale.y(0) - 18, "#111827");
+
+      ctx.fillStyle = "#dbeafe";
+      ctx.strokeStyle = "#2563eb";
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(scale.x(ball.x), scale.y(ball.y), 7, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+      drawText(`ball ${fmt(params.ballDistance)} ft`, scale.x(ball.x) + 9, scale.y(ball.y) + 18, "#1d4ed8");
+
+      if (p1.ok && p2.ok) {
+        const projection = projectionAlongLine(p1, ball, p2);
+        ctx.strokeStyle = "#b45309";
+        ctx.lineWidth = 1.4;
+        ctx.setLineDash([4, 4]);
+        ctx.beginPath();
+        ctx.moveTo(scale.x(p1.x), scale.y(p1.y));
+        ctx.lineTo(scale.x(projection.x), scale.y(projection.y));
+        ctx.stroke();
+        ctx.setLineDash([]);
+        drawText("F1 miss", scale.x(projection.x) + 7, scale.y(projection.y) - 12, "#b45309");
+      }
+
+      ctx.fillStyle = "#475569";
+      ctx.font = "12px Inter, system-ui, sans-serif";
+      ctx.textAlign = "left";
+      ctx.fillText(
+        params.showRange
+          ? "Dots: speed*time downrange with K-LD7 bearing height. Red: ball to frame 2. Green dashed: free-start line. Diamonds: F1B range points."
+          : "Dots: speed*time downrange with K-LD7 bearing height. Red: ball to frame 2. Green dashed: free-start line.",
+        16,
+        height - 16,
+      );
+    }
+
+    function updateMetrics(params, p1, p2, freeLine, r1, r2) {
+      const ball = { x: params.ballDistance, y: params.ballOffset };
+      const status = document.getElementById("status");
+      const messages = [];
+      if (!p1.ok && p1.reason !== "not_configured") {
+        messages.push(
+          p1.closest
+            ? `Frame 1: bearing ray misses the speed/time circle; hollow marker shows closest approach.`
+            : `Frame 1: ${p1.reason}.`,
+        );
+      }
+      if (!p2.ok && p2.reason !== "not_configured") {
+        messages.push(
+          p2.closest
+            ? `Frame 2: bearing ray misses the speed/time circle; hollow marker shows closest approach.`
+            : `Frame 2: ${p2.reason}.`,
+        );
+      }
+      const preImpactNotes = [];
+      if (p1.ok && p1.isPreImpact) preImpactNotes.push(`F${params.frame1.index}`);
+      if (p2.ok && p2.isPreImpact) preImpactNotes.push(`F${params.frame2.index}`);
+
+      if (p2.ok) {
+        const launch = radToDeg(Math.atan2(p2.y - ball.y, p2.x - ball.x));
+        document.getElementById("launchMetric").textContent = `${fmt(launch, 2)} deg`;
+        document.getElementById("launchSub").textContent =
+          `Ball to F${params.frame2.index}, using bearing ${fmt(params.frame2.bearingDeg, 1)} deg`;
+      } else {
+        document.getElementById("launchMetric").textContent = "-";
+        document.getElementById("launchSub").textContent = "Frame 2 cannot be placed";
+      }
+
+      if (freeLine) {
+        document.getElementById("nominalMetric").textContent = `${fmt(freeLine.launchDeg, 2)} deg`;
+        document.getElementById("nominalSub").textContent =
+          `Crosses ball height at ${fmt(freeLine.xAtBallHeight, 2)} ft`;
+        const startError = freeLine.xAtBallHeight - params.ballDistance;
+        document.getElementById("startErrorMetric").textContent =
+          `${startError >= 0 ? "+" : ""}${fmt(startError, 2)} ft`;
+        document.getElementById("startErrorSub").textContent =
+          startError >= 0 ? "green line crosses after ball" : "green line crosses before ball";
+      } else {
+        document.getElementById("nominalMetric").textContent = "-";
+        document.getElementById("nominalSub").textContent = "Needs two placed frames";
+        document.getElementById("startErrorMetric").textContent = "-";
+        document.getElementById("startErrorSub").textContent = "Needs free-start line";
+      }
+
+      const fit = geometryFit(params);
+      if (fit) {
+        document.getElementById("geometryMetric").textContent = `${fmt(fit.launchDeg, 2)} deg`;
+        document.getElementById("geometrySub").textContent =
+          `${fit.frameCount}-frame weighted fit, RMSE ${fmt(fit.rmse, 2)} deg`;
+      } else {
+        document.getElementById("geometryMetric").textContent = "-";
+        document.getElementById("geometrySub").textContent = "Needs at least one placed frame";
+      }
+
+      if (p1.ok && p2.ok) {
+        const miss = signedPointLineDistance(p1, ball, p2);
+        document.getElementById("missMetric").textContent = `${fmt(Math.abs(miss), 3)} ft`;
+        document.getElementById("missSub").textContent =
+          `${miss >= 0 ? "above/left" : "below/right"} of ball-to-F${params.frame2.index} line`;
+      } else {
+        document.getElementById("missMetric").textContent = "-";
+        document.getElementById("missSub").textContent = "Needs both frames";
+      }
+
+      document.getElementById("timesMetric").textContent =
+        `${fmt(params.frame1.timeMs, 1)} / ${fmt(params.frame2.timeMs, 1)} ms`;
+      document.getElementById("timesSub").textContent =
+        `Raw ${fmt(params.frame1.rawTimeMs, 1)} / ${fmt(params.frame2.rawTimeMs, 1)}, shift ${fmt(params.shiftMs, 1)} ms`;
+
+      document.getElementById("distanceMetric").textContent =
+        `${fmt(p1.flightDistance, 2)} / ${fmt(p2.flightDistance, 2)} ft`;
+      document.getElementById("distanceSub").textContent =
+        `speed * corrected time`;
+
+      const r1Delta = rangeDelta(p1, r1);
+      const r2Delta = rangeDelta(p2, r2);
+      document.getElementById("rangeMetric").textContent =
+        `${fmt(r1.rangeFt, 2)} / ${fmt(r2.rangeFt, 2)} ft`;
+      document.getElementById("rangeSub").textContent =
+        `raw ${fmt(params.frame1.rangeFt, 2)} / ${fmt(params.frame2.rangeFt, 2)}, ` +
+        `F1B bin ${fmt(params.frame1.rangeBinError, 0)} / ${fmt(params.frame2.rangeBinError, 0)}`;
+      document.getElementById("rangeDeltaMetric").textContent =
+        `${r1Delta === null ? "-" : `${r1Delta >= 0 ? "+" : ""}${fmt(r1Delta, 2)}`} / ` +
+        `${r2Delta === null ? "-" : `${r2Delta >= 0 ? "+" : ""}${fmt(r2Delta, 2)}`} ft`;
+      document.getElementById("rangeDeltaSub").textContent =
+        `F1B range - speed/time ray distance`;
+
+      if (p1.reason === "not_configured" && p2.ok) {
+        status.innerHTML =
+          `<strong>Single-frame mode:</strong> Frame 2 is placed from the selected frame. ` +
+          `Select one more frame to draw the free-start green line and timing-error metrics.`;
+      } else if (messages.length === 0) {
+        status.innerHTML =
+          `<strong>How to read it:</strong> Red is the direct ball-to-frame-2 line. ` +
+          `Green dashed is the line through both frame circles, ignoring the known ball start point. ` +
+          `Frame dots use speed*time for downrange position and K-LD7 bearing for height; the blue ball line is only a reference. ` +
+          `Frame 1 should land on the red line when the per-shot timing shift is right. ` +
+          (preImpactNotes.length
+            ? `${preImpactNotes.join(" and ")} are drawn before the ball-strike line; Geometry Fit ignores pre-impact frames. `
+            : ``) +
+          (params.showRange ? `Orange/red diamonds show F1B range points. ` : ``) +
+          `Use +/- to slide both frame times together by 1 ms.`;
+      } else {
+        status.innerHTML = `<strong>Placement warning:</strong> ${messages.join(" ")}`;
+      }
+    }
+
+    function render() {
+      const params = getParams();
+      const p1 = pointOnBearingAtFlightDistance(
+        params.frame1.bearingDeg,
+        params.frame1.timeMs,
+        params,
+      );
+      const p2 = pointOnBearingAtFlightDistance(
+        params.frame2.bearingDeg,
+        params.frame2.timeMs,
+        params,
+      );
+      const r1 = pointOnBearingAtMeasuredRange(params.frame1, params);
+      const r2 = pointOnBearingAtMeasuredRange(params.frame2, params);
+      const freeLine = freeStartLine(p1, p2, params);
+      draw(params, p1, p2, freeLine, r1, r2);
+      updateMetrics(params, p1, p2, freeLine, r1, r2);
+    }
+
+    document.getElementById("minus").addEventListener("click", () => {
+      inputs.shiftMs.value = String(value("shiftMs") - 1);
+      render();
+    });
+    document.getElementById("plus").addEventListener("click", () => {
+      inputs.shiftMs.value = String(value("shiftMs") + 1);
+      render();
+    });
+    showRange.addEventListener("change", render);
+    loadCsvUrl.addEventListener("click", () => {
+      loadFramesCsvFromUrl({ preferLatest: true }).catch((error) => {
+        csvStatus.textContent = `CSV URL load failed: ${error.message}`;
+      });
+    });
+    reloadCsvUrl.addEventListener("click", () => {
+      loadFramesCsvFromUrl({ preferLatest: autoReloadCsv.checked }).catch((error) => {
+        csvStatus.textContent = `CSV URL reload failed: ${error.message}`;
+      });
+    });
+    autoReloadCsv.addEventListener("change", () => {
+      updateAutoReloadTimer();
+      if (autoReloadCsv.checked) {
+        loadFramesCsvFromUrl({ preferLatest: true }).catch((error) => {
+          csvStatus.textContent = `Auto reload failed: ${error.message}`;
+        });
+      }
+    });
+    csvFile.addEventListener("change", async () => {
+      const file = csvFile.files && csvFile.files[0];
+      if (!file) return;
+      try {
+        latestCsvText = "";
+        loadFramesCsv(await file.text());
+      } catch (error) {
+        csvStatus.textContent = `CSV load failed: ${error.message}`;
+      }
+    });
+    shotSelect.addEventListener("change", selectDefaultFramesForShot);
+    for (const [id, input] of Object.entries(inputs)) {
+      input.addEventListener("input", () => {
+        if (id === "angleOffset" && framesByShot.size) {
+          if (selectedFrameKeys.length) applySelectedFrames();
+          renderFrameList();
+        }
+        render();
+      });
+    }
+    window.addEventListener("resize", render);
+    const query = new URLSearchParams(window.location.search);
+    if (query.has("csv")) {
+      csvUrl.value = query.get("csv") || "";
+    }
+    if (query.get("auto") === "1" || query.get("auto") === "true") {
+      autoReloadCsv.checked = true;
+      updateAutoReloadTimer();
+      loadFramesCsvFromUrl({ preferLatest: true }).catch((error) => {
+        csvStatus.textContent = `Auto reload failed: ${error.message}`;
+      });
+    }
+    render();
+  </script>
+</body>
+</html>

--- a/tests/test_kld7_geometry_selection_report.py
+++ b/tests/test_kld7_geometry_selection_report.py
@@ -1,0 +1,319 @@
+"""Tests for the offline K-LD7 geometry selection report."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "analysis"))
+
+import kld7_geometry_selection_report as report
+
+from openflight.kld7.geometry import predicted_bearing_deg
+
+
+def _frame(
+    index: int,
+    t_ms: float,
+    *,
+    bin_error: int,
+    snr: float,
+    bearing_deg: float,
+    speed_mph: float = 110.0,
+) -> report.FrameReport:
+    return report.FrameReport(
+        shot_number=1,
+        frame_index=index,
+        timestamp=100.0 + t_ms / 1000.0,
+        t_ms=t_ms,
+        expected_bin=1800,
+        peak_bin=1800 + bin_error,
+        bin_error=bin_error,
+        speed_mph=speed_mph,
+        speed_error_mph=0.0,
+        snr=snr,
+        angle_centroid_deg=bearing_deg - 2.5,
+        bearing_deg=bearing_deg,
+        phase_coherence=0.95,
+        status="candidate",
+    )
+
+
+def test_select_candidate_frames_prefers_primary_adjacent_pair():
+    config = report.ReportConfig()
+    frames = [
+        _frame(38, 12.0, bin_error=12, snr=4.0, bearing_deg=-6.0),
+        _frame(39, 48.0, bin_error=2, snr=18.0, bearing_deg=2.0),
+        _frame(40, 82.0, bin_error=8, snr=10.0, bearing_deg=8.0),
+    ]
+
+    selected, notes = report.select_candidate_frames(frames, config)
+
+    assert [frame.frame_index for frame in selected] == [39, 40]
+    assert [frame.selection_role for frame in selected] == ["anchor", "neighbor"]
+    assert notes == ["selected_2_frames"]
+
+
+def test_populated_low_snr_peak_is_not_selectable():
+    config = report.ReportConfig()
+    low_snr = _frame(38, 35.0, bin_error=1, snr=2.5, bearing_deg=4.0)
+    low_snr.peak_source = "ops_anchored_low_snr"
+    low_snr.peak_selectable = False
+    low_snr.status = "invalid"
+    low_snr.reasons.append("ops_anchored_snr_too_low")
+    anchor = _frame(39, 70.0, bin_error=2, snr=10.0, bearing_deg=8.0)
+
+    selected, notes = report.select_candidate_frames([low_snr, anchor], config)
+
+    assert low_snr.peak_bin is not None
+    assert low_snr.selectable is False
+    assert low_snr.status == "invalid"
+    assert selected == [anchor]
+    assert notes == ["anchor_only_no_rising_neighbor"]
+
+
+def test_select_candidate_frames_uses_early_context_when_no_primary_pair():
+    config = report.ReportConfig()
+    frames = [
+        _frame(38, 12.0, bin_error=12, snr=4.0, bearing_deg=-6.0),
+        _frame(39, 48.0, bin_error=2, snr=18.0, bearing_deg=2.0),
+    ]
+    frames[0].peak_source = "ops_anchored_weak"
+
+    selected, notes = report.select_candidate_frames(frames, config)
+
+    assert [frame.frame_index for frame in selected] == [38, 39]
+    assert [frame.selection_role for frame in selected] == ["neighbor", "anchor"]
+    assert notes == ["selected_2_frames"]
+
+
+def test_select_candidate_frames_falls_back_to_anchor_when_neighbor_is_not_rising():
+    config = report.ReportConfig()
+    frames = [
+        _frame(38, 14.0, bin_error=5, snr=10.0, bearing_deg=7.0),
+        _frame(39, 48.0, bin_error=1, snr=14.0, bearing_deg=5.0),
+    ]
+
+    selected, notes = report.select_candidate_frames(frames, config)
+
+    assert [frame.frame_index for frame in selected] == [39]
+    assert notes == ["anchor_only_no_rising_neighbor"]
+    assert "not_rising" in frames[0].reasons
+
+
+def test_range_shift_fit_recovers_synthetic_timing_offset():
+    config = report.ReportConfig(clock_error_ms=20.0, shift_step_ms=1.0)
+    ball_speed_mph = 110.0
+    launch_angle_deg = 18.0
+    true_times_ms = [22.0, 55.0]
+    measured_time_error_ms = -10.0
+    frames = []
+    for index, true_t_ms in enumerate(true_times_ms, start=39):
+        true_t_s = true_t_ms / 1000.0
+        bearing = predicted_bearing_deg(
+            launch_angle_deg,
+            true_t_s,
+            ball_speed_mph,
+            config.ball_distance_ft,
+            config.mount_deg,
+            config.ball_above_radar_ft,
+        )
+        rng = report._predicted_range_ft(launch_angle_deg, true_t_s, ball_speed_mph, config)
+        frame = _frame(
+            index,
+            true_t_ms + measured_time_error_ms,
+            bin_error=2,
+            snr=12.0,
+            bearing_deg=bearing,
+        )
+        frame.f1b_range_ft = rng
+        frames.append(frame)
+
+    fit = report.best_range_shift_fit(frames, ball_speed_mph, config)
+
+    assert fit is not None
+    assert fit.shift_ms == pytest.approx(10.0, abs=1.0)
+    assert fit.launch_angle_deg == pytest.approx(launch_angle_deg, abs=0.2)
+    assert fit.range_rmse_ft == pytest.approx(0.0, abs=0.05)
+
+
+def test_high_rmse_pair_falls_back_to_first_strong_single_frame():
+    config = report.ReportConfig()
+    frames = [
+        _frame(38, 27.5, bin_error=10, snr=18.4, bearing_deg=-1.6, speed_mph=112.1),
+        _frame(39, 62.5, bin_error=1, snr=16.6, bearing_deg=13.5, speed_mph=112.8),
+    ]
+    for frame in frames:
+        frame.peak_source = "ops_anchored"
+        frame.status = "selected"
+    notes: list[str] = []
+
+    selected = report.apply_high_rmse_single_frame_fallback(
+        frames,
+        112.7,
+        config,
+        notes,
+    )
+
+    assert [frame.frame_index for frame in selected] == [38]
+    assert "high_rmse_pair_fallback_to_single_frame" in notes[0]
+    assert frames[1].status == "rejected"
+    assert "high_rmse_pair_fallback" in frames[1].reasons
+
+
+def test_logged_ball_angle_selection_reads_radc_selection_when_present():
+    details = report._logged_ball_angle_selection(
+        {
+            "ball_angle": {
+                "vertical_deg": 19.9,
+                "confidence": 0.93,
+                "accepted": True,
+                "selection_reason": "strict_accept",
+                "num_frames": 2,
+                "radc_selection": {
+                    "estimator": "geometry",
+                    "selection_path": "geometry_primary",
+                    "selected_frame_indices": [39, 40],
+                    "selected_t_ms": [51.4, 84.5],
+                    "selected_bin_errors": [2, 7],
+                    "geom_fit_rmse_deg": 1.37,
+                },
+            }
+        }
+    )
+
+    assert details["logged_ball_angle_deg"] == pytest.approx(19.9)
+    assert details["logged_ball_angle_accepted"] is True
+    assert details["logged_radc_selection_available"] is True
+    assert details["logged_radc_selected_frame_indices"] == [39, 40]
+    assert details["logged_radc_selected_t_ms"] == [51.4, 84.5]
+    assert details["logged_radc_selected_bin_errors"] == [2, 7]
+    assert details["logged_radc_fit_rmse_deg"] == pytest.approx(1.37)
+
+
+def test_high_snr_selector_prefers_broad_peak_snr_over_bin_error():
+    frames = [
+        _frame(38, 16.0, bin_error=3, snr=4.0, bearing_deg=-4.0),
+        _frame(39, 52.0, bin_error=2, snr=7.0, bearing_deg=2.0),
+        _frame(40, 86.0, bin_error=1, snr=8.0, bearing_deg=9.0),
+    ]
+    # The broad/high-SNR view can disagree with the OPS-anchored peak.
+    frames[0].broad_peak_bin = 1900
+    frames[0].broad_bin_error = 150
+    frames[0].broad_speed_mph = 119.0
+    frames[0].broad_snr = 11.0
+    frames[0].broad_bearing_deg = -3.0
+    frames[1].broad_peak_bin = 1910
+    frames[1].broad_bin_error = 160
+    frames[1].broad_speed_mph = 120.0
+    frames[1].broad_snr = 30.0
+    frames[1].broad_bearing_deg = 4.0
+    frames[2].broad_peak_bin = 1801
+    frames[2].broad_bin_error = 1
+    frames[2].broad_speed_mph = 110.2
+    frames[2].broad_snr = 15.0
+    frames[2].broad_bearing_deg = 10.0
+
+    high_snr_frames = report.broad_high_snr_frames(frames, 110.0, report.ReportConfig())
+    selected, notes = report.select_high_snr_candidate_frames(
+        high_snr_frames,
+        report.ReportConfig(),
+    )
+
+    assert high_snr_frames[1].peak_source == "broad_high_snr"
+    assert high_snr_frames[1].bin_error == 160
+    assert [frame.frame_index for frame in selected] == [39, 40]
+    assert [frame.selection_role for frame in selected] == ["anchor", "neighbor"]
+    assert notes == ["selected_2_frames_high_snr"]
+
+
+def test_logged_ball_angle_selection_marks_older_logs_without_radc_selection():
+    details = report._logged_ball_angle_selection(
+        {
+            "ball_angle": {
+                "vertical_deg": 21.7,
+                "confidence": 0.94,
+                "accepted": True,
+                "selection_reason": "strict_accept",
+                "num_frames": 2,
+            }
+        }
+    )
+
+    assert details["logged_ball_angle_deg"] == pytest.approx(21.7)
+    assert details["logged_ball_angle_num_frames"] == 2
+    assert details["logged_radc_selection_available"] is False
+    assert details["logged_radc_selected_frame_indices"] == []
+
+
+def test_shot_csv_marks_logged_radc_fields_unavailable_for_older_sessions():
+    shot = report.ShotReport(
+        shot_number=3,
+        ball_speed_mph=112.0,
+        impact_timestamp=100.0,
+        impact_timestamp_source="kld7_buffer.shot_timestamp",
+        logged_launch_angle_deg=12.5,
+        logged_angle_source="estimated",
+        logged_ball_angle_deg=29.2,
+        logged_ball_angle_confidence=0.77,
+        logged_ball_angle_accepted=False,
+        logged_ball_angle_selection_reason="outside_soft_lane",
+        logged_ball_angle_num_frames=2,
+        logged_radc_selection_available=False,
+        logged_radc_estimator=None,
+        logged_radc_selection_path=None,
+        logged_radc_selected_frame_indices=[],
+        logged_radc_selected_t_ms=[],
+        logged_radc_selected_bin_errors=[],
+        logged_radc_fit_rmse_deg=None,
+        frame_count=204,
+        considered_frame_count=63,
+        selected_frame_indices=[38],
+        selection_method="single_anchor",
+        selection_notes=[],
+        nominal_fit=None,
+        best_range_fit=None,
+        minus_sensitivity_fit=None,
+        plus_sensitivity_fit=None,
+    )
+
+    row = report._shot_csv_row(shot)
+
+    assert row["logged_radc_estimator"] == "not_logged_in_session"
+    assert row["logged_radc_selection_path"] == "not_logged_in_session"
+    assert row["logged_radc_selected_frame_indices"] == "not_logged_in_session"
+    assert row["logged_radc_selected_t_ms"] == "not_logged_in_session"
+    assert row["logged_radc_selected_bin_errors"] == "not_logged_in_session"
+    assert row["logged_radc_fit_rmse_deg"] == "not_logged_in_session"
+
+
+def test_unwrap_f1b_ranges_adds_period_for_good_wrapped_ball_frame():
+    config = report.ReportConfig(kld7_range_m=5.0)
+    frames = [
+        _frame(39, 35.0, bin_error=3, snr=18.0, bearing_deg=4.6),
+        _frame(40, 70.0, bin_error=2, snr=10.5, bearing_deg=24.8),
+    ]
+    frames[0].f1b_range_ft = 13.25
+    frames[1].f1b_range_ft = 1.67
+
+    report.unwrap_f1b_ranges(frames, config)
+
+    assert frames[0].f1b_range_unwrapped_ft == pytest.approx(13.25)
+    assert frames[0].f1b_range_unwrap_count == 0
+    assert frames[1].f1b_range_unwrapped_ft == pytest.approx(1.67 + config.unambiguous_range_ft)
+    assert frames[1].f1b_range_unwrap_count == 1
+
+
+def test_unwrap_f1b_ranges_does_not_unwrap_bad_bin_or_low_snr_frame():
+    config = report.ReportConfig(range_unwrap_bin_error_max=80, range_unwrap_snr_min=3.0)
+    bad_bin = _frame(39, 35.0, bin_error=120, snr=18.0, bearing_deg=4.6)
+    low_snr = _frame(40, 70.0, bin_error=2, snr=2.5, bearing_deg=24.8)
+    bad_bin.f1b_range_ft = 1.67
+    low_snr.f1b_range_ft = 1.91
+
+    report.unwrap_f1b_ranges([bad_bin, low_snr], config)
+
+    assert bad_bin.f1b_range_unwrapped_ft == pytest.approx(1.67)
+    assert bad_bin.f1b_range_unwrap_count == 0
+    assert low_snr.f1b_range_unwrapped_ft == pytest.approx(1.91)
+    assert low_snr.f1b_range_unwrap_count == 0


### PR DESCRIPTION
## Summary

Adds analysis tooling for debugging K-LD7 vertical launch-angle frame selection from saved OpenFlight session logs and live Pi sessions.

This introduces:

- Offline K-LD7 geometry selection report generation
- Live SSH/SCP sync from the Pi with local CSV regeneration
- Browser-based timing shift visualizer
- Documentation for live/offline workflows
- Focused tests for frame selection, logged RADC metadata, F1B range unwrap, and geometry timing shift behavior

## Why

During TrackMan comparison testing, we needed a repeatable way to inspect:

- which K-LD7 RADC frames were considered
- which frames were selected as anchor/neighbor frames
- whether selected bins matched OPS ball speed
- whether two-frame geometry could be recovered with a small whole-shot timing shift
- whether F1B range agreed with expected ball position
- why shots fell back to one-frame geometry, estimated launch, or no radar angle

The goal is to make these decisions visible without changing the production kiosk path.

## Added Files

- `scripts/analysis/kld7_geometry_selection_report.py`
  - Builds `shots.csv`, `frames.csv`, `shots_live.csv`, `frames_live.csv`, `summary.md`, and `config.json` from a session JSONL.
- `scripts/analysis/kld7_live_sync.py`
  - Polls a Pi over SSH/SCP, pulls the latest session log, regenerates the report, and serves the visualizer locally.
- `scripts/analysis/kld7_timing_shift_visualizer.html`
  - Browser UI for inspecting selected frames, geometry fits, whole-shot timing shifts, F1B range overlays, and start-position error.
- `scripts/analysis/kld7_analysis_tooling.md`
  - Usage guide for offline and live workflows.
- `tests/test_kld7_geometry_selection_report.py`
  - Unit tests for report selection and geometry helper behavior.

## Notes

`frames_live.csv` / `shots_live.csv` are intended to mirror the current OPS-bin/live-style replay path.

`frames.csv` / `shots.csv` are broader exploratory outputs that can surface high-SNR clutter, alternate bins, or non-production candidates for debugging.

The live sync tool requires the caller to pass `--pi-host`; no user-specific hostnames, usernames, IPs, or local paths are checked in.

## Validation

Ran:

```bash
uv run pytest tests/test_kld7_geometry_selection_report.py -v
uv run ruff check scripts/analysis/kld7_geometry_selection_report.py scripts/analysis/kld7_live_sync.py tests/test_kld7_geometry_selection_report.py
uv run ruff format --check scripts/analysis/kld7_geometry_selection_report.py scripts/analysis/kld7_live_sync.py tests/test_kld7_geometry_selection_report.py
```

All passed.
