### PR TITLE
fix: install kld7 driver by default so clean installs don't fail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "flask>=3.1.3",
     "flask-cors>=6.0.2",
     "flask-socketio>=5.6.1",
+    "kld7>=0.2.1",
 ]
 
 [project.optional-dependencies]
@@ -52,8 +53,6 @@ camera = [
     # "picamera2>=0.3.0; sys_platform == 'linux'",
     # "inference-sdk>=0.9.0",  # Roboflow inference API
 ]
-# K-LD7 radar support
-kld7 = ["kld7>=0.2.1"]
 # Analysis tools for I/Q capture data
 analysis = [
     "numpy>=1.20.0",

--- a/scripts/analysis/calibrate_kld7_reflector.py
+++ b/scripts/analysis/calibrate_kld7_reflector.py
@@ -234,7 +234,8 @@ def main() -> int:
     try:
         from kld7 import FrameCode  # type: ignore
     except ImportError:
-        print("[calibrate] kld7 package not installed (uv add kld7).",
+        print("[calibrate] kld7 package not installed. Reinstall the project: "
+              "uv pip install -e '.[ui]'",
               file=sys.stderr)
         return 2
 

--- a/scripts/analysis/capture_kld7_radc.py
+++ b/scripts/analysis/capture_kld7_radc.py
@@ -46,7 +46,7 @@ from pathlib import Path
 try:
     from kld7 import KLD7, FrameCode, KLD7Exception
 except ImportError:
-    print("kld7 package not installed. Run: pip install kld7")
+    print("kld7 package not installed. Reinstall the project: uv pip install -e '.[ui]'")
     sys.exit(1)
 
 # Add src to path for OPS243 import. This script lives in scripts/analysis.

--- a/scripts/hardware-test/test_kld7.py
+++ b/scripts/hardware-test/test_kld7.py
@@ -23,7 +23,7 @@ A golf ball transits the 5m detection zone in ~30ms, so expect only
 (tracked target) since the tracking filter may not lock on in time.
 
 Prerequisites:
-    pip install kld7 pyserial
+    uv pip install -e '.[ui]'   # kld7 ships as a base dependency
 
 Usage:
     # Basic capture (auto-detect port, Ctrl+C to stop)
@@ -56,7 +56,7 @@ from pathlib import Path
 try:
     from kld7 import KLD7, FrameCode, KLD7Exception
 except ImportError:
-    print("Error: kld7 package not installed. Run: pip install kld7")
+    print("Error: kld7 package not installed. Reinstall the project: uv pip install -e '.[ui]'")
     sys.exit(1)
 
 from serial.tools.list_ports import comports

--- a/scripts/start-kiosk.sh
+++ b/scripts/start-kiosk.sh
@@ -416,7 +416,7 @@ fi
 
 # Check if venv exists
 if [ ! -d ".venv" ]; then
-    error "Virtual environment not found. Run: uv venv && uv pip install -e '.[ui,kld7]'"
+    error "Virtual environment not found. Run: uv venv && uv pip install -e '.[ui]'"
     exit 1
 fi
 

--- a/src/openflight/kld7/tracker.py
+++ b/src/openflight/kld7/tracker.py
@@ -196,7 +196,10 @@ class KLD7Tracker:
     def connect(self) -> bool:
         """Connect to K-LD7 and configure for golf."""
         if find_spec("kld7") is None:
-            logger.error("[KLD7] kld7 package not installed. Run: pip install kld7")
+            logger.error(
+                "[KLD7] kld7 package not installed. Reinstall the project: "
+                "uv pip install -e '.[ui]'"
+            )
             return False
 
         port = self.port or _find_port()

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -1,5 +1,6 @@
 """Tests for packaging metadata that affects setup/install behavior."""
 
+import re
 from pathlib import Path
 
 try:
@@ -10,6 +11,25 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
 
 def _pyproject() -> dict:
     return tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+
+def _requirement_name(dependency: str) -> str:
+    """Extract the distribution name from a PEP 508 dependency string."""
+    return re.split(r"[<>=!~ \[;]", dependency, maxsplit=1)[0].strip()
+
+
+def test_kld7_is_installed_by_default():
+    """K-LD7 driver must be a base dependency so every install path includes it.
+
+    The package is a tiny pure-Python wheel whose only requirement (pyserial) is
+    already a base dependency, and the --kld7 runtime flag gates actual hardware
+    use. Shipping it by default avoids the recurring "kld7 package not installed"
+    failure on clean installs, since setup.sh, `uv sync`, and CI do not pull
+    optional extras.
+    """
+    dependencies = _pyproject()["project"]["dependencies"]
+
+    assert any(_requirement_name(dep) == "kld7" for dep in dependencies)
 
 
 def test_camera_dependencies_are_not_installed_by_default():


### PR DESCRIPTION
## Problem
On a clean install the K-LD7 angle radar fails with `kld7 package not installed`, forcing users to manually `pip install kld7`. `kld7` was an optional extra (`.[kld7]`), but no install path actually pulled it in:
- `scripts/setup/setup.sh` installs `.[ui,analysis]` — no `kld7`
- `make install` / `uv sync --group dev` don't install optional extras
- CI doesn't install it either

Only `start-kiosk.sh`'s error message mentioned `.[ui,kld7]`, so the extra was effectively never installed.

## Fix
Move `kld7>=0.2.1` into base `dependencies`. It's a 7KB pure-Python wheel whose only requirement (`pyserial`) is already a base dep, and the `--kld7` runtime flag still gates actual hardware use — so there's minimal downside to shipping it everywhere, and it can't be forgotten by any install path again. The existing defensive `find_spec("kld7")` import guards remain as a safety net.

- Removed the now-redundant `kld7` optional extra
- Updated the `start-kiosk.sh` hint to `.[ui]`
- Updated stale `pip install kld7` / `uv add kld7` messages in the kld7 driver and helper scripts to point at the project install (`uv pip install -e '.[ui]'`)
- Added a regression test asserting `kld7` is a base dependency

## Testing
- `uv run pytest tests/` → 581 passed, 6 skipped
- `uv run ruff check src/openflight/` → clean
- Confirmed `uv run` now auto-installs `kld7` and `import kld7` works
