### PR TITLE
Fix OPS trigger timing with per-shot clock sync

### DIFF
--- a/src/openflight/ops243.py
+++ b/src/openflight/ops243.py
@@ -272,6 +272,7 @@ class OPS243Radar:
         per_read_timeout: float = 0.2,
         max_sync_duration_s: float = 1.25,
         sample_interval_s: float = 0.01,
+        store: bool = True,
     ) -> dict:
         """Map the OPS internal clock to host epoch via repeated ``C?`` reads.
 
@@ -296,9 +297,10 @@ class OPS243Radar:
 
         Sound-triggered captures use this mapping to convert the radar's
         internal ``trigger_time`` to host epoch only when
-        ``usable_for_trigger_timestamps`` is true. Returns a summary dict (also
-        stored on ``self.last_clock_sync``); never raises on a missing/garbled
-        reply.
+        ``usable_for_trigger_timestamps`` is true. Returns a summary dict. By
+        default it is also stored on ``self.last_clock_sync``; pass
+        ``store=False`` for diagnostics that should not affect the live timing
+        path. Never raises on a missing/garbled reply.
         """
         if not self.serial or not self.serial.is_open:
             raise ConnectionError("Not connected to radar")
@@ -409,7 +411,8 @@ class OPS243Radar:
             "rollover_uncertainty_ms": rollover_uncertainty_ms,
             "reads": reads,
         }
-        self.last_clock_sync = summary
+        if store:
+            self.last_clock_sync = summary
         if usable_for_trigger_timestamps:
             logger.info(
                 "[OPS] Clock sync: method=%s offset=%.3fs best_read_latency=%.1fms "

--- a/src/openflight/rolling_buffer/trigger.py
+++ b/src/openflight/rolling_buffer/trigger.py
@@ -780,6 +780,11 @@ class SoundTrigger(TriggerStrategy):
     instead, which uses Pi GPIO (lower threshold) + software S! trigger.
     """
 
+    CLOCK_SYNC_SAMPLES = 36
+    CLOCK_SYNC_MAX_ROLLOVER_UNCERTAINTY_MS = 40.0
+    CLOCK_SYNC_MAX_TIMEOUT_READ_MS = 50.0
+    CLOCK_SYNC_MAX_FALLBACK_AGE_S = 60.0
+
     def __init__(
         self,
         pre_trigger_segments: int = 12,
@@ -795,6 +800,207 @@ class SoundTrigger(TriggerStrategy):
                 The trigger does NOT configure rolling buffer mode itself.
         """
         super().__init__(pre_trigger_segments=pre_trigger_segments)
+
+    @staticmethod
+    def _clock_sync_last_read_host_time(clock_sync: dict) -> Optional[float]:
+        """Return the host time of the last C? read in a clock-sync summary."""
+        reads = clock_sync.get("reads") or []
+        if not reads or not isinstance(reads[-1], dict):
+            return None
+        return reads[-1].get("host_after") or reads[-1].get("host_mid")
+
+    @classmethod
+    def _clock_sync_age_s(cls, clock_sync: dict) -> Optional[float]:
+        """Return age in seconds for a clock-sync summary."""
+        last_host_time = cls._clock_sync_last_read_host_time(clock_sync)
+        if last_host_time is None:
+            return None
+        try:
+            return time.time() - float(last_host_time)
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _clock_sync_quality(cls, clock_sync: object) -> tuple[bool, str]:
+        """Return whether a clock sync is trustworthy enough for shot timing."""
+        if not isinstance(clock_sync, dict):
+            return False, "missing"
+
+        if not clock_sync.get("usable_for_trigger_timestamps"):
+            return False, f"unusable_method:{clock_sync.get('clock_sync_method', 'unknown')}"
+
+        if clock_sync.get("best_offset_s") is None:
+            return False, "missing_best_offset"
+
+        reads = clock_sync.get("reads") or []
+        slow_invalid_reads = [
+            read
+            for read in reads
+            if isinstance(read, dict)
+            and read.get("radar_clock_s") is None
+            and (read.get("read_latency_ms") or 0.0) >= cls.CLOCK_SYNC_MAX_TIMEOUT_READ_MS
+        ]
+        if slow_invalid_reads:
+            return False, f"timeout_reads:{len(slow_invalid_reads)}"
+
+        method = clock_sync.get("clock_sync_method")
+        if method == "integer_rollover":
+            uncertainty = clock_sync.get("rollover_uncertainty_ms")
+            if uncertainty is None:
+                return False, "missing_rollover_uncertainty"
+            try:
+                if float(uncertainty) > cls.CLOCK_SYNC_MAX_ROLLOVER_UNCERTAINTY_MS:
+                    return False, f"rollover_uncertainty:{float(uncertainty):.1f}ms"
+            except (TypeError, ValueError):
+                return False, "invalid_rollover_uncertainty"
+            return True, "valid_integer_rollover"
+
+        if method == "fractional_clock":
+            return True, "valid_fractional_clock"
+
+        return False, f"unsupported_method:{method or 'unknown'}"
+
+    @classmethod
+    def _clock_sync_summary_for_log(cls, clock_sync: object) -> Optional[dict]:
+        """Return a compact JSONL-safe summary of a clock-sync candidate."""
+        if not isinstance(clock_sync, dict):
+            return None
+        valid, reason = cls._clock_sync_quality(clock_sync)
+        return {
+            "valid": valid,
+            "reason": reason,
+            "source": clock_sync.get("source"),
+            "samples": clock_sync.get("samples"),
+            "valid_samples": clock_sync.get("valid_samples"),
+            "clock_sync_method": clock_sync.get("clock_sync_method"),
+            "best_offset_s": clock_sync.get("best_offset_s"),
+            "raw_best_offset_s": clock_sync.get("raw_best_offset_s"),
+            "best_read_latency_ms": clock_sync.get("best_read_latency_ms"),
+            "offset_spread_ms": clock_sync.get("offset_spread_ms"),
+            "rollover_uncertainty_ms": clock_sync.get("rollover_uncertainty_ms"),
+            "age_s": (
+                round(cls._clock_sync_age_s(clock_sync), 3)
+                if cls._clock_sync_age_s(clock_sync) is not None
+                else None
+            ),
+        }
+
+    def _select_clock_sync_for_capture(
+        self,
+        radar: "OPS243Radar",
+        capture: IQCapture,
+    ) -> Optional[dict]:
+        """Choose and apply the best OPS clock sync for this capture."""
+        previous_sync = getattr(radar, "last_clock_sync", None)
+        previous_valid, previous_reason = self._clock_sync_quality(previous_sync)
+        previous_age_s = (
+            self._clock_sync_age_s(previous_sync) if isinstance(previous_sync, dict) else None
+        )
+
+        fresh_sync = None
+        fresh_error = None
+        if hasattr(radar, "read_clock_sync"):
+            try:
+                fresh_sync = radar.read_clock_sync(
+                    samples=self.CLOCK_SYNC_SAMPLES,
+                    store=False,
+                )
+                if isinstance(fresh_sync, dict):
+                    fresh_sync["source"] = "per_shot"
+            except Exception as exc:  # pylint: disable=broad-except
+                fresh_error = str(exc)
+                logger.warning("[TRIGGER] Per-shot OPS clock sync failed: %s", exc, exc_info=True)
+
+        fresh_valid, fresh_reason = self._clock_sync_quality(fresh_sync)
+
+        selected_sync = None
+        selected_source = "first_byte"
+        selected_reason = "no_valid_clock_sync"
+
+        if fresh_valid and isinstance(fresh_sync, dict):
+            selected_sync = fresh_sync
+            selected_source = "fresh"
+            selected_reason = fresh_reason
+            radar.last_clock_sync = fresh_sync
+        elif (
+            previous_valid
+            and isinstance(previous_sync, dict)
+            and previous_age_s is not None
+            and previous_age_s <= self.CLOCK_SYNC_MAX_FALLBACK_AGE_S
+        ):
+            selected_sync = previous_sync
+            selected_source = "previous"
+            selected_reason = (
+                f"fresh_rejected:{fresh_reason};previous_age:{previous_age_s:.1f}s"
+            )
+        elif previous_valid and previous_age_s is not None:
+            selected_reason = (
+                f"fresh_rejected:{fresh_reason};previous_too_old:{previous_age_s:.1f}s"
+            )
+        elif previous_reason != "missing":
+            selected_reason = f"fresh_rejected:{fresh_reason};previous_rejected:{previous_reason}"
+        elif fresh_error:
+            selected_reason = f"fresh_error:{fresh_error}"
+        else:
+            selected_reason = f"fresh_rejected:{fresh_reason}"
+
+        selected_offset_s = None
+        selected_age_s = None
+        if isinstance(selected_sync, dict):
+            selected_offset_s = selected_sync.get("best_offset_s")
+            selected_age_s = self._clock_sync_age_s(selected_sync)
+            try:
+                capture.apply_trigger_timestamp_from_clock_sync(float(selected_offset_s))
+            except (TypeError, ValueError):
+                logger.warning(
+                    "[TRIGGER] Ignoring invalid selected OPS clock-sync offset: %r",
+                    selected_offset_s,
+                )
+                selected_sync = None
+                selected_source = "first_byte"
+                selected_reason = "selected_offset_invalid"
+                selected_offset_s = None
+
+        previous_offset_s = (
+            previous_sync.get("best_offset_s") if isinstance(previous_sync, dict) else None
+        )
+        fresh_offset_s = fresh_sync.get("best_offset_s") if isinstance(fresh_sync, dict) else None
+
+        selection_log = {
+            "selection": selected_source,
+            "selection_reason": selected_reason,
+            "selected_offset_s": selected_offset_s,
+            "selected_age_s": round(selected_age_s, 3) if selected_age_s is not None else None,
+            "fresh": self._clock_sync_summary_for_log(fresh_sync),
+            "previous": self._clock_sync_summary_for_log(previous_sync),
+            "fresh_error": fresh_error,
+            "fresh_delta_from_previous_ms": (
+                round((fresh_offset_s - previous_offset_s) * 1000.0, 3)
+                if fresh_offset_s is not None and previous_offset_s is not None
+                else None
+            ),
+        }
+
+        if selected_sync is not None:
+            logger.info(
+                "[TRIGGER] OPS clock sync selected: %s offset=%.6fs age=%sms "
+                "(fresh=%s, previous=%s, delta=%sms)",
+                selected_source,
+                selected_offset_s,
+                "n/a" if selected_age_s is None else f"{selected_age_s:.1f}",
+                fresh_reason,
+                previous_reason,
+                "n/a"
+                if selection_log["fresh_delta_from_previous_ms"] is None
+                else f"{selection_log['fresh_delta_from_previous_ms']:.1f}",
+            )
+        else:
+            logger.info(
+                "[TRIGGER] OPS clock sync fallback to first-byte timing: %s",
+                selected_reason,
+            )
+
+        return selection_log
 
     def wait_for_trigger(
         self,
@@ -849,44 +1055,6 @@ class SoundTrigger(TriggerStrategy):
         if first_byte_timestamp is not None and capture.first_byte_timestamp is None:
             capture.first_byte_timestamp = float(first_byte_timestamp)
 
-        clock_sync = getattr(radar, "last_clock_sync", None)
-        clock_sync_usable = (
-            bool(clock_sync.get("usable_for_trigger_timestamps"))
-            if isinstance(clock_sync, dict)
-            else False
-        )
-        clock_offset_s = (
-            clock_sync.get("best_offset_s")
-            if isinstance(clock_sync, dict) and clock_sync_usable
-            else None
-        )
-        if clock_offset_s is not None:
-            try:
-                capture.apply_trigger_timestamp_from_clock_sync(float(clock_offset_s))
-            except (TypeError, ValueError):
-                logger.warning(
-                    "[TRIGGER] Ignoring invalid OPS clock-sync offset: %r",
-                    clock_offset_s,
-                )
-        elif isinstance(clock_sync, dict) and clock_sync.get("best_offset_s") is not None:
-            logger.info(
-                "[TRIGGER] Ignoring unusable OPS clock sync for trigger timestamp (method=%s)",
-                clock_sync.get("clock_sync_method", "unknown"),
-            )
-
-        if capture.first_byte_timestamp is not None and capture.trigger_timestamp is None:
-            capture.apply_trigger_timestamp_from_first_byte()
-
-        if capture.trigger_timestamp is not None and capture.first_byte_timestamp is not None:
-            logger.info(
-                "[TRIGGER] Sound trigger wall time %.3f "
-                "(source=%s, first byte %.3f, post-trigger %.1fms)",
-                capture.trigger_timestamp,
-                capture.trigger_timestamp_source or "unknown",
-                capture.first_byte_timestamp,
-                capture.post_trigger_duration_ms,
-            )
-
         # Quick validation: does the capture contain any real swing data?
         # At a driving range, a nearby player's impact sound can trip the
         # trigger even though nothing was moving in front of our radar.
@@ -908,6 +1076,21 @@ class SoundTrigger(TriggerStrategy):
                 response_bytes=response_len,
             )
             return None
+
+        self._select_clock_sync_for_capture(radar, capture)
+
+        if capture.first_byte_timestamp is not None and capture.trigger_timestamp is None:
+            capture.apply_trigger_timestamp_from_first_byte()
+
+        if capture.trigger_timestamp is not None and capture.first_byte_timestamp is not None:
+            logger.info(
+                "[TRIGGER] Sound trigger wall time %.3f "
+                "(source=%s, first byte %.3f, post-trigger %.1fms)",
+                capture.trigger_timestamp,
+                capture.trigger_timestamp_source or "unknown",
+                capture.first_byte_timestamp,
+                capture.post_trigger_duration_ms,
+            )
 
         logger.info(
             "[TRIGGER] Sound trigger accepted — peak %.1f mph, %d outbound readings",

--- a/tests/test_ops243.py
+++ b/tests/test_ops243.py
@@ -286,6 +286,16 @@ class TestReadClockSync:
         assert summary["offset_spread_ms"] is not None
         assert summary["offset_spread_ms"] >= 0.0
 
+    def test_store_false_does_not_replace_last_clock_sync(self):
+        existing = {"best_offset_s": 42.0}
+        radar = self._radar(_FakeClockSerial(clock_value="137.429"))
+        radar.last_clock_sync = existing
+
+        summary = radar.read_clock_sync(samples=2, per_read_timeout=0.05, store=False)
+
+        assert summary["best_offset_s"] is not None
+        assert radar.last_clock_sync is existing
+
     def test_no_response_is_handled(self):
         radar = self._radar(_FakeClockSerial(respond=False))
         summary = radar.read_clock_sync(samples=2, per_read_timeout=0.01)

--- a/tests/test_rolling_buffer.py
+++ b/tests/test_rolling_buffer.py
@@ -1,6 +1,7 @@
 """Tests for rolling_buffer module."""
 
 import math
+import time
 from datetime import datetime
 from unittest.mock import MagicMock
 
@@ -592,9 +593,23 @@ class TestSoundTriggerTimestampPropagation:
         radar = MagicMock()
         radar.wait_for_hardware_trigger.return_value = '{"sample_time": 0.0}'
         radar.last_hardware_trigger_first_byte_timestamp = 12345.678
-        radar.last_clock_sync = {
+        radar.last_clock_sync = None
+        radar.read_clock_sync.return_value = {
+            "source": "per_shot",
+            "samples": 3,
+            "valid_samples": 3,
             "best_offset_s": 12000.0,
+            "clock_sync_method": "integer_rollover",
             "usable_for_trigger_timestamps": True,
+            "rollover_uncertainty_ms": 10.0,
+            "reads": [
+                {
+                    "host_after": time.time(),
+                    "host_mid": time.time(),
+                    "radar_clock_s": 100.0,
+                    "read_latency_ms": 1.0,
+                }
+            ],
         }
 
         capture = IQCapture(
@@ -623,6 +638,80 @@ class TestSoundTriggerTimestampPropagation:
         assert result is capture
         assert result.trigger_timestamp == pytest.approx(12100.068)
         assert result.trigger_timestamp_source == "ops_clock_sync"
+        assert radar.last_clock_sync is radar.read_clock_sync.return_value
+        radar.read_clock_sync.assert_called_once_with(samples=36, store=False)
+
+    def test_sound_trigger_uses_recent_previous_sync_when_fresh_sync_is_bad(self):
+        """A bad per-shot C? read should not discard a recent valid sync."""
+        from openflight.rolling_buffer.trigger import SoundTrigger
+
+        now = time.time()
+        radar = MagicMock()
+        radar.wait_for_hardware_trigger.return_value = '{"sample_time": 0.0}'
+        radar.last_hardware_trigger_first_byte_timestamp = 12345.678
+        previous_sync = {
+            "source": "startup",
+            "samples": 3,
+            "valid_samples": 3,
+            "best_offset_s": 12000.0,
+            "clock_sync_method": "integer_rollover",
+            "usable_for_trigger_timestamps": True,
+            "rollover_uncertainty_ms": 10.0,
+            "reads": [
+                {
+                    "host_after": now,
+                    "host_mid": now,
+                    "radar_clock_s": 100.0,
+                    "read_latency_ms": 1.0,
+                }
+            ],
+        }
+        radar.last_clock_sync = previous_sync
+        radar.read_clock_sync.return_value = {
+            "source": "per_shot",
+            "samples": 4,
+            "valid_samples": 2,
+            "best_offset_s": 12100.0,
+            "clock_sync_method": "integer_rollover",
+            "usable_for_trigger_timestamps": True,
+            "rollover_uncertainty_ms": 900.0,
+            "reads": [
+                {
+                    "host_after": now,
+                    "host_mid": now,
+                    "radar_clock_s": None,
+                    "read_latency_ms": 200.0,
+                }
+            ],
+        }
+
+        capture = IQCapture(
+            sample_time=100.000,
+            trigger_time=100.068,
+            i_samples=[2048] * 4096,
+            q_samples=[2048] * 4096,
+        )
+        processor = MagicMock()
+        processor.parse_capture.return_value = capture
+        processor.process_standard.return_value = SpeedTimeline(
+            readings=[
+                SpeedReading(
+                    speed_mph=100.0,
+                    magnitude=1000.0,
+                    timestamp_ms=68.0,
+                    direction="outbound",
+                )
+            ],
+            sample_rate_hz=937.5,
+        )
+
+        trigger = SoundTrigger(pre_trigger_segments=12)
+        result = trigger.wait_for_trigger(radar, processor, timeout=1.0)
+
+        assert result is capture
+        assert result.trigger_timestamp == pytest.approx(12100.068)
+        assert result.trigger_timestamp_source == "ops_clock_sync"
+        assert radar.last_clock_sync is previous_sync
 
     def test_sound_trigger_ignores_unusable_ops_clock_sync(self):
         """Whole-second-only clock sync should not override first-byte timing."""
@@ -635,6 +724,14 @@ class TestSoundTriggerTimestampPropagation:
             "best_offset_s": 12000.0,
             "usable_for_trigger_timestamps": False,
             "clock_sync_method": "integer_unusable_no_rollover",
+        }
+        radar.read_clock_sync.return_value = {
+            "samples": 1,
+            "valid_samples": 0,
+            "best_offset_s": None,
+            "usable_for_trigger_timestamps": False,
+            "clock_sync_method": "no_valid_reads",
+            "reads": [],
         }
 
         capture = IQCapture(


### PR DESCRIPTION
## Summary

This PR refreshes the OPS243 clock sync for each accepted sound-trigger capture instead of relying on the startup/previous sync indefinitely.

The stale OPS clock sync could drift during idle gaps, which shifted the K-LD7 impact timestamp by tens or hundreds of milliseconds. In testing, per-shot sync corrected stale-sync deltas as large as ~370ms while keeping the K-LD7 anchor within roughly one frame of impact.

## Changes

- Read a fresh OPS `C?` clock sync after a sound-trigger capture is accepted.
- Use the fresh sync when it passes quality checks.
- Fall back to a recent previous sync only when the fresh read is invalid.
- Fall back to first-byte timing only when no trustworthy clock sync is available.
- Add clock-sync quality gates for rollover uncertainty and timeout-like reads.
- Prevent diagnostic `read_clock_sync(store=False)` reads from replacing `last_clock_sync`.
- Add tests for fresh sync selection, previous-sync fallback, and non-mutating sync reads.

## Validation

- `uv run pytest tests/test_rolling_buffer.py tests/test_ops243.py -q`
- `uv run ruff check src/openflight/rolling_buffer/trigger.py src/openflight/ops243.py tests/test_rolling_buffer.py tests/test_ops243.py`

Manual validation:
- 9 spaced clap tests over a long-running session: all used fresh sync; anchor timing stayed about `-14ms` to `+13ms`.
- 25 golf shots: all used fresh sync; anchor timing stayed about `-16ms` to `+16ms`.

## Notes

This PR intentionally does not include K-LD7 debug endpoints, timing-analysis tooling, or the planned early K-LD7 snapshot architecture change.
