### PR TITLE
fix(ops): don't truncate buffer dump when sound trigger fires near timeout

### DIFF
--- a/src/openflight/ops243.py
+++ b/src/openflight/ops243.py
@@ -1051,7 +1051,7 @@ class OPS243Radar:
 
         return full_response
 
-    def wait_for_hardware_trigger(self, timeout: float = 30.0) -> str:
+    def wait_for_hardware_trigger(self, timeout: float = 30.0, dump_grace: float = 8.0) -> str:
         """
         Wait for hardware trigger to fire and read the buffer dump.
 
@@ -1060,7 +1060,11 @@ class OPS243Radar:
         (HOST_INT). Used with SoundTrigger (SparkFun SEN-14262).
 
         Args:
-            timeout: Maximum time to wait for trigger data
+            timeout: Maximum time to wait for the trigger to fire
+            dump_grace: Extra time allowed for the dump to finish once the
+                first byte has arrived. The ~46KB rolling-buffer dump takes
+                ~4-5s; a trigger firing near the end of the timeout window
+                must not have its dump cut off by the original deadline.
 
         Returns:
             Raw response string containing JSON lines, or empty string on timeout
@@ -1073,11 +1077,12 @@ class OPS243Radar:
 
         response_lines = []
         start_time = time.time()
+        deadline = start_time + timeout
         last_data_time = None
         bytes_received = 0
         self.last_hardware_trigger_first_byte_timestamp = None
 
-        while (time.time() - start_time) < timeout:
+        while time.time() < deadline:
             if self.serial.in_waiting:
                 first_byte_timestamp = time.time() if last_data_time is None else None
                 chunk = self.serial.read(self.serial.in_waiting)
@@ -1086,6 +1091,9 @@ class OPS243Radar:
                 if first_byte_timestamp is not None:
                     last_data_time = first_byte_timestamp
                     self.last_hardware_trigger_first_byte_timestamp = last_data_time
+                    # The trigger fired — the dump is now in flight. Extend
+                    # the deadline so a late trigger gets its full dump.
+                    deadline = max(deadline, last_data_time + dump_grace)
                     logger.debug(
                         "[OPS] Hardware trigger: first byte after %.1fs",
                         last_data_time - start_time,

--- a/tests/test_ops243.py
+++ b/tests/test_ops243.py
@@ -1,5 +1,7 @@
 """Tests for OPS243 radar driver."""
 
+import time
+
 import pytest
 
 from openflight.ops243 import Direction, OPS243Radar, SpeedReading
@@ -340,3 +342,88 @@ class TestReadClockSync:
         radar.serial = None
         with pytest.raises(ConnectionError):
             radar.read_clock_sync(samples=1)
+
+
+class _ScheduledSerial:
+    """Serial stand-in that releases bytes on a wall-clock schedule.
+
+    Models the rolling-buffer dump: nothing arrives until the hardware
+    trigger fires, then ~46KB streams over several seconds. Schedule is
+    a list of (seconds_after_reset, bytes) pairs.
+    """
+
+    def __init__(self, schedule):
+        self.is_open = True
+        self._schedule = sorted(schedule, key=lambda item: item[0])
+        self._t0 = time.time()
+        self._consumed = 0
+
+    def reset_input_buffer(self):
+        self._t0 = time.time()
+        self._consumed = 0
+
+    def _released(self):
+        elapsed = time.time() - self._t0
+        return b"".join(data for t, data in self._schedule if t <= elapsed)
+
+    @property
+    def in_waiting(self):
+        return len(self._released()) - self._consumed
+
+    def read(self, n):
+        released = self._released()
+        chunk = released[self._consumed : self._consumed + n]
+        self._consumed += len(chunk)
+        return chunk
+
+
+class TestWaitForHardwareTrigger:
+    """Tests for the hardware-trigger read loop (sound trigger path)."""
+
+    # A complete dump ends with a closed Q array — the loop's completeness
+    # check requires '"Q"' followed by ']}'.
+    _DUMP = [
+        b'{"sample_time":946.077}\r\n{"trigger_time":946.145}\r\n',
+        b'{"I":[2168,2187,2155,2154]}\r\n',
+        b'{"Q":[2048,2050,2047,2049]}',
+    ]
+
+    def _radar(self, serial_obj):
+        radar = OPS243Radar.__new__(OPS243Radar)
+        radar.serial = serial_obj
+        radar.last_hardware_trigger_first_byte_timestamp = None
+        return radar
+
+    def test_trigger_near_timeout_still_reads_full_dump(self):
+        """A trigger firing just before the timeout must not truncate the dump.
+
+        Regression test: the wait loop bounded TOTAL elapsed time, so a
+        trigger at 26s of a 30s window had its ~4.5s dump cut off at 30.0s
+        ("Incomplete capture (missing: Q)"). Scaled down: trigger at 0.3s
+        of a 0.4s window, dump completes at 0.7s.
+        """
+        schedule = [
+            (0.30, self._DUMP[0]),
+            (0.50, self._DUMP[1]),
+            (0.70, self._DUMP[2]),
+        ]
+        radar = self._radar(_ScheduledSerial(schedule))
+        response = radar.wait_for_hardware_trigger(timeout=0.4)
+        assert response == b"".join(self._DUMP).decode("ascii")
+
+    def test_no_trigger_returns_empty_after_timeout(self):
+        """With no data at all, the wait still times out promptly."""
+        radar = self._radar(_ScheduledSerial([]))
+        start = time.time()
+        response = radar.wait_for_hardware_trigger(timeout=0.3)
+        assert response == ""
+        assert time.time() - start < 1.5
+
+    def test_complete_dump_returns_before_grace_expires(self):
+        """A dump that finishes early returns immediately on completeness."""
+        schedule = [(0.05, b"".join(self._DUMP))]
+        radar = self._radar(_ScheduledSerial(schedule))
+        start = time.time()
+        response = radar.wait_for_hardware_trigger(timeout=5.0)
+        assert response == b"".join(self._DUMP).decode("ascii")
+        assert time.time() - start < 1.0


### PR DESCRIPTION
## Problem

`wait_for_hardware_trigger()` bounds **total elapsed time**, not time-to-trigger. The 30s wait window and the dump readout share one deadline, so when an impact lands in the last ~5s of the window, the ~46KB rolling-buffer dump (~4-5s at serial speed) gets cut off mid-stream and the shot is silently lost.

At a 30s re-arm cadence this throws away roughly 1 in 6 randomly-timed shots.

## Observed

Live session, 2026-06-12 — trigger fired at 26.0s into the 30s window, read loop died at exactly 30.0s mid-I-array:

```
2026-06-12 09:22:19,438 - ops243 - DEBUG - [OPS] Hardware trigger: first byte after 26.0s
2026-06-12 09:22:23,463 - ops243 - INFO - [OPS] Hardware trigger: 40243 bytes in 30.0s
2026-06-12 09:22:23,463 - openflight.rolling_buffer.trigger - INFO - [TRIGGER] Sound trigger fired, 40243 bytes received
2026-06-12 09:22:24,217 - openflight.rolling_buffer.processor - WARNING - [PROCESSOR] Incomplete capture (missing: Q). Response (40243 bytes): '{"sample_time":946.077}...'
2026-06-12 09:22:24,218 - openflight.rolling_buffer.trigger - WARNING - [TRIGGER] Sound trigger parse failed (40243 bytes received)
```

A complete dump is ~46KB; 40,243 bytes in exactly 30.0s is the deadline killing the read, not a transfer problem.

## Fix

Once the first byte arrives, the trigger has fired and the dump is in flight — extend the deadline to `first_byte + dump_grace` (default 8s, ~2x the worst observed dump time). The existing completeness check (closed `Q` array) and 0.5s-inactivity exit are untouched, so a normal dump still returns the instant it completes; no latency is added to the common path.

- No data at all → still times out at the original `timeout`
- Trigger early in the window → behavior unchanged (deadline only ever extends, `max()`)

## Tests

Wrote the failing test first (`TestWaitForHardwareTrigger` in `tests/test_ops243.py`) using a `_ScheduledSerial` fake that releases bytes on a wall-clock schedule, scaled down (trigger at 0.3s of a 0.4s window, dump completes at 0.7s):

- `test_trigger_near_timeout_still_reads_full_dump` — reproduces the truncation against the old code, passes with the fix
- `test_no_trigger_returns_empty_after_timeout` — timeout path unchanged
- `test_complete_dump_returns_before_grace_expires` — grace adds no latency to a fast dump

Full suite: 636 passed. `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)