### PR TITLE
Add openflight-cloud session uploader

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ scripts/start-kiosk.sh --mock
 
 Then open http://localhost:8080 or use the touchscreen.
 
+### 5. Sync to the cloud (optional)
+
+OpenFlight can push your sessions to the **FlightWeb** cloud so you can review
+shots from any device. It's opt-in, and **raw radar data never leaves your
+Pi** — only shot results and session metadata are uploaded (verify with
+`openflight-cloud push --dry-run`).
+
+`setup.sh` offers to enable this and link your Pi. To do it by hand:
+
+```bash
+openflight-cloud link       # pair this Pi (enter a short code in your browser)
+openflight-cloud status     # linked? queued? parked?
+```
+
+Once linked, sessions sync automatically (on session end and via a ~10-minute
+timer that heals wifi outages). See the **[Cloud Sync Guide](docs/cloud-sync.md)**
+for details.
+
 ### TV Display Mode
 
 OpenFlight also serves a fullscreen-friendly browser display for tablets, TV browsers, or a Chrome tab cast to Chromecast.
@@ -241,6 +259,7 @@ uv run pytest tests/ -v
 - **[Parts List](docs/PARTS.md)** — What to buy
 - **[Sound Trigger Wiring](docs/sound-trigger-wiring.md)** — How to wire the sound trigger
 - **[Raspberry Pi Setup](docs/raspberry-pi-setup.md)** — Full setup guide
+- **[Cloud Sync](docs/cloud-sync.md)** — Push filtered sessions to FlightWeb
 - **[Rolling Buffer & Spin Detection](docs/rolling_buffer_spin_detection.md)** — Spin measurement details
 - **[Dechirped-Sideband Spin Replay](docs/spin-dechirp-replay.md)** — Next-gen spin estimator test bench
 - **[K-LD7 Ball Detection Theory](docs/kld7-ball-detection-theory.md)** — How angle detection works

--- a/docs/cloud-sync-design.md
+++ b/docs/cloud-sync-design.md
@@ -1,0 +1,178 @@
+# OpenFlight Cloud Sync — Client-Side Design (Proposal)
+
+Status: **draft / not implemented**. Design for the two pieces of the planned
+cloud service that live in this (public) repo: the ingest API contract the Pi
+speaks, and the uploader that speaks it. The service itself lives in a
+separate private repo; this document is the interface between them.
+
+Design priorities, in order:
+
+1. **The contract is forever.** Fielded Pis update rarely. The wire format
+   must tolerate old clients indefinitely and evolve additively.
+2. **Never upload raw ADC/I-Q.** Filtered session summaries only — keeps
+   storage costs sane, uploads fast on bad wifi, and is the
+   privacy-friendly default.
+3. **No user babysitting.** Sessions upload themselves when connectivity
+   exists; "no wifi at the range" is a non-event, not a manual step.
+
+---
+
+## 1. Ingest API contract (v1)
+
+All endpoints under `https://<cloud-host>/v1/`, TLS only. Authentication is
+an opaque per-device bearer token (`of_device_...` prefix) — revocable from
+the web app, scoped to one device.
+
+### Device linking (how a Pi gets its token)
+
+Simplified RFC 8628 device-code flow — the user never copies a long token
+onto the Pi:
+
+```
+Pi                                          Cloud
+──                                          ─────
+POST /v1/device-link/start
+  {device_name, client_version}      ─────▶
+                                     ◀───── {link_code: "ABCD-1234",
+                                             poll_token, interval_s, expires_s}
+
+  (Pi prints: "Go to cloud.openflight.example/link
+   and enter code ABCD-1234")
+
+POST /v1/device-link/poll
+  {poll_token}            (repeat)   ─────▶
+                                     ◀───── {status: "pending"}
+                                     ◀───── {status: "linked",
+                                             device_token, device_id}
+```
+
+The user enters the code on the website while signed in. Token is stored at
+`~/.config/openflight/cloud.json`, mode `0600`, never logged.
+
+### Session upload
+
+```
+PUT /v1/sessions/{session_id}
+  Authorization: Bearer <device_token>
+  Content-Type: application/x-ndjson
+  Content-Encoding: gzip
+
+  <filtered session JSONL, gzipped>
+```
+
+- **`session_id` is the `session_uuid` embedded in the `session_start`
+  entry** (a UUID4 written at session creation since format_version 1 /
+  app 0.2.0 — survives file renames and copies). For older sessions that
+  predate the field, the uploader falls back to a deterministic UUIDv5 of
+  `(device_id, session filename)`. Either way the auto-push and the manual
+  push script can both submit the same session and the server dedupes for
+  free; PUT semantics make retries safe.
+- The client prepends one manifest line to the body:
+
+  ```json
+  {"type": "upload_manifest", "format_version": 1, "client_version": "0.2.0",
+   "device_id": "...", "filtered": true, "kept_entry_types": ["session_start", ...]}
+  ```
+
+**Responses:**
+
+| code | meaning | client behavior |
+|---|---|---|
+| 201 | accepted (`{session_id, shot_count}`) | mark pushed |
+| 200 | duplicate — already stored | mark pushed |
+| 401 | token invalid/revoked | stop, flag "needs re-link" |
+| 402 | quota/entitlement exceeded | park, retry daily |
+| 413 | body too large (cap ~20 MB gzipped) | log error, park file |
+| 422 | unparseable (`{reason}`) | log error, park file |
+| 429 | rate limited (`Retry-After`) | back off |
+| 5xx | server trouble | retry with backoff |
+
+`GET /v1/health` → 200, used by the uploader to short-circuit when offline.
+
+### Evolution rules
+
+- The server must **accept and store unknown entry types** (skip parsing,
+  don't reject) — old and new clients coexist for years.
+- Additive changes only within `/v1`; breaking changes get `/v2` and `/v1`
+  keeps working.
+
+---
+
+## 2. Client-side filtering (the raw-ADC strip)
+
+Filtering uses an **allowlist**, not a blocklist — a future heavy entry type
+added to the session logger can never leak to the cloud by accident:
+
+```
+keep:  session_start, session_end, shot_detected, trigger_event, session_error
+drop:  rolling_buffer_capture, iq_blocks, iq_reading, reading_accepted,
+       and anything not on the keep list
+guard: any kept line > 32 KB is dropped and counted (belt and suspenders)
+```
+
+`shot_detected` carries everything the insights product needs (speeds, spin
++ quality/confidence, angles, carry, K-LD7 diagnostics). `trigger_event` and
+`session_error` are small and power reliability insights. Raw I/Q and RADC
+stay on the Pi where they belong — they remain available locally for the
+offline analysis workflows.
+
+A typical filtered session is **tens of KB gzipped** vs tens of MB raw.
+
+---
+
+## 3. The uploader (spool-and-retry)
+
+Lives in the public repo. Three entry points, one mechanism:
+
+```
+openflight-cloud link              # device-link flow (one time)
+openflight-cloud push [--dry-run]  # filter + upload anything unpushed
+openflight-cloud status            # linked? queued? parked? last error?
+```
+
+**Mechanism:**
+
+- The session directory itself is the queue. A session counts as "pushed"
+  when a sidecar marker (`<session>.jsonl.pushed`) exists — originals are
+  never moved or modified, state survives crashes, and no database is
+  involved.
+- A **systemd timer** (every ~10 min) runs `push`; the server process also
+  fires a non-blocking `push` on session end. The timer makes wifi outages
+  self-healing; the hook makes the happy path fast. Neither can ever delay
+  shot processing.
+- Per-file attempt counter (in the sidecar); after ~20 failures the file is
+  parked (`.parked`) and reported by `status` instead of retried forever.
+- `--dry-run` prints exactly which entry lines would upload — the privacy
+  answer to "what are you sending?"
+
+**Config** (`~/.config/openflight/cloud.json`):
+
+```json
+{"endpoint": "https://cloud.openflight.example",
+ "device_token": "of_device_...", "device_id": "...", "enabled": true}
+```
+
+Uploading is **opt-in**: nothing leaves the Pi until the user runs
+`openflight-cloud link`. Later, the interactive `setup.sh` can offer linking
+as an optional step.
+
+---
+
+## 4. Server-side checklist (private repo, for reference)
+
+Not designed here, but the contract above implies: the four endpoints;
+dedupe on `session_id`; entitlement check at ingest (quota → 402);
+blob → object storage; parse kept entries → per-shot rows in Postgres;
+device management UI (list/revoke); link-code UI.
+
+## Open questions
+
+- Tier gating: does the free tier get full history or last-N sessions?
+  (Affects only server; contract unchanged.)
+- Should `iq_reading` summaries (SNR stats, no raw data) join the allowlist
+  later for radar-health insights? Cheap to add — allowlist makes it an
+  explicit decision.
+- AGPL hygiene: the uploader (public repo) is AGPL like everything here;
+  the private service must not import code from this repo unless that code
+  is dual-licensed or contributor-cleared. Keep the boundary at the wire
+  contract.

--- a/docs/cloud-sync.md
+++ b/docs/cloud-sync.md
@@ -23,6 +23,16 @@ openflight-cloud push              # filter + upload anything not yet pushed
 `scripts/setup/setup.sh` offers to enable cloud sync and link the Pi for you
 (on a Raspberry Pi). Everything below can also be done by hand.
 
+> **Upgrading an existing install?** The `openflight-cloud` command is created
+> at install time. If you added cloud sync by pulling new code into a venv that
+> predates it, reinstall so the console script gets wired up:
+>
+> ```bash
+> uv pip install -e .
+> ```
+>
+> Until then you can run it as a module: `python -m openflight.cloud.cli link`.
+
 ## Linking a device
 
 You never copy a long token onto the Pi. Linking uses a short, screen-readable

--- a/docs/cloud-sync.md
+++ b/docs/cloud-sync.md
@@ -1,0 +1,144 @@
+# Cloud Sync
+
+OpenFlight can push your session logs to the **FlightWeb** cloud so you can
+review shots from any device. It's an opt-in `openflight-cloud` CLI that runs
+on the Pi.
+
+> **Privacy promise — raw radar data never leaves your Pi.** The uploader
+> applies an allowlist *before* upload: only shot results and session metadata
+> are sent. Raw I/Q captures, rolling-buffer dumps, and per-reading detections
+> stay local. The server stores exactly what the Pi sends — so the filter is
+> enforced here, on the device. Run `openflight-cloud push --dry-run` any time
+> to see precisely what would be uploaded.
+
+## Quick start
+
+```bash
+openflight-cloud link              # one-time: pair this Pi with your account
+openflight-cloud status            # linked? queued? parked? last error?
+openflight-cloud push --dry-run    # show exactly which entries would upload
+openflight-cloud push              # filter + upload anything not yet pushed
+```
+
+`scripts/setup/setup.sh` offers to enable cloud sync and link the Pi for you
+(on a Raspberry Pi). Everything below can also be done by hand.
+
+## Linking a device
+
+You never copy a long token onto the Pi. Linking uses a short, screen-readable
+code (RFC 8628 device flow):
+
+1. Run `openflight-cloud link`. It prints something like:
+
+   ```
+     Go to https://flightweb.fly.dev/link and enter code:  ABCD-2345
+
+     (waiting up to 900s; sign in and enter the code)
+   ```
+
+2. Open that URL in any browser, sign in, and enter the code.
+3. The Pi detects the pairing, saves its device token, and enables uploads:
+
+   ```
+   Linked! device_id=… . Uploads are now enabled.
+   ```
+
+The code expires after ~15 minutes. If it expires or you mistype, just re-run
+`openflight-cloud link`.
+
+To name the device (defaults to the Pi's hostname):
+
+```bash
+openflight-cloud link --device-name "garage pi"
+```
+
+## How uploads happen
+
+Two triggers, one mechanism — both are safe to run at any time and never block
+shot processing:
+
+- **systemd timer** (`openflight-cloud.timer`, ~every 10 min) runs `push`. This
+  is the safety net that heals wifi outages.
+- **On session end**, the server fires a non-blocking `push` for the fast happy
+  path. If it fails (offline, etc.), the timer picks it up later.
+
+**The session directory is the queue.** No database is involved — state lives
+in sidecar files next to each `session_*.jsonl`, so it survives reboots and
+crashes:
+
+| Sidecar | Meaning |
+|---|---|
+| `<session>.jsonl.pushed` | Successfully uploaded (won't be sent again). |
+| `<session>.jsonl.parked` | Given up on — see `reason`; reported by `status`. |
+| `<session>.jsonl.state`  | In-flight retry counter / quota cooldown. |
+
+Originals are never moved or modified. Uploads are idempotent: re-sending a
+session that's already stored is safe and dedupes server-side.
+
+### What gets retried, what gets parked
+
+| Situation | Behavior |
+|---|---|
+| Network down / server 5xx | Retried on the next timer tick (exponential per-file backoff); parked after ~20 failures. |
+| Rate limited (429) | Backs off for the server-provided interval, then retries. |
+| Quota exceeded (402) | Deferred ~24h, then retried automatically. |
+| Token rejected (401) | All uploads stop and `status` flags **needs re-link** — run `openflight-cloud link` again. |
+| Rejected as malformed/too large (413/422) | Parked (this indicates a client bug and shouldn't happen with correct filtering). |
+
+## Config
+
+Stored at `~/.config/openflight/cloud.json`, mode `0600` (the `device_token` is
+a bearer credential — keep it secret):
+
+```json
+{
+  "endpoint": "https://flightweb.fly.dev",
+  "device_token": "of_device_…",
+  "device_id": "…",
+  "enabled": true
+}
+```
+
+- Written by `link`; read by `push` / `status`.
+- Set `"enabled": false` (or delete the file) to turn the uploader into a no-op
+  without unlinking.
+- `endpoint` is configurable in case the production domain moves.
+
+## systemd units
+
+Installed by `setup.sh`, or by hand:
+
+```bash
+sudo cp scripts/setup/openflight-cloud.{service,timer} /etc/systemd/system/
+# edit User= and the paths if your install isn't /home/coleman/openflight
+sudo systemctl daemon-reload
+sudo systemctl enable --now openflight-cloud.timer
+```
+
+Inspect it:
+
+```bash
+systemctl status openflight-cloud.timer     # next run time
+journalctl -u openflight-cloud.service       # upload logs
+```
+
+The timer is harmless before you link — uploads stay off until a device token
+exists.
+
+## Troubleshooting
+
+- **`status` says "not linked"** — run `openflight-cloud link`.
+- **"needs re-link" / 401** — the token was revoked or rotated. Re-run
+  `openflight-cloud link`; the new token replaces the old one in the config.
+- **A session is parked** — `status` shows the reason and last error. Parked
+  sessions are skipped on future runs. To retry one, delete its
+  `<session>.jsonl.parked` (and `<session>.jsonl.state`) sidecar.
+- **Nothing uploads** — confirm `enabled: true` in the config and that the Pi
+  is online (`openflight-cloud status` reports reachability).
+- **"What is it sending?"** — `openflight-cloud push --dry-run` lists every
+  entry type and count that would be uploaded, and what's dropped.
+
+## See also
+
+- [`docs/openflight-cloud-uploader-spec.md`](openflight-cloud-uploader-spec.md)
+  — the wire contract this client implements (endpoints, status codes, caps).

--- a/docs/cloud-sync.md
+++ b/docs/cloud-sync.md
@@ -18,6 +18,7 @@ openflight-cloud link              # one-time: pair this Pi with your account
 openflight-cloud status            # linked? queued? parked? last error?
 openflight-cloud push --dry-run    # show exactly which entries would upload
 openflight-cloud push              # filter + upload anything not yet pushed
+openflight-cloud push --retry      # also re-attempt parked/failed sessions
 ```
 
 `scripts/setup/setup.sh` offers to enable cloud sync and link the Pi for you
@@ -141,10 +142,18 @@ exists.
 - **"needs re-link" / 401** — the token was revoked or rotated. Re-run
   `openflight-cloud link`; the new token replaces the old one in the config.
 - **A session is parked** — `status` shows the reason and last error. Parked
-  sessions are skipped on future runs. To retry one, delete its
-  `<session>.jsonl.parked` (and `<session>.jsonl.state`) sidecar.
-- **Nothing uploads** — confirm `enabled: true` in the config and that the Pi
-  is online (`openflight-cloud status` reports reachability).
+  sessions are skipped on future runs. Re-attempt all parked/deferred sessions
+  with `openflight-cloud push --retry`.
+- **A session uploaded with 0 shots (or you want to re-send a stored one)** —
+  `status` flags 0-shot uploads by name. Force a re-upload of a specific
+  session (even one already marked pushed) with
+  `openflight-cloud push --retry <session-name>` — `<session-name>` is the
+  filename or any substring of it. Re-uploads are idempotent (the server
+  dedupes), so this is always safe.
+- **Nothing uploads / "Nothing to upload"** — everything is already pushed.
+  Confirm `enabled: true` and that the Pi is online (`status` reports
+  reachability). To re-send a session that was already pushed, use
+  `push --retry <session-name>` as above.
 - **"What is it sending?"** — `openflight-cloud push --dry-run` lists every
   entry type and count that would be uploaded, and what's dropped.
 

--- a/docs/openflight-cloud-uploader-spec.md
+++ b/docs/openflight-cloud-uploader-spec.md
@@ -1,0 +1,272 @@
+# `openflight-cloud` Uploader — Implementation Spec
+
+**Audience:** an agent building the uploader in the public **openflight** repo
+(AGPL-3.0). **Author:** the FlightWeb server team. This describes the wire
+contract **as the server actually implements it today** (verified against the
+deployed code, not the original draft). It supersedes the speculative parts of
+`openflight/docs/cloud-sync-design.md`; where they differ, this wins.
+
+> Drop this file into the openflight repo (e.g. `docs/openflight-cloud-uploader-spec.md`).
+> Nothing here requires importing FlightWeb code — the wire contract *is* the
+> boundary between the two repos.
+
+---
+
+## 0. What you're building
+
+A small CLI, `openflight-cloud`, that lives on the Pi and pushes filtered
+session logs to the FlightWeb cloud. Three subcommands, one spool-and-retry
+mechanism:
+
+```
+openflight-cloud link              # one-time device pairing
+openflight-cloud push [--dry-run]  # filter + upload anything unpushed
+openflight-cloud status            # linked? queued? parked? last error?
+```
+
+**The single most important rule:** the server stores the device-uploaded blob
+**verbatim** — it does *not* re-filter raw radar data out of a device upload.
+Therefore **the uploader MUST apply the allowlist filter (§4) before upload.**
+The product promise "raw radar data never leaves your Pi" is enforced *here*,
+in this client. (The server does filter *manual web uploads* as defense in
+depth, but that path is irrelevant to the Pi.)
+
+---
+
+## 1. Endpoint + transport
+
+- Base URL: configurable; current deployment **`https://flightweb.fly.dev`**.
+  Store it in config — the production domain may move (openflight vs. flightweb
+  is undecided). All paths below are under `/v1`.
+- TLS only. Bearer auth for session upload; link endpoints are unauthenticated.
+- Request/response bodies are JSON except the session-upload body, which is
+  gzipped NDJSON.
+- The server returns `Retry-After` (seconds) on every `429`.
+
+---
+
+## 2. Device linking (RFC 8628-style)
+
+The user never copies a long token onto the Pi. Flow:
+
+### 2a. `POST /v1/device-link/start`
+
+Unauthenticated. Rate limited **per IP: 10 requests / 15 min** (→ `429`).
+
+Request:
+```json
+{ "device_name": "garage pi", "client_version": "0.3.0" }
+```
+- `device_name`: **required, 1–64 chars** (trimmed). Missing/blank/too-long → `422`.
+- `client_version`: optional string.
+
+Response `200`:
+```json
+{ "link_code": "ABCD-2345", "poll_token": "<opaque>", "interval_s": 5, "expires_s": 900 }
+```
+- `link_code` format: `^[ABCDEFGHJKLMNPQRSTUVWXYZ]{4}-[2-9]{4}$` (no I/O/0/1 —
+  built to be read off a screen). Print it for the user:
+  `Go to <endpoint>/link and enter code ABCD-2345`.
+- `poll_token`: high-entropy opaque string; **persist it** for polling. Treat as
+  a secret (don't log).
+- `interval_s` (5): minimum seconds between polls — **honor it**.
+- `expires_s` (900): code/poll lifetime (~15 min).
+
+### 2b. User action (out of band)
+
+The user opens `<endpoint>/link` in a browser, signs in, and enters the code.
+
+### 2c. `POST /v1/device-link/poll`
+
+Rate limited **per poll_token: 30 / 60s** (→ `429`). Poll no faster than
+`interval_s`.
+
+Request:
+```json
+{ "poll_token": "<opaque>" }
+```
+
+Responses (all `200` unless noted):
+| Body | Meaning | Client action |
+|---|---|---|
+| `{"status":"pending"}` | not entered yet | keep polling at `interval_s` |
+| `{"status":"expired"}` | code lifetime passed | stop; tell user to re-run `link` |
+| `{"status":"linked","device_token":"of_device_…","device_id":"<uuid>"}` | paired | **save token + id, stop polling** |
+| `404 {"reason":"unknown_poll_token"}` | unknown OR already consumed | stop; re-run `link` |
+| `429` + `Retry-After` | polling too fast | back off |
+
+**The `linked` response is returned exactly once.** The first successful poll
+after the user enters the code issues the token; any subsequent poll with the
+same `poll_token` gets `404`. So persist `device_token` + `device_id`
+**atomically on first receipt** — if you crash between receiving and saving,
+the user must re-link.
+
+- `device_token` format: `^of_device_[0-9A-Za-z]{32}$`. The server stores only a
+  SHA-256 hash; this plaintext is shown **once**.
+
+---
+
+## 3. Session upload
+
+### `PUT /v1/sessions/{session_id}`
+
+```
+PUT /v1/sessions/1f0e9c2a-7b3d-4e5f-8a9b-0c1d2e3f4a5b
+Authorization: Bearer of_device_<…>
+Content-Type: application/x-ndjson
+Content-Encoding: gzip
+
+<gzipped, filtered NDJSON>
+```
+
+Rate limited **per device: 120 / hour** (→ `429`). A full backlog flush stays
+well under this; if you somehow hit it, honor `Retry-After`.
+
+**`{session_id}`** must be a lowercase UUID (server lowercases anyway, but send
+lowercase). It is:
+- the **`session_uuid`** from the `session_start` entry (UUID4, present since
+  openflight 0.2.0 / format_version 1) — **preferred**; or
+- for older sessions lacking it, a deterministic **UUIDv5 of
+  `(device_id, session_filename)`** so the same file always maps to the same id
+  (free dedupe + safe retries).
+
+If the body contains a `session_start` with a `session_uuid`, it **must equal**
+the URL id (case-insensitive) or you get `422 session_uuid_mismatch`. Simplest:
+always use the embedded `session_uuid` as the URL id when present.
+
+**Body:** gzipped NDJSON, filtered per §4, with a manifest first line (§4).
+PUT is idempotent — re-uploading the same session is safe and dedupes.
+
+### Responses → client behavior
+
+| Code | Body | Meaning | Client action |
+|---|---|---|---|
+| `201` | `{session_id, shot_count}` | accepted, stored | mark `.pushed` |
+| `200` | `{session_id, shot_count}` | duplicate (already stored) | mark `.pushed` |
+| `401` | `{reason}` | bad/revoked/missing token (`missing_or_malformed_token` \| `invalid_or_revoked_token`) | stop all uploads; flag "needs re-link" |
+| `402` | `{reason:"quota_exceeded"}` | over entitlement | park; retry daily |
+| `413` | `{reason}` | too large (`body_too_large` gz>20 MB, or `inflated_too_large` >64 MB) | log + park (should never happen if §4 filtering works) |
+| `422` | `{reason}` | unparseable (`invalid_session_id`, `session_uuid_mismatch`, `invalid_gzip`, `no_valid_jsonl`) | log + park; this is a client bug — surface it |
+| `429` | `{reason:"rate_limited"}` + `Retry-After` | rate limited | back off `Retry-After` seconds |
+| `5xx` | — | server trouble | retry with exponential backoff |
+
+`200` and `201` are both success — treat identically (mark pushed). Don't
+distinguish them for retry purposes.
+
+### `GET /v1/health`
+
+`200 {"status":"ok"}`, unauthenticated, no side effects. Use it to
+short-circuit `push` when offline (cheap connectivity probe before doing work).
+
+---
+
+## 4. Client-side filtering (the raw-ADC strip) — REQUIRED
+
+Build the upload body by transforming the session `.jsonl`:
+
+1. **Prepend one manifest line** as the first line:
+   ```json
+   {"type":"upload_manifest","format_version":1,"client_version":"0.3.0",
+    "device_id":"<id>","filtered":true,"kept_entry_types":[...]}
+   ```
+2. **Keep only allowlisted entry types** (filter by each line's `type`):
+   ```
+   KEEP:  session_start, session_end, shot_detected, trigger_event, session_error
+   DROP:  rolling_buffer_capture, iq_blocks, iq_reading, reading_accepted,
+          ops_clock_sync, shot_camera, config_change, and ANYTHING not on the keep list
+   ```
+   Use an **allowlist, not a blocklist** — a future heavy entry type the session
+   logger gains must never leak by default.
+3. **Drop any kept line > 32 KB** (and count it) — belt-and-suspenders guard
+   matching the server's per-line cap.
+4. **gzip** the result. Keep it under **20 MB gzipped / 64 MB inflated** (a
+   filtered session is normally tens of KB, so this is just a safety check —
+   if a session somehow exceeds it, park the file and report it rather than
+   uploading raw).
+
+`--dry-run` should print exactly which entry lines *would* upload (the privacy
+answer to "what are you sending?"). The server matches this allowlist exactly,
+so anything you keep here is what gets stored.
+
+> Why this is load-bearing: the server stores the device blob **as received**.
+> Whatever you upload is what lives in the cloud. Filtering is not optional.
+
+---
+
+## 5. The uploader mechanism (spool-and-retry)
+
+- **The session directory is the queue.** A session counts as pushed when a
+  sidecar marker `"<session>.jsonl.pushed"` exists. Never move or modify
+  originals — state survives crashes, no database needed.
+- **Triggers:** a **systemd timer** (~every 10 min) runs `push` (heals wifi
+  outages); the server process also fires a non-blocking `push` on session end
+  (fast happy path). Neither may ever block/delay shot processing.
+- **Per-file attempt counter** in the sidecar; after ~20 failures, **park** the
+  file (`"<session>.jsonl.parked"`) and report via `status` instead of
+  retrying forever.
+- **Terminal vs. retryable** (see §3 table): `401` stops everything and flags
+  re-link; `402` parks for daily retry; `413`/`422` park (client bug — these
+  shouldn't happen with correct filtering); `429`/`5xx` back off and retry.
+- Push is **opt-in**: nothing leaves the Pi until the user runs
+  `openflight-cloud link`.
+
+---
+
+## 6. Config — `~/.config/openflight/cloud.json`, mode `0600`
+
+```json
+{ "endpoint": "https://flightweb.fly.dev",
+  "device_token": "of_device_…",
+  "device_id": "…",
+  "enabled": true }
+```
+- `0600`, never logged. `device_token` is a bearer credential.
+- `enabled:false` (or file absent) → uploader is a no-op.
+- Written by `link` on success; read by `push`/`status`.
+
+---
+
+## 7. Evolution rules (so old Pis keep working forever)
+
+- The server **accepts and stores unknown entry types** in the blob (it skips
+  parsing them, doesn't reject) — but you should still filter to the allowlist
+  so raw data doesn't leak.
+- The server **accepts unknown fields** on known entry types.
+- `/v1` is append-only and tolerates old clients indefinitely. Breaking changes
+  would ship as `/v2`; `/v1` keeps working. So a fielded Pi that never updates
+  keeps uploading forever.
+- Send a real `client_version` in `device-link/start` and the manifest — it's
+  stored per-device and helps the server team support old clients.
+
+---
+
+## 8. Reference values (verified against deployed server)
+
+| Thing | Value |
+|---|---|
+| Link code regex | `^[ABCDEFGHJKLMNPQRSTUVWXYZ]{4}-[2-9]{4}$` |
+| Device token regex | `^of_device_[0-9A-Za-z]{32}$` |
+| Poll interval / code TTL | 5 s / 900 s |
+| Rate: link-start | 10 / 15 min per IP |
+| Rate: poll | 30 / 60 s per poll_token |
+| Rate: upload | 120 / hour per device |
+| Caps | 20 MB gzipped, 64 MB inflated, 32 KB per line |
+| Allowlist (keep) | session_start, session_end, shot_detected, trigger_event, session_error (+ upload_manifest) |
+| Health | `GET /v1/health` → `200 {"status":"ok"}` |
+
+---
+
+## 9. Suggested build order
+
+1. `link` against `/v1/device-link/{start,poll}` → write config. Verify a real
+   device row appears (the user will see it on the FlightWeb Devices page).
+2. Filtering + manifest (§4) with `--dry-run` first — get the body exactly right
+   before uploading anything.
+3. `push` for a single session → confirm `201`, then re-run → confirm `200`
+   duplicate.
+4. Spool/sidecar/park mechanics + systemd timer.
+5. `status` reporting.
+
+**Exit test (shared with the server team):** a real Pi runs `link`, the user
+enters the code, a session uploads, and it appears on FlightWeb. That closes
+the Phase 1 loop.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ analysis = [
 
 [project.scripts]
 openflight-server = "openflight.server:main"
+openflight-cloud = "openflight.cloud.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/jewbetcha/openflight"

--- a/scripts/setup/openflight-cloud.service
+++ b/scripts/setup/openflight-cloud.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=OpenFlight cloud uploader (push filtered sessions to FlightWeb)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=coleman
+WorkingDirectory=/home/coleman/openflight
+# Uses the venv's console script; falls back to module form if not on PATH.
+ExecStart=/home/coleman/openflight/.venv/bin/openflight-cloud push
+# Opt-in: this no-ops until the user runs `openflight-cloud link`.

--- a/scripts/setup/openflight-cloud.timer
+++ b/scripts/setup/openflight-cloud.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run the OpenFlight cloud uploader every ~10 minutes (heals wifi outages)
+
+[Timer]
+# Fire shortly after boot, then every 10 minutes. RandomizedDelaySec spreads
+# load so a fleet of Pis doesn't hit the server in lockstep.
+OnBootSec=2min
+OnUnitActiveSec=10min
+RandomizedDelaySec=60
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -269,6 +269,46 @@ if [ "$PLATFORM" == "pi" ] && [ "$DEPS_ONLY" == "false" ] && [ "$INTERACTIVE" ==
         chmod +x "$HOME/Desktop/OpenFlight.desktop"
         log "Desktop shortcut added ✓"
     fi
+
+    # --- Cloud sync (opt-in) ---
+    echo ""
+    info "Cloud sync pushes *filtered* session logs (shots, not raw radar) to"
+    info "FlightWeb so you can review them from anywhere. It is opt-in: nothing"
+    info "leaves this Pi until you link it to your account."
+    echo ""
+    if confirm "Enable cloud sync for this Pi?" "N"; then
+        log "Installing the cloud uploader timer (runs every ~10 min)..."
+        for unit in openflight-cloud.service openflight-cloud.timer; do
+            sed -e "s|^User=.*|User=$USER|" \
+                -e "s|/home/coleman/openflight|$PROJECT_DIR|g" \
+                "$SCRIPT_DIR/$unit" | sudo tee "/etc/systemd/system/$unit" > /dev/null
+        done
+        sudo systemctl daemon-reload
+        sudo systemctl enable --now openflight-cloud.timer
+        log "Cloud uploader timer installed and enabled ✓"
+
+        echo ""
+        if confirm "Link this Pi to your FlightWeb account now?" "Y"; then
+            log "Starting device linking..."
+            echo ""
+            # `openflight-cloud` is on PATH via the activated venv. The command
+            # prints a short code; enter it in your browser when prompted.
+            if openflight-cloud link; then
+                log "Pi linked ✓ — sessions will sync automatically from now on."
+            else
+                warn "Linking did not complete. Re-run any time with:"
+                warn "    openflight-cloud link"
+            fi
+        else
+            info "Skipped. Link later (the timer keeps running, but uploads stay"
+            info "off until you do) with:"
+            info "    openflight-cloud link"
+        fi
+        info "Check sync state any time with: openflight-cloud status"
+    else
+        info "Skipped. Enable later by re-running this script, or see"
+        info "    docs/cloud-sync.md"
+    fi
 elif [ "$PLATFORM" == "pi" ]; then
     info "Skipping hardware setup ($([ "$INTERACTIVE" == "false" ] && echo "non-interactive" || echo "--deps-only"))."
     info "Run ./scripts/setup/setup.sh again without flags to configure hardware."
@@ -290,5 +330,11 @@ echo "    ./scripts/start-kiosk.sh --mock         # Mock mode (no hardware)"
 echo ""
 log "Then open http://localhost:8080 (or use the touchscreen)."
 echo ""
+log "Cloud sync (optional):"
+echo "    openflight-cloud link                   # pair this Pi with FlightWeb"
+echo "    openflight-cloud status                 # linked? queued? parked?"
+echo "    openflight-cloud push --dry-run         # see exactly what would upload"
+echo ""
 log "For details and troubleshooting, see docs/raspberry-pi-setup.md"
+log "For cloud sync details, see docs/cloud-sync.md"
 echo ""

--- a/src/openflight/cloud/cli.py
+++ b/src/openflight/cloud/cli.py
@@ -1,0 +1,91 @@
+"""``openflight-cloud`` command-line entry point.
+
+openflight-cloud link              # one-time device pairing
+openflight-cloud push [--dry-run]  # filter + upload anything unpushed
+openflight-cloud status            # linked? queued? parked? last error?
+"""
+
+import argparse
+from pathlib import Path
+from typing import List, Optional
+
+from ..session_logger import SessionLogger
+from . import commands
+from .client import CloudClient
+from .config import CONFIG_PATH, CloudConfig, load_config
+
+DEFAULT_LOG_DIR = SessionLogger.DEFAULT_LOG_DIR
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    # Shared options usable either before or after the subcommand.
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--config",
+        type=Path,
+        default=CONFIG_PATH,
+        help=f"Path to cloud config (default: {CONFIG_PATH}).",
+    )
+    common.add_argument(
+        "--log-dir",
+        type=Path,
+        default=DEFAULT_LOG_DIR,
+        help=f"Session log directory (default: {DEFAULT_LOG_DIR}).",
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="openflight-cloud",
+        description="Push filtered OpenFlight session logs to the FlightWeb cloud.",
+        parents=[common],
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    link = sub.add_parser(
+        "link", parents=[common], help="Pair this device with a FlightWeb account."
+    )
+    link.add_argument("--device-name", default=None, help="Device label (default: hostname).")
+
+    push = sub.add_parser("push", parents=[common], help="Upload any unpushed sessions.")
+    push.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show exactly which entries would upload; send nothing.",
+    )
+
+    sub.add_parser("status", parents=[common], help="Show link state, queue, and parked sessions.")
+    return parser
+
+
+def _client(config: CloudConfig) -> CloudClient:
+    """Build a CloudClient from persisted config."""
+    return CloudClient(config.endpoint, token=config.device_token or None)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    config = load_config(args.config) or CloudConfig()
+
+    if args.command == "link":
+        ok = commands.cmd_link(config, args.config, _client(config), device_name=args.device_name)
+        return 0 if ok else 1
+
+    if args.command == "push":
+        summary = commands.cmd_push(config, args.log_dir, _client(config), dry_run=args.dry_run)
+        return 1 if summary.get("needs_relink") else 0
+
+    if args.command == "status":
+        commands.cmd_status(config, args.log_dir, _client(config))
+        return 0
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/openflight/cloud/cli.py
+++ b/src/openflight/cloud/cli.py
@@ -51,6 +51,18 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Show exactly which entries would upload; send nothing.",
     )
+    push.add_argument(
+        "--retry",
+        nargs="?",
+        const="__ALL__",
+        default=None,
+        metavar="SESSION",
+        help=(
+            "Re-upload sessions that were parked or failed. Give a session "
+            "filename (or substring) to force re-upload a specific one even if "
+            "it was already sent."
+        ),
+    )
 
     sub.add_parser("status", parents=[common], help="Show link state, queue, and parked sessions.")
     return parser
@@ -76,7 +88,16 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 0 if ok else 1
 
     if args.command == "push":
-        summary = commands.cmd_push(config, args.log_dir, _client(config), dry_run=args.dry_run)
+        retry = args.retry is not None
+        session = None if args.retry == "__ALL__" else args.retry
+        summary = commands.cmd_push(
+            config,
+            args.log_dir,
+            _client(config),
+            dry_run=args.dry_run,
+            retry=retry,
+            session=session,
+        )
         return 1 if summary.get("needs_relink") else 0
 
     if args.command == "status":

--- a/src/openflight/cloud/client.py
+++ b/src/openflight/cloud/client.py
@@ -1,0 +1,247 @@
+"""HTTP client for the FlightWeb cloud wire contract.
+
+Uses the standard library (``urllib``) — no third-party HTTP dependency on the
+Pi. The low-level transport is injectable (``request_fn``) so tests run without
+the network.
+
+The contract lives entirely in this module; nothing here imports FlightWeb
+code. See docs/openflight-cloud-uploader-spec.md.
+"""
+
+import json
+import urllib.error
+import urllib.request
+from collections import namedtuple
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+API_PREFIX = "/v1"
+DEFAULT_TIMEOUT = 30
+
+HttpResponse = namedtuple("HttpResponse", ["status", "headers", "body"])
+
+
+class CloudNetworkError(Exception):
+    """Raised when the request never reached the server (DNS, TLS, offline)."""
+
+
+class RateLimited(Exception):
+    """Raised on a 429 for link endpoints; carries Retry-After seconds."""
+
+    def __init__(self, retry_after: Optional[int]):
+        super().__init__(f"rate limited, retry after {retry_after}s")
+        self.retry_after = retry_after
+
+
+class LinkError(Exception):
+    """Raised when a link request is rejected (e.g. 422 invalid device name)."""
+
+    def __init__(self, message: str, status: int, reason: Optional[str] = None):
+        super().__init__(message)
+        self.status = status
+        self.reason = reason
+
+
+@dataclass
+class LinkStart:
+    """Response from ``device-link/start``: code to show + token to poll."""
+
+    link_code: str
+    poll_token: str
+    interval_s: int
+    expires_s: int
+
+
+@dataclass
+class LinkPoll:
+    """Response from ``device-link/poll``: pending/expired/linked/unknown."""
+
+    status: str
+    device_token: Optional[str] = None
+    device_id: Optional[str] = None
+
+
+@dataclass
+class UploadResult:
+    """Outcome of an upload, with the action the spool layer should take."""
+
+    status_code: int
+    # one of: success, relink, quota, park, rate_limited, retry
+    action: str
+    reason: Optional[str] = None
+    retry_after: Optional[int] = None
+    session_id: Optional[str] = None
+    shot_count: Optional[int] = None
+
+
+def _header(headers: Dict[str, str], name: str) -> Optional[str]:
+    """Case-insensitive header lookup."""
+    lowered = {k.lower(): v for k, v in (headers or {}).items()}
+    return lowered.get(name.lower())
+
+
+def _retry_after(headers: Dict[str, str]) -> Optional[int]:
+    value = _header(headers, "Retry-After")
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def urllib_request(
+    method: str,
+    url: str,
+    data: Optional[bytes] = None,
+    headers: Optional[Dict[str, str]] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> HttpResponse:
+    """Default transport. Returns HttpResponse for any HTTP status (including
+    4xx/5xx); raises CloudNetworkError only when the server was unreachable."""
+    req = urllib.request.Request(url, data=data, headers=headers or {}, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return HttpResponse(
+                status=resp.status,
+                headers=dict(resp.headers.items()),
+                body=resp.read(),
+            )
+    except urllib.error.HTTPError as exc:
+        # HTTP error responses are valid contract responses, not failures.
+        return HttpResponse(
+            status=exc.code,
+            headers=dict(exc.headers.items()) if exc.headers else {},
+            body=exc.read(),
+        )
+    except urllib.error.URLError as exc:
+        raise CloudNetworkError(str(exc.reason)) from exc
+    except (TimeoutError, OSError) as exc:
+        raise CloudNetworkError(str(exc)) from exc
+
+
+class CloudClient:
+    """Thin client over the ``/v1`` wire contract."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        token: Optional[str] = None,
+        request_fn: Callable[..., HttpResponse] = urllib_request,
+        timeout: int = DEFAULT_TIMEOUT,
+    ):
+        self.endpoint = endpoint.rstrip("/")
+        self.token = token
+        self._request = request_fn
+        self.timeout = timeout
+
+    def _url(self, path: str) -> str:
+        return f"{self.endpoint}{API_PREFIX}{path}"
+
+    def _json_request(
+        self, method: str, path: str, payload: Optional[dict] = None, headers: Optional[dict] = None
+    ) -> HttpResponse:
+        body = json.dumps(payload).encode("utf-8") if payload is not None else None
+        hdrs = {"Accept": "application/json"}
+        if body is not None:
+            hdrs["Content-Type"] = "application/json"
+        if headers:
+            hdrs.update(headers)
+        return self._request(method, self._url(path), data=body, headers=hdrs, timeout=self.timeout)
+
+    @staticmethod
+    def _body_json(resp: HttpResponse) -> dict:
+        if not resp.body:
+            return {}
+        try:
+            parsed = json.loads(resp.body.decode("utf-8"))
+            return parsed if isinstance(parsed, dict) else {}
+        except (json.JSONDecodeError, ValueError):
+            return {}
+
+    def health(self) -> bool:
+        """Cheap connectivity probe; True iff the server reports healthy."""
+        try:
+            resp = self._request(
+                "GET", self._url("/health"), data=None, headers=None, timeout=self.timeout
+            )
+        except CloudNetworkError:
+            return False
+        return resp.status == 200 and self._body_json(resp).get("status") == "ok"
+
+    def device_link_start(self, device_name: str, client_version: str) -> LinkStart:
+        """Begin pairing; returns a link code to show the user and a poll token."""
+        resp = self._json_request(
+            "POST",
+            "/device-link/start",
+            {"device_name": device_name, "client_version": client_version},
+        )
+        if resp.status == 429:
+            raise RateLimited(_retry_after(resp.headers))
+        body = self._body_json(resp)
+        if resp.status != 200:
+            raise LinkError(f"link start failed ({resp.status})", resp.status, body.get("reason"))
+        return LinkStart(
+            link_code=body["link_code"],
+            poll_token=body["poll_token"],
+            interval_s=int(body.get("interval_s", 5)),
+            expires_s=int(body.get("expires_s", 900)),
+        )
+
+    def device_link_poll(self, poll_token: str) -> LinkPoll:
+        """Poll for pairing completion; on ``linked`` returns the device token."""
+        resp = self._json_request("POST", "/device-link/poll", {"poll_token": poll_token})
+        if resp.status == 429:
+            raise RateLimited(_retry_after(resp.headers))
+        if resp.status == 404:
+            # Unknown OR already-consumed poll token.
+            return LinkPoll(status="unknown")
+        body = self._body_json(resp)
+        if resp.status != 200:
+            raise LinkError(f"link poll failed ({resp.status})", resp.status, body.get("reason"))
+        return LinkPoll(
+            status=body.get("status", "pending"),
+            device_token=body.get("device_token"),
+            device_id=body.get("device_id"),
+        )
+
+    def upload_session(self, session_id: str, gzipped_body: bytes) -> UploadResult:
+        """PUT a filtered, gzipped session. Maps status -> spool action."""
+        headers = {
+            "Content-Type": "application/x-ndjson",
+            "Content-Encoding": "gzip",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        resp = self._request(
+            "PUT",
+            self._url(f"/sessions/{session_id}"),
+            data=gzipped_body,
+            headers=headers,
+            timeout=self.timeout,
+        )
+        body = self._body_json(resp)
+        reason = body.get("reason")
+
+        if resp.status in (200, 201):
+            return UploadResult(
+                status_code=resp.status,
+                action="success",
+                session_id=body.get("session_id"),
+                shot_count=body.get("shot_count"),
+            )
+        if resp.status == 401:
+            return UploadResult(resp.status, action="relink", reason=reason)
+        if resp.status == 402:
+            return UploadResult(resp.status, action="quota", reason=reason)
+        if resp.status in (413, 422):
+            return UploadResult(resp.status, action="park", reason=reason)
+        if resp.status == 429:
+            return UploadResult(
+                resp.status,
+                action="rate_limited",
+                reason=reason,
+                retry_after=_retry_after(resp.headers),
+            )
+        # 5xx and anything unexpected: back off and retry.
+        return UploadResult(resp.status, action="retry", reason=reason)

--- a/src/openflight/cloud/commands.py
+++ b/src/openflight/cloud/commands.py
@@ -1,0 +1,239 @@
+"""Command orchestration for the openflight-cloud CLI.
+
+Each function takes its dependencies explicitly (config, client, output sink,
+sleep) so the logic is testable without the network or real timers.
+"""
+
+import socket
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from . import filtering, spool
+from .client import CloudNetworkError, RateLimited
+from .config import CloudConfig, save_config
+
+OutFn = Callable[[str], None]
+
+
+def cmd_link(
+    config: CloudConfig,
+    config_path: Path,
+    client,
+    device_name: Optional[str] = None,
+    sleep: Callable[[float], None] = time.sleep,
+    now_fn: Callable[[], float] = time.monotonic,
+    out: OutFn = print,
+) -> bool:
+    """One-time device pairing (RFC 8628-style). Returns True on success."""
+    device_name = (device_name or socket.gethostname() or "openflight pi").strip()[:64]
+    try:
+        start = client.device_link_start(device_name, filtering.CLIENT_VERSION)
+    except RateLimited as exc:
+        out(f"Rate limited starting link; try again in {exc.retry_after}s.")
+        return False
+
+    link_url = f"{config.endpoint.rstrip('/')}/link"
+    out("")
+    out(f"  Go to {link_url} and enter code:  {start.link_code}")
+    out("")
+    out(f"  (waiting up to {start.expires_s}s; sign in and enter the code)")
+
+    deadline = now_fn() + start.expires_s
+    interval = max(1, start.interval_s)
+    while now_fn() < deadline:
+        sleep(interval)
+        try:
+            poll = client.device_link_poll(start.poll_token)
+        except RateLimited as exc:
+            sleep(exc.retry_after or interval)
+            continue
+
+        if poll.status == "pending":
+            continue
+        if poll.status == "linked":
+            # Persist token + id atomically on first receipt — the linked
+            # response is returned exactly once.
+            config.device_token = poll.device_token
+            config.device_id = poll.device_id
+            config.enabled = True
+            save_config(config, config_path)
+            out(f"Linked! device_id={poll.device_id}. Uploads are now enabled.")
+            return True
+        # expired or unknown (consumed/invalid token)
+        out(f"Link {poll.status}. Re-run `openflight-cloud link`.")
+        return False
+
+    out("Link timed out. Re-run `openflight-cloud link`.")
+    return False
+
+
+def _describe_dry_run(filename: str, session_id: str, result: filtering.FilterResult, out: OutFn):
+    out(f"\n{filename}  ->  session {session_id}")
+    if not result.kept_lines:
+        out("  (nothing to upload — no allowlisted entries)")
+    for entry_type in sorted(result.kept_type_counts):
+        out(f"  keep  {result.kept_type_counts[entry_type]:>5} x {entry_type}")
+    if result.dropped_oversize:
+        out(f"  drop  {result.dropped_oversize:>5} oversize line(s) (>32 KB)")
+
+
+def cmd_push(
+    config: CloudConfig,
+    log_dir: Path,
+    client,
+    dry_run: bool = False,
+    out: OutFn = print,
+) -> Dict[str, Any]:
+    """Filter and upload anything unpushed. Returns a summary dict."""
+    summary: Dict[str, Any] = {
+        "uploaded": 0,
+        "parked": 0,
+        "deferred": 0,
+        "failed": 0,
+        "offline": False,
+        "needs_relink": False,
+        "dry_run": dry_run,
+    }
+
+    if not dry_run and not config.is_active():
+        out("Uploader inactive (not linked or disabled). Run `openflight-cloud link`.")
+        summary["skipped"] = "inactive"
+        return summary
+
+    # Cheap connectivity probe so we don't churn while offline.
+    if not dry_run and not client.health():
+        out("Cloud unreachable; will retry later.")
+        summary["offline"] = True
+        return summary
+
+    pending = spool.pending_sessions(log_dir)
+    if not pending:
+        out("Nothing to upload.")
+        return summary
+
+    for path in pending:
+        if not dry_run and spool.in_cooldown(path):
+            summary["deferred"] += 1
+            continue
+
+        lines = path.read_text(errors="replace").splitlines()
+        session_id = filtering.resolve_session_id(lines, config.device_id, path.name)
+        result = filtering.filter_session_lines(lines, config.device_id)
+
+        if dry_run:
+            _describe_dry_run(path.name, session_id, result, out)
+            continue
+
+        try:
+            body = filtering.build_upload_body(result)
+        except filtering.BodyTooLargeError as exc:
+            spool.mark_parked(
+                path,
+                reason="body_too_large",
+                attempts=spool.read_attempts(path),
+                last_error=str(exc),
+            )
+            summary["parked"] += 1
+            out(f"{path.name}: too large after filtering — parked ({exc}).")
+            continue
+
+        try:
+            upload = client.upload_session(session_id, body)
+        except CloudNetworkError as exc:
+            out(f"{path.name}: network error ({exc}); will retry later.")
+            summary["offline"] = True
+            break
+
+        action = upload.action
+        if action == "success":
+            spool.mark_pushed(path, session_id, upload.shot_count)
+            summary["uploaded"] += 1
+            out(f"{path.name}: uploaded ({upload.status_code}).")
+        elif action == "relink":
+            summary["needs_relink"] = True
+            out("Device token rejected. Stopping uploads — re-run `openflight-cloud link`.")
+            break
+        elif action == "quota":
+            spool.record_cooldown(path, "quota_exceeded", spool.QUOTA_COOLDOWN_S)
+            summary["deferred"] += 1
+            out(f"{path.name}: quota exceeded — deferring ~24h.")
+        elif action == "park":
+            spool.mark_parked(
+                path,
+                reason=upload.reason or "client_error",
+                attempts=spool.read_attempts(path),
+                last_error=str(upload.status_code),
+            )
+            summary["parked"] += 1
+            out(f"{path.name}: rejected ({upload.status_code} {upload.reason}) — parked.")
+        elif action == "rate_limited":
+            out(f"Rate limited; backing off {upload.retry_after}s. Will retry later.")
+            summary["rate_limited"] = upload.retry_after
+            break
+        else:  # retry (5xx / unexpected)
+            attempts = spool.record_failure(
+                path, f"{upload.status_code} {upload.reason or ''}".strip()
+            )
+            summary["failed"] += 1
+            if spool.is_parked(path):
+                summary["parked"] += 1
+                out(f"{path.name}: failed {attempts}x — parked.")
+            else:
+                out(f"{path.name}: server error ({upload.status_code}); attempt {attempts}.")
+
+    return summary
+
+
+def cmd_status(
+    config: CloudConfig,
+    log_dir: Path,
+    client=None,
+    out: OutFn = print,
+) -> Dict[str, Any]:
+    """Report link state, queue counts, and parked sessions."""
+    out(f"Endpoint:   {config.endpoint}")
+    if config.is_linked():
+        out(f"Linked:     yes (device_id={config.device_id})")
+        out(f"Enabled:    {'yes' if config.enabled else 'no (uploads paused)'}")
+    else:
+        out("Linked:     no — this device is not linked. Run `openflight-cloud link` to pair it.")
+
+    online = None
+    if client is not None and config.is_active():
+        online = client.health()
+        out(f"Reachable:  {'yes' if online else 'no (cloud unreachable)'}")
+
+    counts = spool.summarize(log_dir)
+    out(
+        f"Sessions:   {counts['total']} total | {counts['pushed']} pushed | "
+        f"{counts['pending']} pending | {counts['parked']} parked"
+    )
+
+    parked = _parked_details(log_dir)
+    if parked:
+        out("Parked:")
+        for name, info in parked:
+            out(f"  {name}: {info.get('reason')} (last_error={info.get('last_error')})")
+
+    return {
+        "counts": counts,
+        "parked": [name for name, _ in parked],
+        "linked": config.is_linked(),
+        "online": online,
+    }
+
+
+def _parked_details(log_dir: Path) -> List:
+    import json
+
+    details = []
+    for path in spool.session_files(log_dir):
+        if spool.is_parked(path):
+            marker = path.with_name(path.name + spool.PARKED_SUFFIX)
+            try:
+                info = json.loads(marker.read_text())
+            except (json.JSONDecodeError, ValueError, OSError):
+                info = {}
+            details.append((path.name, info))
+    return details

--- a/src/openflight/cloud/commands.py
+++ b/src/openflight/cloud/commands.py
@@ -78,14 +78,48 @@ def _describe_dry_run(filename: str, session_id: str, result: filtering.FilterRe
         out(f"  drop  {result.dropped_oversize:>5} oversize line(s) (>32 KB)")
 
 
+def _apply_retry(log_dir: Path, session: Optional[str], out: OutFn) -> int:
+    """Clear markers so failed/parked (or named) sessions upload again.
+
+    Bulk retry (no ``session``) un-parks and clears cooldowns but leaves
+    already-pushed sessions alone. A named ``session`` (filename substring)
+    force-clears even ``.pushed`` so a session the server already stored — e.g.
+    one that landed with 0 shots — can be re-sent. Returns how many matched.
+    """
+    targeted = bool(session)
+    matched = 0
+    for path in spool.session_files(log_dir):
+        if targeted:
+            if session not in path.name:
+                continue
+        elif not (spool.is_parked(path) or spool.in_cooldown(path)):
+            continue
+        cleared = spool.clear_markers(path, include_pushed=targeted)
+        matched += 1
+        if cleared:
+            out(f"{path.name}: reset {', '.join(cleared)} for retry.")
+    if matched == 0:
+        if targeted:
+            out(f"No session matching '{session}'. Run `openflight-cloud status` to list them.")
+        else:
+            out("No parked or deferred sessions to retry.")
+    return matched
+
+
 def cmd_push(
     config: CloudConfig,
     log_dir: Path,
     client,
     dry_run: bool = False,
+    retry: bool = False,
+    session: Optional[str] = None,
     out: OutFn = print,
 ) -> Dict[str, Any]:
-    """Filter and upload anything unpushed. Returns a summary dict."""
+    """Filter and upload anything unpushed. Returns a summary dict.
+
+    With ``retry``, first reset markers so previously parked/failed sessions
+    (or a specific ``session`` by filename substring) are eligible again.
+    """
     summary: Dict[str, Any] = {
         "uploaded": 0,
         "parked": 0,
@@ -100,6 +134,9 @@ def cmd_push(
         out("Uploader inactive (not linked or disabled). Run `openflight-cloud link`.")
         summary["skipped"] = "inactive"
         return summary
+
+    if retry:
+        _apply_retry(log_dir, session, out)
 
     # Cheap connectivity probe so we don't churn while offline.
     if not dry_run and not client.health():
@@ -217,24 +254,43 @@ def cmd_status(
         for name, info in parked:
             out(f"  {name}: {info.get('reason')} (last_error={info.get('last_error')})")
 
+    zero_shot = _zero_shot_uploads(log_dir)
+    if zero_shot:
+        out("Uploaded with 0 shots (re-upload with `openflight-cloud push --retry <name>`):")
+        for name in zero_shot:
+            out(f"  {name}")
+
     return {
         "counts": counts,
         "parked": [name for name, _ in parked],
+        "zero_shot": zero_shot,
         "linked": config.is_linked(),
         "online": online,
     }
 
 
-def _parked_details(log_dir: Path) -> List:
+def _read_marker(path: Path, suffix: str) -> dict:
     import json
 
-    details = []
+    marker = path.with_name(path.name + suffix)
+    try:
+        return json.loads(marker.read_text())
+    except (json.JSONDecodeError, ValueError, OSError):
+        return {}
+
+
+def _parked_details(log_dir: Path) -> List:
+    return [
+        (path.name, _read_marker(path, spool.PARKED_SUFFIX))
+        for path in spool.session_files(log_dir)
+        if spool.is_parked(path)
+    ]
+
+
+def _zero_shot_uploads(log_dir: Path) -> List[str]:
+    """Pushed sessions the server stored with no shots — likely worth re-sending."""
+    names = []
     for path in spool.session_files(log_dir):
-        if spool.is_parked(path):
-            marker = path.with_name(path.name + spool.PARKED_SUFFIX)
-            try:
-                info = json.loads(marker.read_text())
-            except (json.JSONDecodeError, ValueError, OSError):
-                info = {}
-            details.append((path.name, info))
-    return details
+        if spool.is_pushed(path) and not _read_marker(path, spool.PUSHED_SUFFIX).get("shot_count"):
+            names.append(path.name)
+    return names

--- a/src/openflight/cloud/commands.py
+++ b/src/openflight/cloud/commands.py
@@ -117,9 +117,10 @@ def cmd_push(
             summary["deferred"] += 1
             continue
 
-        lines = path.read_text(errors="replace").splitlines()
-        session_id = filtering.resolve_session_id(lines, config.device_id, path.name)
-        result = filtering.filter_session_lines(lines, config.device_id)
+        # Stream the file: a raw-ADC session can be hundreds of MB, but we only
+        # keep the (tiny) shot lines. Loading it whole would risk OOM on a Pi.
+        result = filtering.filter_session_file(path, config.device_id)
+        session_id = result.session_id
 
         if dry_run:
             _describe_dry_run(path.name, session_id, result, out)

--- a/src/openflight/cloud/config.py
+++ b/src/openflight/cloud/config.py
@@ -1,0 +1,65 @@
+"""Persistent config for the openflight-cloud uploader.
+
+Stored at ``~/.config/openflight/cloud.json`` with mode ``0600``. The
+``device_token`` is a bearer credential and must never be logged. The file is
+written by ``link`` on success and read by ``push``/``status``. When the file
+is absent (or ``enabled`` is false) the uploader is a no-op.
+"""
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+# Current deployment. The production domain is undecided (openflight vs.
+# flightweb), so it lives in config and may move.
+DEFAULT_ENDPOINT = "https://flightweb.fly.dev"
+
+CONFIG_PATH = Path.home() / ".config" / "openflight" / "cloud.json"
+
+
+@dataclass
+class CloudConfig:
+    """Uploader configuration persisted to disk."""
+
+    endpoint: str = DEFAULT_ENDPOINT
+    device_token: str = ""
+    device_id: str = ""
+    enabled: bool = True
+
+    def is_linked(self) -> bool:
+        """True when a device token and id are both present."""
+        return bool(self.device_token and self.device_id)
+
+    def is_active(self) -> bool:
+        """True when the uploader should actually push (linked and enabled)."""
+        return self.enabled and self.is_linked()
+
+
+def load_config(path: Path = CONFIG_PATH) -> Optional[CloudConfig]:
+    """Load config from ``path``; return None if the file is absent."""
+    path = Path(path)
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    return CloudConfig(
+        endpoint=data.get("endpoint", DEFAULT_ENDPOINT),
+        device_token=data.get("device_token", ""),
+        device_id=data.get("device_id", ""),
+        enabled=data.get("enabled", True),
+    )
+
+
+def save_config(config: CloudConfig, path: Path = CONFIG_PATH) -> None:
+    """Write config to ``path`` with mode 0600, creating parent dirs."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Create with restrictive permissions from the start so the bearer token is
+    # never briefly world-readable.
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(asdict(config), handle, indent=2)
+        handle.write("\n")
+    # Re-assert mode in case the file already existed with looser permissions.
+    os.chmod(path, 0o600)

--- a/src/openflight/cloud/filtering.py
+++ b/src/openflight/cloud/filtering.py
@@ -1,0 +1,163 @@
+"""Client-side filtering — the raw-ADC strip.
+
+This is the load-bearing privacy boundary. The FlightWeb server stores a
+device upload **verbatim**; it does not re-filter raw radar data out of a
+device upload. So the product promise "raw radar data never leaves your Pi"
+is enforced *here*, by applying an allowlist before upload.
+
+Use an allowlist, not a blocklist — any future heavy entry type the session
+logger gains must never leak by default.
+"""
+
+import gzip
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+from .. import __version__
+
+CLIENT_VERSION = __version__
+
+# Allowlisted entry types — only these are uploaded. ``error`` and
+# ``session_error`` are both kept: the session logger currently emits ``error``
+# (see session_logger.py), while the server spec names ``session_error``;
+# keeping both is privacy-safe (error entries carry only error strings/context,
+# never raw ADC) and future-proofs a rename.
+KEEP_ENTRY_TYPES = frozenset(
+    {
+        "session_start",
+        "session_end",
+        "shot_detected",
+        "trigger_event",
+        "session_error",
+        "error",
+    }
+)
+
+MANIFEST_TYPE = "upload_manifest"
+MANIFEST_FORMAT_VERSION = 1
+
+# Per-line cap mirroring the server's per-line guard. Belt-and-suspenders.
+MAX_LINE_BYTES = 32 * 1024
+# Body caps mirroring the server. A filtered session is normally tens of KB,
+# so these are safety checks, not normal operating limits.
+MAX_GZIP_BYTES = 20 * 1024 * 1024
+MAX_INFLATED_BYTES = 64 * 1024 * 1024
+
+# Fixed namespace for deterministic UUIDv5 of (device_id, session_filename),
+# used for older sessions that predate the embedded session_uuid. A stable
+# namespace makes the same file always map to the same id (dedupe + safe retry).
+SESSION_NAMESPACE = uuid.UUID("8d8ac610-566d-4ef0-9c22-186b2a5ed793")
+
+
+class BodyTooLargeError(Exception):
+    """Raised when a filtered body exceeds the gzip/inflated caps."""
+
+
+@dataclass
+class FilterResult:
+    """Outcome of filtering one session file."""
+
+    manifest: Dict[str, Any]
+    kept_lines: List[str]
+    dropped_oversize: int = 0
+    kept_type_counts: Dict[str, int] = field(default_factory=dict)
+
+
+def _iter_entries(lines: Iterable[str]):
+    """Yield (raw_line, parsed_dict) for parseable JSON lines, skipping junk."""
+    for raw in lines:
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(parsed, dict):
+            yield stripped, parsed
+
+
+def resolve_session_id(lines: Iterable[str], device_id: str, filename: str) -> str:
+    """Resolve the upload session id.
+
+    Prefer the ``session_uuid`` embedded in the ``session_start`` entry
+    (present since openflight 0.2.0). For older sessions lacking it, fall back
+    to a deterministic UUIDv5 of ``(device_id, filename)`` so the same file
+    always maps to the same id. Always lowercase.
+    """
+    for _, entry in _iter_entries(lines):
+        if entry.get("type") == "session_start":
+            session_uuid = entry.get("session_uuid")
+            if session_uuid:
+                return str(session_uuid).lower()
+            break
+    return str(uuid.uuid5(SESSION_NAMESPACE, f"{device_id}:{filename}"))
+
+
+def filter_session_lines(
+    lines: Iterable[str], device_id: str, client_version: str = CLIENT_VERSION
+) -> FilterResult:
+    """Filter raw session lines to the allowlist and build the manifest.
+
+    Drops non-allowlisted types, drops any kept line over ``MAX_LINE_BYTES``
+    (counting them), and skips blank/unparseable lines.
+    """
+    kept_lines: List[str] = []
+    kept_type_counts: Dict[str, int] = {}
+    dropped_oversize = 0
+
+    for raw, entry in _iter_entries(lines):
+        entry_type = entry.get("type")
+        if entry_type not in KEEP_ENTRY_TYPES:
+            continue
+        if len(raw.encode("utf-8")) > MAX_LINE_BYTES:
+            dropped_oversize += 1
+            continue
+        kept_lines.append(raw)
+        kept_type_counts[entry_type] = kept_type_counts.get(entry_type, 0) + 1
+
+    manifest = {
+        "type": MANIFEST_TYPE,
+        "format_version": MANIFEST_FORMAT_VERSION,
+        "client_version": client_version,
+        "device_id": device_id,
+        "filtered": True,
+        "kept_entry_types": sorted(kept_type_counts),
+    }
+    return FilterResult(
+        manifest=manifest,
+        kept_lines=kept_lines,
+        dropped_oversize=dropped_oversize,
+        kept_type_counts=kept_type_counts,
+    )
+
+
+def build_upload_body(
+    result: FilterResult,
+    max_gzip_bytes: Optional[int] = None,
+    max_inflated_bytes: Optional[int] = None,
+) -> bytes:
+    """Build the gzipped NDJSON upload body (manifest first), enforcing caps.
+
+    Raises BodyTooLargeError if the body would exceed either cap — the caller
+    should park the session and report it rather than upload raw.
+    """
+    # Resolve at call time so tests (and config) can adjust the module caps.
+    max_gzip_bytes = MAX_GZIP_BYTES if max_gzip_bytes is None else max_gzip_bytes
+    max_inflated_bytes = MAX_INFLATED_BYTES if max_inflated_bytes is None else max_inflated_bytes
+    out_lines = [json.dumps(result.manifest)]
+    out_lines.extend(result.kept_lines)
+    ndjson = ("\n".join(out_lines) + "\n").encode("utf-8")
+
+    if len(ndjson) > max_inflated_bytes:
+        raise BodyTooLargeError(
+            f"inflated body {len(ndjson)} bytes exceeds cap {max_inflated_bytes}"
+        )
+
+    # mtime=0 keeps the gzip output deterministic (stable retries/dedupe).
+    body = gzip.compress(ndjson, mtime=0)
+    if len(body) > max_gzip_bytes:
+        raise BodyTooLargeError(f"gzip body {len(body)} bytes exceeds cap {max_gzip_bytes}")
+    return body

--- a/src/openflight/cloud/filtering.py
+++ b/src/openflight/cloud/filtering.py
@@ -13,6 +13,7 @@ import gzip
 import json
 import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
 from .. import __version__
@@ -63,6 +64,7 @@ class FilterResult:
     kept_lines: List[str]
     dropped_oversize: int = 0
     kept_type_counts: Dict[str, int] = field(default_factory=dict)
+    session_id: str = ""
 
 
 def _iter_entries(lines: Iterable[str]):
@@ -79,37 +81,27 @@ def _iter_entries(lines: Iterable[str]):
             yield stripped, parsed
 
 
-def resolve_session_id(lines: Iterable[str], device_id: str, filename: str) -> str:
-    """Resolve the upload session id.
-
-    Prefer the ``session_uuid`` embedded in the ``session_start`` entry
-    (present since openflight 0.2.0). For older sessions lacking it, fall back
-    to a deterministic UUIDv5 of ``(device_id, filename)`` so the same file
-    always maps to the same id. Always lowercase.
-    """
-    for _, entry in _iter_entries(lines):
-        if entry.get("type") == "session_start":
-            session_uuid = entry.get("session_uuid")
-            if session_uuid:
-                return str(session_uuid).lower()
-            break
-    return str(uuid.uuid5(SESSION_NAMESPACE, f"{device_id}:{filename}"))
-
-
-def filter_session_lines(
-    lines: Iterable[str], device_id: str, client_version: str = CLIENT_VERSION
+def _filter_entries(
+    lines: Iterable[str], device_id: str, filename: str, client_version: str
 ) -> FilterResult:
-    """Filter raw session lines to the allowlist and build the manifest.
+    """Single-pass core: consume ``lines`` once, applying the allowlist.
 
-    Drops non-allowlisted types, drops any kept line over ``MAX_LINE_BYTES``
-    (counting them), and skips blank/unparseable lines.
+    Works on any line iterable — including an open file object, which streams
+    line by line so a huge raw-ADC session is never held in memory at once.
+    Captures the ``session_uuid`` from ``session_start`` during the same pass
+    so we don't need a second read to resolve the upload id.
     """
     kept_lines: List[str] = []
     kept_type_counts: Dict[str, int] = {}
     dropped_oversize = 0
+    embedded_uuid = ""
 
     for raw, entry in _iter_entries(lines):
         entry_type = entry.get("type")
+        if entry_type == "session_start" and not embedded_uuid:
+            session_uuid = entry.get("session_uuid")
+            if session_uuid:
+                embedded_uuid = str(session_uuid).lower()
         if entry_type not in KEEP_ENTRY_TYPES:
             continue
         if len(raw.encode("utf-8")) > MAX_LINE_BYTES:
@@ -118,6 +110,7 @@ def filter_session_lines(
         kept_lines.append(raw)
         kept_type_counts[entry_type] = kept_type_counts.get(entry_type, 0) + 1
 
+    session_id = embedded_uuid or str(uuid.uuid5(SESSION_NAMESPACE, f"{device_id}:{filename}"))
     manifest = {
         "type": MANIFEST_TYPE,
         "format_version": MANIFEST_FORMAT_VERSION,
@@ -131,7 +124,35 @@ def filter_session_lines(
         kept_lines=kept_lines,
         dropped_oversize=dropped_oversize,
         kept_type_counts=kept_type_counts,
+        session_id=session_id,
     )
+
+
+def filter_session_lines(
+    lines: Iterable[str],
+    device_id: str,
+    client_version: str = CLIENT_VERSION,
+    filename: str = "",
+) -> FilterResult:
+    """Filter raw session lines to the allowlist and build the manifest.
+
+    Drops non-allowlisted types, drops any kept line over ``MAX_LINE_BYTES``
+    (counting them), and skips blank/unparseable lines. ``filename`` is only
+    used for the UUIDv5 session-id fallback when no ``session_uuid`` is present.
+    """
+    return _filter_entries(lines, device_id, filename, client_version)
+
+
+def filter_session_file(path, device_id: str, client_version: str = CLIENT_VERSION) -> FilterResult:
+    """Stream-filter a session file by path without loading it into memory.
+
+    The raw ADC (rolling_buffer_capture / kld7_buffer / iq_blocks) is dropped as
+    each line is read, so peak memory stays near a single line regardless of how
+    large the raw-ADC file is. This is the production path for ``push``.
+    """
+    path = Path(path)
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        return _filter_entries(handle, device_id, path.name, client_version)
 
 
 def build_upload_body(

--- a/src/openflight/cloud/spool.py
+++ b/src/openflight/cloud/spool.py
@@ -1,0 +1,164 @@
+"""Spool-and-retry mechanics — the session directory *is* the queue.
+
+State lives in sidecar files next to each ``session_*.jsonl`` so it survives
+crashes with no database:
+
+- ``<session>.jsonl.pushed`` — present once accepted by the server (terminal).
+- ``<session>.jsonl.parked`` — present once given up on (terminal).
+- ``<session>.jsonl.state`` — JSON attempt counter + last error for in-flight
+  retries; removed on success.
+
+Originals are never moved or modified.
+"""
+
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+PUSHED_SUFFIX = ".pushed"
+PARKED_SUFFIX = ".parked"
+STATE_SUFFIX = ".state"
+
+SESSION_GLOB = "session_*.jsonl"
+
+# After this many failures, park the file and report via ``status`` instead of
+# retrying forever.
+MAX_ATTEMPTS = 20
+
+# How long to defer a session after a quota (402) rejection — retry daily
+# rather than every timer tick.
+QUOTA_COOLDOWN_S = 24 * 60 * 60
+
+
+def _sidecar(path: Path, suffix: str) -> Path:
+    # Append (not replace) so "session_x.jsonl" -> "session_x.jsonl.pushed".
+    return path.with_name(path.name + suffix)
+
+
+def _now() -> str:
+    return datetime.now().isoformat()
+
+
+def session_files(log_dir: Path) -> List[Path]:
+    """All session JSONL files in ``log_dir`` (sorted); empty if dir missing."""
+    log_dir = Path(log_dir)
+    if not log_dir.is_dir():
+        return []
+    return sorted(log_dir.glob(SESSION_GLOB))
+
+
+def is_pushed(path: Path) -> bool:
+    """True if a ``.pushed`` marker exists for this session."""
+    return _sidecar(path, PUSHED_SUFFIX).exists()
+
+
+def is_parked(path: Path) -> bool:
+    """True if a ``.parked`` marker exists for this session."""
+    return _sidecar(path, PARKED_SUFFIX).exists()
+
+
+def pending_sessions(log_dir: Path) -> List[Path]:
+    """Session files that are neither pushed nor parked."""
+    return [p for p in session_files(log_dir) if not is_pushed(p) and not is_parked(p)]
+
+
+def read_attempts(path: Path) -> int:
+    """Number of recorded failed attempts for this session (0 if none)."""
+    state_path = _sidecar(path, STATE_SUFFIX)
+    if not state_path.exists():
+        return 0
+    try:
+        return int(json.loads(state_path.read_text()).get("attempts", 0))
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+
+def _write_json(path: Path, data: Dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def record_failure(path: Path, error: str) -> int:
+    """Increment the attempt counter, store the error, and park if maxed out.
+
+    Returns the new attempt count.
+    """
+    attempts = read_attempts(path) + 1
+    _write_json(
+        _sidecar(path, STATE_SUFFIX),
+        {"attempts": attempts, "last_error": error, "last_attempt_at": _now()},
+    )
+    if attempts >= MAX_ATTEMPTS:
+        mark_parked(path, reason="max_attempts", attempts=attempts, last_error=error)
+    return attempts
+
+
+def record_cooldown(path: Path, reason: str, seconds: float, now: Optional[float] = None) -> None:
+    """Defer retries for this session until ``seconds`` from now (e.g. quota).
+
+    Does not increment the failure counter or park — quota is not a client bug.
+    """
+    now = time.time() if now is None else now
+    state_path = _sidecar(path, STATE_SUFFIX)
+    state: Dict[str, Any] = {}
+    if state_path.exists():
+        try:
+            state = json.loads(state_path.read_text())
+        except (json.JSONDecodeError, ValueError):
+            state = {}
+    state.update(
+        {"cooldown_until": now + seconds, "cooldown_reason": reason, "last_attempt_at": _now()}
+    )
+    _write_json(state_path, state)
+
+
+def in_cooldown(path: Path, now: Optional[float] = None) -> bool:
+    """True if this session is deferred (cooldown not yet elapsed)."""
+    now = time.time() if now is None else now
+    state_path = _sidecar(path, STATE_SUFFIX)
+    if not state_path.exists():
+        return False
+    try:
+        until = json.loads(state_path.read_text()).get("cooldown_until")
+    except (json.JSONDecodeError, ValueError):
+        return False
+    return until is not None and now < until
+
+
+def mark_pushed(path: Path, session_id: str, shot_count: Optional[int]) -> None:
+    """Mark a session as successfully uploaded and clear retry state."""
+    _write_json(
+        _sidecar(path, PUSHED_SUFFIX),
+        {"session_id": session_id, "shot_count": shot_count, "pushed_at": _now()},
+    )
+    state_path = _sidecar(path, STATE_SUFFIX)
+    if state_path.exists():
+        state_path.unlink()
+
+
+def mark_parked(path: Path, reason: str, attempts: int, last_error: Optional[str]) -> None:
+    """Mark a session as parked (given up on); reported via ``status``."""
+    _write_json(
+        _sidecar(path, PARKED_SUFFIX),
+        {
+            "reason": reason,
+            "attempts": attempts,
+            "last_error": last_error,
+            "parked_at": _now(),
+        },
+    )
+
+
+def summarize(log_dir: Path) -> Dict[str, int]:
+    """Count pushed / parked / pending sessions for ``status``."""
+    files = session_files(log_dir)
+    pushed = sum(1 for p in files if is_pushed(p))
+    parked = sum(1 for p in files if is_parked(p))
+    pending = sum(1 for p in files if not is_pushed(p) and not is_parked(p))
+    return {
+        "total": len(files),
+        "pushed": pushed,
+        "parked": parked,
+        "pending": pending,
+    }

--- a/src/openflight/cloud/spool.py
+++ b/src/openflight/cloud/spool.py
@@ -150,6 +150,26 @@ def mark_parked(path: Path, reason: str, attempts: int, last_error: Optional[str
     )
 
 
+def clear_markers(path: Path, include_pushed: bool = False) -> List[str]:
+    """Remove terminal/retry markers so a session becomes pending again.
+
+    Clears ``.parked`` and ``.state`` (un-park + reset attempts/cooldown). With
+    ``include_pushed`` also clears ``.pushed`` to force re-upload of a session
+    the server already stored (idempotent server-side). Returns the suffixes
+    actually removed.
+    """
+    suffixes = [PARKED_SUFFIX, STATE_SUFFIX]
+    if include_pushed:
+        suffixes.append(PUSHED_SUFFIX)
+    cleared: List[str] = []
+    for suffix in suffixes:
+        marker = _sidecar(path, suffix)
+        if marker.exists():
+            marker.unlink()
+            cleared.append(suffix)
+    return cleared
+
+
 def summarize(log_dir: Path) -> Dict[str, int]:
     """Count pushed / parked / pending sessions for ``status``."""
     files = session_files(log_dir)

--- a/src/openflight/cloud/trigger.py
+++ b/src/openflight/cloud/trigger.py
@@ -1,0 +1,50 @@
+"""Fire-and-forget push trigger for the server's session-end happy path.
+
+Spawns ``openflight-cloud push`` as a detached subprocess so an upload never
+blocks or delays shot processing. The systemd timer remains the safety net that
+heals wifi outages; this is just the fast path.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+from .config import CONFIG_PATH, CloudConfig
+
+
+def fire_push_async(
+    config: CloudConfig,
+    log_dir: Path,
+    config_path: Path = CONFIG_PATH,
+    popen_fn: Callable[..., object] = subprocess.Popen,
+) -> bool:
+    """Spawn a detached ``push`` if the uploader is active. Never raises.
+
+    Returns True if a push was spawned, False otherwise (inactive or spawn
+    failed). The caller is on the shot/session path, so all errors are
+    swallowed.
+    """
+    if not config.is_active():
+        return False
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "openflight.cloud.cli",
+        "--config",
+        str(config_path),
+        "--log-dir",
+        str(log_dir),
+        "push",
+    ]
+    try:
+        popen_fn(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return True
+    except (OSError, ValueError):
+        return False

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -2037,6 +2037,26 @@ def start_monitor(
         monitor.start(shot_callback=on_shot_detected, live_callback=on_live_reading)
 
 
+def _fire_cloud_push(session_logger):
+    """Best-effort, non-blocking cloud push on session end.
+
+    Fully guarded: the uploader is opt-in and must never delay or break the
+    shot/session path. The systemd timer is the safety net if this no-ops.
+    """
+    try:
+        from .cloud.config import load_config
+        from .cloud.trigger import fire_push_async
+
+        config = load_config()
+        if config is None or not config.is_active():
+            return
+        log_dir = getattr(session_logger, "log_dir", None)
+        if log_dir is not None:
+            fire_push_async(config, log_dir=log_dir)
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+
 def stop_monitor():
     """Stop the launch monitor."""
     global monitor  # pylint: disable=global-statement
@@ -2045,6 +2065,7 @@ def stop_monitor():
     session_logger = get_session_logger()
     if session_logger:
         session_logger.end_session()
+        _fire_cloud_push(session_logger)
 
     if monitor:
         monitor.stop()

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -1,0 +1,58 @@
+"""Tests for the openflight-cloud CLI argument wiring."""
+
+import pytest
+
+from openflight.cloud import cli
+
+
+class TestArgParsing:
+    def test_requires_subcommand(self, capsys):
+        rc = cli.main([])
+        assert rc != 0
+
+    def test_unknown_subcommand_errors(self):
+        with pytest.raises(SystemExit):
+            cli.main(["frobnicate"])
+
+
+class TestDispatch:
+    def test_status_dispatches(self, monkeypatch, tmp_path):
+        called = {}
+
+        def fake_status(config, log_dir, client=None, out=print):
+            called["log_dir"] = log_dir
+            out("status-ran")
+            return {}
+
+        monkeypatch.setattr(cli.commands, "cmd_status", fake_status)
+        rc = cli.main(["status", "--log-dir", str(tmp_path), "--config", str(tmp_path / "c.json")])
+        assert rc == 0
+        assert called["log_dir"] == tmp_path
+
+    def test_push_passes_dry_run_flag(self, monkeypatch, tmp_path):
+        captured = {}
+
+        def fake_push(config, log_dir, client, dry_run=False, out=print):
+            captured["dry_run"] = dry_run
+            return {"needs_relink": False}
+
+        monkeypatch.setattr(cli.commands, "cmd_push", fake_push)
+        cli.main(["push", "--dry-run", "--log-dir", str(tmp_path), "--config", str(tmp_path / "c.json")])
+        assert captured["dry_run"] is True
+
+    def test_push_returns_nonzero_when_relink_needed(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            cli.commands, "cmd_push", lambda *a, **k: {"needs_relink": True}
+        )
+        rc = cli.main(["push", "--log-dir", str(tmp_path), "--config", str(tmp_path / "c.json")])
+        assert rc != 0
+
+    def test_link_dispatches(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(cli.commands, "cmd_link", lambda *a, **k: True)
+        rc = cli.main(["link", "--config", str(tmp_path / "c.json")])
+        assert rc == 0
+
+    def test_link_returns_nonzero_on_failure(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(cli.commands, "cmd_link", lambda *a, **k: False)
+        rc = cli.main(["link", "--config", str(tmp_path / "c.json")])
+        assert rc != 0

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -32,18 +32,63 @@ class TestDispatch:
     def test_push_passes_dry_run_flag(self, monkeypatch, tmp_path):
         captured = {}
 
-        def fake_push(config, log_dir, client, dry_run=False, out=print):
+        def fake_push(config, log_dir, client, dry_run=False, retry=False, session=None, out=print):
             captured["dry_run"] = dry_run
             return {"needs_relink": False}
 
         monkeypatch.setattr(cli.commands, "cmd_push", fake_push)
-        cli.main(["push", "--dry-run", "--log-dir", str(tmp_path), "--config", str(tmp_path / "c.json")])
+        cli.main(
+            ["push", "--dry-run", "--log-dir", str(tmp_path), "--config", str(tmp_path / "c.json")]
+        )
         assert captured["dry_run"] is True
 
-    def test_push_returns_nonzero_when_relink_needed(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(
-            cli.commands, "cmd_push", lambda *a, **k: {"needs_relink": True}
+    def test_push_retry_all(self, monkeypatch, tmp_path):
+        captured = {}
+
+        def fake_push(config, log_dir, client, dry_run=False, retry=False, session=None, out=print):
+            captured.update(retry=retry, session=session)
+            return {"needs_relink": False}
+
+        monkeypatch.setattr(cli.commands, "cmd_push", fake_push)
+        cli.main(
+            ["push", "--retry", "--log-dir", str(tmp_path), "--config", str(tmp_path / "c.json")]
         )
+        assert captured == {"retry": True, "session": None}
+
+    def test_push_retry_named_session(self, monkeypatch, tmp_path):
+        captured = {}
+
+        def fake_push(config, log_dir, client, dry_run=False, retry=False, session=None, out=print):
+            captured.update(retry=retry, session=session)
+            return {"needs_relink": False}
+
+        monkeypatch.setattr(cli.commands, "cmd_push", fake_push)
+        cli.main(
+            [
+                "push",
+                "--retry",
+                "session_20260527",
+                "--log-dir",
+                str(tmp_path),
+                "--config",
+                str(tmp_path / "c.json"),
+            ]
+        )
+        assert captured == {"retry": True, "session": "session_20260527"}
+
+    def test_push_no_retry_by_default(self, monkeypatch, tmp_path):
+        captured = {}
+
+        def fake_push(config, log_dir, client, dry_run=False, retry=False, session=None, out=print):
+            captured.update(retry=retry, session=session)
+            return {"needs_relink": False}
+
+        monkeypatch.setattr(cli.commands, "cmd_push", fake_push)
+        cli.main(["push", "--log-dir", str(tmp_path), "--config", str(tmp_path / "c.json")])
+        assert captured == {"retry": False, "session": None}
+
+    def test_push_returns_nonzero_when_relink_needed(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(cli.commands, "cmd_push", lambda *a, **k: {"needs_relink": True})
         rc = cli.main(["push", "--log-dir", str(tmp_path), "--config", str(tmp_path / "c.json")])
         assert rc != 0
 

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -1,0 +1,166 @@
+"""Tests for the openflight-cloud HTTP client (wire contract)."""
+
+import json
+
+import pytest
+
+from openflight.cloud import client as cl
+
+
+class FakeTransport:
+    """Records requests and returns queued responses."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def __call__(self, method, url, data=None, headers=None, timeout=30):
+        self.calls.append(
+            {"method": method, "url": url, "data": data, "headers": headers or {}}
+        )
+        return self._responses.pop(0)
+
+
+def _resp(status, body=None, headers=None):
+    raw = json.dumps(body).encode() if body is not None else b""
+    return cl.HttpResponse(status=status, headers=headers or {}, body=raw)
+
+
+class TestHealth:
+    def test_ok_returns_true(self):
+        client = cl.CloudClient("https://e.test", request_fn=FakeTransport([_resp(200, {"status": "ok"})]))
+        assert client.health() is True
+
+    def test_non_ok_returns_false(self):
+        client = cl.CloudClient("https://e.test", request_fn=FakeTransport([_resp(503)]))
+        assert client.health() is False
+
+    def test_network_error_returns_false(self):
+        def boom(*a, **k):
+            raise cl.CloudNetworkError("offline")
+
+        client = cl.CloudClient("https://e.test", request_fn=boom)
+        assert client.health() is False
+
+    def test_uses_v1_health_path(self):
+        t = FakeTransport([_resp(200, {"status": "ok"})])
+        cl.CloudClient("https://e.test/", request_fn=t).health()
+        assert t.calls[0]["url"] == "https://e.test/v1/health"
+        assert t.calls[0]["method"] == "GET"
+
+
+class TestDeviceLinkStart:
+    def test_parses_link_start_response(self):
+        body = {
+            "link_code": "ABCD-2345",
+            "poll_token": "secret-token",
+            "interval_s": 5,
+            "expires_s": 900,
+        }
+        t = FakeTransport([_resp(200, body)])
+        client = cl.CloudClient("https://e.test", request_fn=t)
+        result = client.device_link_start("garage pi", "0.2.0")
+        assert result.link_code == "ABCD-2345"
+        assert result.poll_token == "secret-token"
+        assert result.interval_s == 5
+        assert result.expires_s == 900
+
+    def test_sends_device_name_and_version(self):
+        t = FakeTransport([_resp(200, {"link_code": "A", "poll_token": "p", "interval_s": 5, "expires_s": 900})])
+        cl.CloudClient("https://e.test", request_fn=t).device_link_start("garage pi", "9.9.9")
+        sent = json.loads(t.calls[0]["data"].decode())
+        assert sent == {"device_name": "garage pi", "client_version": "9.9.9"}
+        assert t.calls[0]["url"] == "https://e.test/v1/device-link/start"
+
+    def test_422_raises_link_error(self):
+        t = FakeTransport([_resp(422, {"reason": "invalid_device_name"})])
+        with pytest.raises(cl.LinkError):
+            cl.CloudClient("https://e.test", request_fn=t).device_link_start("", "0.2.0")
+
+    def test_429_raises_rate_limited_with_retry_after(self):
+        t = FakeTransport([_resp(429, {"reason": "rate_limited"}, headers={"Retry-After": "42"})])
+        with pytest.raises(cl.RateLimited) as exc:
+            cl.CloudClient("https://e.test", request_fn=t).device_link_start("pi", "0.2.0")
+        assert exc.value.retry_after == 42
+
+
+class TestDeviceLinkPoll:
+    def test_pending(self):
+        t = FakeTransport([_resp(200, {"status": "pending"})])
+        result = cl.CloudClient("https://e.test", request_fn=t).device_link_poll("tok")
+        assert result.status == "pending"
+
+    def test_linked_returns_token_and_id(self):
+        body = {"status": "linked", "device_token": "of_device_x", "device_id": "uuid-1"}
+        t = FakeTransport([_resp(200, body)])
+        result = cl.CloudClient("https://e.test", request_fn=t).device_link_poll("tok")
+        assert result.status == "linked"
+        assert result.device_token == "of_device_x"
+        assert result.device_id == "uuid-1"
+
+    def test_404_maps_to_unknown(self):
+        t = FakeTransport([_resp(404, {"reason": "unknown_poll_token"})])
+        result = cl.CloudClient("https://e.test", request_fn=t).device_link_poll("tok")
+        assert result.status == "unknown"
+
+    def test_429_raises_rate_limited(self):
+        t = FakeTransport([_resp(429, {}, headers={"Retry-After": "5"})])
+        with pytest.raises(cl.RateLimited):
+            cl.CloudClient("https://e.test", request_fn=t).device_link_poll("tok")
+
+
+class TestUploadSession:
+    def _client(self, responses):
+        return cl.CloudClient(
+            "https://e.test", token="of_device_tok", request_fn=FakeTransport(responses)
+        )
+
+    def test_201_is_success(self):
+        r = self._client([_resp(201, {"session_id": "s1", "shot_count": 7})]).upload_session("s1", b"gz")
+        assert r.action == "success"
+        assert r.shot_count == 7
+
+    def test_200_is_success(self):
+        r = self._client([_resp(200, {"session_id": "s1", "shot_count": 7})]).upload_session("s1", b"gz")
+        assert r.action == "success"
+
+    def test_401_needs_relink(self):
+        r = self._client([_resp(401, {"reason": "invalid_or_revoked_token"})]).upload_session("s1", b"gz")
+        assert r.action == "relink"
+
+    def test_402_quota(self):
+        r = self._client([_resp(402, {"reason": "quota_exceeded"})]).upload_session("s1", b"gz")
+        assert r.action == "quota"
+
+    def test_413_parks(self):
+        r = self._client([_resp(413, {"reason": "body_too_large"})]).upload_session("s1", b"gz")
+        assert r.action == "park"
+
+    def test_422_parks(self):
+        r = self._client([_resp(422, {"reason": "invalid_gzip"})]).upload_session("s1", b"gz")
+        assert r.action == "park"
+        assert r.reason == "invalid_gzip"
+
+    def test_429_retry_with_retry_after(self):
+        r = self._client(
+            [_resp(429, {"reason": "rate_limited"}, headers={"Retry-After": "30"})]
+        ).upload_session("s1", b"gz")
+        assert r.action == "rate_limited"
+        assert r.retry_after == 30
+
+    def test_5xx_retry(self):
+        r = self._client([_resp(503)]).upload_session("s1", b"gz")
+        assert r.action == "retry"
+
+    def test_sends_bearer_auth_and_gzip_headers(self):
+        t = FakeTransport([_resp(201, {"session_id": "s1", "shot_count": 1})])
+        cl.CloudClient("https://e.test", token="of_device_tok", request_fn=t).upload_session(
+            "1f0e9c2a-7b3d-4e5f-8a9b-0c1d2e3f4a5b", b"gzbytes"
+        )
+        call = t.calls[0]
+        assert call["method"] == "PUT"
+        assert call["url"] == "https://e.test/v1/sessions/1f0e9c2a-7b3d-4e5f-8a9b-0c1d2e3f4a5b"
+        assert call["headers"]["Authorization"] == "Bearer of_device_tok"
+        assert call["headers"]["Content-Type"] == "application/x-ndjson"
+        assert call["headers"]["Content-Encoding"] == "gzip"
+        assert call["data"] == b"gzbytes"

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -15,9 +15,7 @@ class FakeTransport:
         self.calls = []
 
     def __call__(self, method, url, data=None, headers=None, timeout=30):
-        self.calls.append(
-            {"method": method, "url": url, "data": data, "headers": headers or {}}
-        )
+        self.calls.append({"method": method, "url": url, "data": data, "headers": headers or {}})
         return self._responses.pop(0)
 
 
@@ -28,7 +26,9 @@ def _resp(status, body=None, headers=None):
 
 class TestHealth:
     def test_ok_returns_true(self):
-        client = cl.CloudClient("https://e.test", request_fn=FakeTransport([_resp(200, {"status": "ok"})]))
+        client = cl.CloudClient(
+            "https://e.test", request_fn=FakeTransport([_resp(200, {"status": "ok"})])
+        )
         assert client.health() is True
 
     def test_non_ok_returns_false(self):
@@ -66,7 +66,9 @@ class TestDeviceLinkStart:
         assert result.expires_s == 900
 
     def test_sends_device_name_and_version(self):
-        t = FakeTransport([_resp(200, {"link_code": "A", "poll_token": "p", "interval_s": 5, "expires_s": 900})])
+        t = FakeTransport(
+            [_resp(200, {"link_code": "A", "poll_token": "p", "interval_s": 5, "expires_s": 900})]
+        )
         cl.CloudClient("https://e.test", request_fn=t).device_link_start("garage pi", "9.9.9")
         sent = json.loads(t.calls[0]["data"].decode())
         assert sent == {"device_name": "garage pi", "client_version": "9.9.9"}
@@ -116,16 +118,22 @@ class TestUploadSession:
         )
 
     def test_201_is_success(self):
-        r = self._client([_resp(201, {"session_id": "s1", "shot_count": 7})]).upload_session("s1", b"gz")
+        r = self._client([_resp(201, {"session_id": "s1", "shot_count": 7})]).upload_session(
+            "s1", b"gz"
+        )
         assert r.action == "success"
         assert r.shot_count == 7
 
     def test_200_is_success(self):
-        r = self._client([_resp(200, {"session_id": "s1", "shot_count": 7})]).upload_session("s1", b"gz")
+        r = self._client([_resp(200, {"session_id": "s1", "shot_count": 7})]).upload_session(
+            "s1", b"gz"
+        )
         assert r.action == "success"
 
     def test_401_needs_relink(self):
-        r = self._client([_resp(401, {"reason": "invalid_or_revoked_token"})]).upload_session("s1", b"gz")
+        r = self._client([_resp(401, {"reason": "invalid_or_revoked_token"})]).upload_session(
+            "s1", b"gz"
+        )
         assert r.action == "relink"
 
     def test_402_quota(self):

--- a/tests/test_cloud_commands.py
+++ b/tests/test_cloud_commands.py
@@ -1,0 +1,216 @@
+"""Tests for openflight-cloud command orchestration (link/push/status)."""
+
+import json
+
+import pytest
+
+from openflight.cloud import commands, spool
+from openflight.cloud.client import LinkPoll, LinkStart, UploadResult
+from openflight.cloud.config import CloudConfig
+
+
+class FakeClient:
+    def __init__(self, *, healthy=True, link_start=None, polls=None, uploads=None):
+        self._healthy = healthy
+        self._link_start = link_start
+        self._polls = list(polls or [])
+        self._uploads = list(uploads or [])
+        self.uploaded = []
+
+    def health(self):
+        return self._healthy
+
+    def device_link_start(self, device_name, client_version):
+        return self._link_start
+
+    def device_link_poll(self, poll_token):
+        return self._polls.pop(0)
+
+    def upload_session(self, session_id, body):
+        self.uploaded.append(session_id)
+        return self._uploads.pop(0)
+
+
+def _write_session(tmp_path, name, *entries):
+    path = tmp_path / name
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+    return path
+
+
+def _linked_config():
+    return CloudConfig(
+        endpoint="https://e.test",
+        device_token="of_device_tok",
+        device_id="dev-1",
+        enabled=True,
+    )
+
+
+class TestPush:
+    def test_offline_short_circuits(self, tmp_path):
+        _write_session(tmp_path, "session_a.jsonl", {"type": "session_start"})
+        client = FakeClient(healthy=False)
+        out = []
+        result = commands.cmd_push(_linked_config(), tmp_path, client, out=out.append)
+        assert result["offline"] is True
+        assert client.uploaded == []
+
+    def test_inactive_config_is_noop(self, tmp_path):
+        _write_session(tmp_path, "session_a.jsonl", {"type": "session_start"})
+        config = CloudConfig(enabled=False)
+        client = FakeClient()
+        result = commands.cmd_push(config, tmp_path, client, out=lambda _m: None)
+        assert result["skipped"] == "inactive"
+        assert client.uploaded == []
+
+    def test_success_marks_pushed(self, tmp_path):
+        path = _write_session(
+            tmp_path,
+            "session_a.jsonl",
+            {"type": "session_start", "session_uuid": "1f0e9c2a-7b3d-4e5f-8a9b-0c1d2e3f4a5b"},
+            {"type": "shot_detected", "ball_speed_mph": 90},
+        )
+        client = FakeClient(
+            uploads=[UploadResult(201, action="success", session_id="x", shot_count=1)]
+        )
+        result = commands.cmd_push(_linked_config(), tmp_path, client, out=lambda _m: None)
+        assert client.uploaded == ["1f0e9c2a-7b3d-4e5f-8a9b-0c1d2e3f4a5b"]
+        assert spool.is_pushed(path)
+        assert result["uploaded"] == 1
+
+    def test_dry_run_does_not_upload_or_mark(self, tmp_path):
+        path = _write_session(
+            tmp_path,
+            "session_a.jsonl",
+            {"type": "session_start", "session_uuid": "u"},
+            {"type": "shot_detected", "ball_speed_mph": 90},
+            {"type": "rolling_buffer_capture", "i_samples": [1, 2, 3]},
+        )
+        client = FakeClient()
+        out = []
+        commands.cmd_push(_linked_config(), tmp_path, client, dry_run=True, out=out.append)
+        assert client.uploaded == []
+        assert not spool.is_pushed(path)
+        printed = "\n".join(out)
+        # The privacy answer: shows kept types, hides dropped raw data.
+        assert "shot_detected" in printed
+        assert "session_start" in printed
+        assert "rolling_buffer_capture" not in printed
+
+    def test_relink_stops_and_flags(self, tmp_path):
+        _write_session(tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"})
+        _write_session(tmp_path, "session_b.jsonl", {"type": "session_start", "session_uuid": "b"})
+        client = FakeClient(
+            uploads=[UploadResult(401, action="relink", reason="invalid_or_revoked_token")]
+        )
+        result = commands.cmd_push(_linked_config(), tmp_path, client, out=lambda _m: None)
+        assert result["needs_relink"] is True
+        # Stops after the first 401 — does not attempt the second session.
+        assert len(client.uploaded) == 1
+
+    def test_park_on_422(self, tmp_path):
+        path = _write_session(tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"})
+        client = FakeClient(uploads=[UploadResult(422, action="park", reason="invalid_gzip")])
+        commands.cmd_push(_linked_config(), tmp_path, client, out=lambda _m: None)
+        assert spool.is_parked(path)
+
+    def test_quota_sets_cooldown_not_park(self, tmp_path):
+        path = _write_session(tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"})
+        client = FakeClient(uploads=[UploadResult(402, action="quota", reason="quota_exceeded")])
+        commands.cmd_push(_linked_config(), tmp_path, client, out=lambda _m: None)
+        assert not spool.is_parked(path)
+        assert spool.in_cooldown(path)
+
+    def test_5xx_records_failure_and_leaves_pending(self, tmp_path):
+        path = _write_session(tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"})
+        client = FakeClient(uploads=[UploadResult(503, action="retry")])
+        commands.cmd_push(_linked_config(), tmp_path, client, out=lambda _m: None)
+        assert spool.read_attempts(path) == 1
+        assert not spool.is_pushed(path)
+        assert not spool.is_parked(path)
+
+    def test_oversize_body_parks(self, tmp_path, monkeypatch):
+        path = _write_session(tmp_path, "session_a.jsonl", {"type": "shot_detected", "ball_speed_mph": 90})
+        from openflight.cloud import filtering
+
+        monkeypatch.setattr(filtering, "MAX_GZIP_BYTES", 1)
+        client = FakeClient(uploads=[UploadResult(201, action="success")])
+        commands.cmd_push(_linked_config(), tmp_path, client, out=lambda _m: None)
+        assert client.uploaded == []
+        assert spool.is_parked(path)
+
+    def test_skips_sessions_in_cooldown(self, tmp_path):
+        path = _write_session(tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"})
+        spool.record_cooldown(path, "quota_exceeded", seconds=spool.QUOTA_COOLDOWN_S)
+        client = FakeClient(uploads=[UploadResult(201, action="success")])
+        result = commands.cmd_push(_linked_config(), tmp_path, client, out=lambda _m: None)
+        assert client.uploaded == []
+        assert result["deferred"] == 1
+
+
+class TestLink:
+    def test_links_and_saves_config(self, tmp_path):
+        config_path = tmp_path / "cloud.json"
+        client = FakeClient(
+            link_start=LinkStart("ABCD-2345", "poll-tok", 5, 900),
+            polls=[
+                LinkPoll("pending"),
+                LinkPoll("linked", device_token="of_device_new", device_id="dev-99"),
+            ],
+        )
+        out = []
+        ok = commands.cmd_link(
+            CloudConfig(endpoint="https://e.test"),
+            config_path,
+            client,
+            device_name="garage pi",
+            sleep=lambda _s: None,
+            out=out.append,
+        )
+        assert ok is True
+        saved = json.loads(config_path.read_text())
+        assert saved["device_token"] == "of_device_new"
+        assert saved["device_id"] == "dev-99"
+        assert saved["enabled"] is True
+        assert "ABCD-2345" in "\n".join(out)
+
+    def test_expired_returns_false(self, tmp_path):
+        client = FakeClient(
+            link_start=LinkStart("ABCD-2345", "poll-tok", 5, 900),
+            polls=[LinkPoll("expired")],
+        )
+        ok = commands.cmd_link(
+            CloudConfig(endpoint="https://e.test"),
+            tmp_path / "cloud.json",
+            client,
+            device_name="pi",
+            sleep=lambda _s: None,
+            out=lambda _m: None,
+        )
+        assert ok is False
+        assert not (tmp_path / "cloud.json").exists()
+
+
+class TestStatus:
+    def test_reports_unlinked(self, tmp_path):
+        out = []
+        commands.cmd_status(CloudConfig(), tmp_path, out=out.append)
+        assert "not linked" in "\n".join(out).lower()
+
+    def test_reports_reachability_when_client_given(self, tmp_path):
+        out = []
+        client = FakeClient(healthy=False)
+        result = commands.cmd_status(_linked_config(), tmp_path, client=client, out=out.append)
+        assert result["online"] is False
+        assert "unreachable" in "\n".join(out).lower()
+
+    def test_reports_counts_and_parked(self, tmp_path):
+        a = _write_session(tmp_path, "session_a.jsonl", {"type": "session_start"})
+        b = _write_session(tmp_path, "session_b.jsonl", {"type": "session_start"})
+        spool.mark_pushed(a, "id-a", 2)
+        spool.mark_parked(b, reason="invalid_gzip", attempts=3, last_error="422")
+        out = []
+        commands.cmd_status(_linked_config(), tmp_path, out=out.append)
+        text = "\n".join(out)
+        assert "dev-1" in text
+        assert "invalid_gzip" in text

--- a/tests/test_cloud_commands.py
+++ b/tests/test_cloud_commands.py
@@ -109,20 +109,26 @@ class TestPush:
         assert len(client.uploaded) == 1
 
     def test_park_on_422(self, tmp_path):
-        path = _write_session(tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"})
+        path = _write_session(
+            tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"}
+        )
         client = FakeClient(uploads=[UploadResult(422, action="park", reason="invalid_gzip")])
         commands.cmd_push(_linked_config(), tmp_path, client, out=lambda _m: None)
         assert spool.is_parked(path)
 
     def test_quota_sets_cooldown_not_park(self, tmp_path):
-        path = _write_session(tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"})
+        path = _write_session(
+            tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"}
+        )
         client = FakeClient(uploads=[UploadResult(402, action="quota", reason="quota_exceeded")])
         commands.cmd_push(_linked_config(), tmp_path, client, out=lambda _m: None)
         assert not spool.is_parked(path)
         assert spool.in_cooldown(path)
 
     def test_5xx_records_failure_and_leaves_pending(self, tmp_path):
-        path = _write_session(tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"})
+        path = _write_session(
+            tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"}
+        )
         client = FakeClient(uploads=[UploadResult(503, action="retry")])
         commands.cmd_push(_linked_config(), tmp_path, client, out=lambda _m: None)
         assert spool.read_attempts(path) == 1
@@ -130,7 +136,9 @@ class TestPush:
         assert not spool.is_parked(path)
 
     def test_oversize_body_parks(self, tmp_path, monkeypatch):
-        path = _write_session(tmp_path, "session_a.jsonl", {"type": "shot_detected", "ball_speed_mph": 90})
+        path = _write_session(
+            tmp_path, "session_a.jsonl", {"type": "shot_detected", "ball_speed_mph": 90}
+        )
         from openflight.cloud import filtering
 
         monkeypatch.setattr(filtering, "MAX_GZIP_BYTES", 1)
@@ -140,12 +148,73 @@ class TestPush:
         assert spool.is_parked(path)
 
     def test_skips_sessions_in_cooldown(self, tmp_path):
-        path = _write_session(tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"})
+        path = _write_session(
+            tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"}
+        )
         spool.record_cooldown(path, "quota_exceeded", seconds=spool.QUOTA_COOLDOWN_S)
         client = FakeClient(uploads=[UploadResult(201, action="success")])
         result = commands.cmd_push(_linked_config(), tmp_path, client, out=lambda _m: None)
         assert client.uploaded == []
         assert result["deferred"] == 1
+
+
+class TestPushRetry:
+    def test_retry_all_reuploads_parked_session(self, tmp_path):
+        path = _write_session(
+            tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"}
+        )
+        spool.mark_parked(path, reason="max_attempts", attempts=20, last_error="503")
+        client = FakeClient(uploads=[UploadResult(201, action="success", shot_count=1)])
+        result = commands.cmd_push(
+            _linked_config(), tmp_path, client, retry=True, out=lambda _m: None
+        )
+        assert client.uploaded == ["a"]
+        assert spool.is_pushed(path)
+        assert result["uploaded"] == 1
+
+    def test_retry_all_reuploads_cooled_down_session(self, tmp_path):
+        path = _write_session(
+            tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"}
+        )
+        spool.record_cooldown(path, "quota_exceeded", seconds=spool.QUOTA_COOLDOWN_S)
+        client = FakeClient(uploads=[UploadResult(201, action="success", shot_count=1)])
+        commands.cmd_push(_linked_config(), tmp_path, client, retry=True, out=lambda _m: None)
+        assert client.uploaded == ["a"]
+
+    def test_retry_all_leaves_pushed_sessions_alone(self, tmp_path):
+        path = _write_session(
+            tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"}
+        )
+        spool.mark_pushed(path, "a", 1)
+        client = FakeClient(uploads=[])
+        commands.cmd_push(_linked_config(), tmp_path, client, retry=True, out=lambda _m: None)
+        assert client.uploaded == []
+        assert spool.is_pushed(path)
+
+    def test_retry_named_session_force_reuploads_pushed(self, tmp_path):
+        path = _write_session(
+            tmp_path, "session_20260527_x.jsonl", {"type": "session_start", "session_uuid": "a"}
+        )
+        spool.mark_pushed(path, "a", 0)  # previously "uploaded" with 0 shots
+        client = FakeClient(uploads=[UploadResult(201, action="success", shot_count=5)])
+        commands.cmd_push(
+            _linked_config(), tmp_path, client, retry=True, session="20260527", out=lambda _m: None
+        )
+        assert client.uploaded == ["a"]
+        assert spool.is_pushed(path)
+
+    def test_retry_named_no_match_reports_and_uploads_nothing(self, tmp_path):
+        path = _write_session(
+            tmp_path, "session_a.jsonl", {"type": "session_start", "session_uuid": "a"}
+        )
+        spool.mark_pushed(path, "a", 1)
+        client = FakeClient(uploads=[])
+        out = []
+        commands.cmd_push(
+            _linked_config(), tmp_path, client, retry=True, session="nope", out=out.append
+        )
+        assert client.uploaded == []
+        assert "no" in "\n".join(out).lower()
 
 
 class TestLink:
@@ -203,6 +272,19 @@ class TestStatus:
         result = commands.cmd_status(_linked_config(), tmp_path, client=client, out=out.append)
         assert result["online"] is False
         assert "unreachable" in "\n".join(out).lower()
+
+    def test_flags_zero_shot_uploads_with_retry_hint(self, tmp_path):
+        a = _write_session(tmp_path, "session_zero.jsonl", {"type": "session_start"})
+        b = _write_session(tmp_path, "session_ok.jsonl", {"type": "session_start"})
+        spool.mark_pushed(a, "id-a", 0)
+        spool.mark_pushed(b, "id-b", 12)
+        out = []
+        result = commands.cmd_status(_linked_config(), tmp_path, out=out.append)
+        text = "\n".join(out)
+        assert "session_zero.jsonl" in text
+        assert "--retry" in text
+        assert "session_ok.jsonl" not in text  # healthy uploads aren't nagged
+        assert result["zero_shot"] == ["session_zero.jsonl"]
 
     def test_reports_counts_and_parked(self, tmp_path):
         a = _write_session(tmp_path, "session_a.jsonl", {"type": "session_start"})

--- a/tests/test_cloud_config.py
+++ b/tests/test_cloud_config.py
@@ -1,0 +1,84 @@
+"""Tests for the openflight-cloud config module."""
+
+import json
+import stat
+
+import pytest
+
+from openflight.cloud import config as cfg
+
+
+class TestLoadConfig:
+    def test_returns_none_when_file_absent(self, tmp_path):
+        assert cfg.load_config(tmp_path / "cloud.json") is None
+
+    def test_loads_all_fields(self, tmp_path):
+        path = tmp_path / "cloud.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "endpoint": "https://example.test",
+                    "device_token": "of_device_" + "a" * 32,
+                    "device_id": "abc-123",
+                    "enabled": True,
+                }
+            )
+        )
+        loaded = cfg.load_config(path)
+        assert loaded.endpoint == "https://example.test"
+        assert loaded.device_token == "of_device_" + "a" * 32
+        assert loaded.device_id == "abc-123"
+        assert loaded.enabled is True
+
+    def test_defaults_endpoint_and_enabled_when_missing(self, tmp_path):
+        path = tmp_path / "cloud.json"
+        path.write_text(json.dumps({"device_token": "t", "device_id": "i"}))
+        loaded = cfg.load_config(path)
+        assert loaded.endpoint == cfg.DEFAULT_ENDPOINT
+        assert loaded.enabled is True
+
+
+class TestSaveConfig:
+    def test_writes_file_with_0600_permissions(self, tmp_path):
+        path = tmp_path / "nested" / "cloud.json"
+        config = cfg.CloudConfig(device_token="tok", device_id="id")
+        cfg.save_config(config, path)
+
+        assert path.exists()
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600
+
+    def test_round_trips_through_load(self, tmp_path):
+        path = tmp_path / "cloud.json"
+        config = cfg.CloudConfig(
+            endpoint="https://e.test",
+            device_token="of_device_" + "b" * 32,
+            device_id="dev-9",
+            enabled=False,
+        )
+        cfg.save_config(config, path)
+        loaded = cfg.load_config(path)
+        assert loaded == config
+
+
+class TestIsLinked:
+    def test_true_when_token_and_id_present(self):
+        config = cfg.CloudConfig(device_token="t", device_id="i")
+        assert config.is_linked()
+
+    def test_false_when_token_missing(self):
+        assert not cfg.CloudConfig(device_id="i").is_linked()
+
+    def test_false_when_id_missing(self):
+        assert not cfg.CloudConfig(device_token="t").is_linked()
+
+
+class TestIsActive:
+    def test_active_requires_enabled_and_linked(self):
+        assert cfg.CloudConfig(device_token="t", device_id="i", enabled=True).is_active()
+
+    def test_inactive_when_disabled(self):
+        assert not cfg.CloudConfig(device_token="t", device_id="i", enabled=False).is_active()
+
+    def test_inactive_when_not_linked(self):
+        assert not cfg.CloudConfig(enabled=True).is_active()

--- a/tests/test_cloud_filtering.py
+++ b/tests/test_cloud_filtering.py
@@ -1,0 +1,141 @@
+"""Tests for the openflight-cloud client-side filtering (raw-ADC strip)."""
+
+import gzip
+import json
+import uuid
+
+import pytest
+
+from openflight.cloud import filtering as flt
+
+
+def _line(entry_type, **fields):
+    return json.dumps({"ts": "2026-06-14T00:00:00", "type": entry_type, **fields})
+
+
+class TestResolveSessionId:
+    def test_uses_embedded_session_uuid_lowercased(self):
+        u = "1F0E9C2A-7B3D-4E5F-8A9B-0C1D2E3F4A5B"
+        lines = [_line("session_start", session_uuid=u)]
+        assert flt.resolve_session_id(lines, "dev-1", "session_x.jsonl") == u.lower()
+
+    def test_uuid5_fallback_when_no_session_uuid(self):
+        lines = [_line("session_start")]
+        result = flt.resolve_session_id(lines, "dev-1", "session_x.jsonl")
+        expected = str(uuid.uuid5(flt.SESSION_NAMESPACE, "dev-1:session_x.jsonl"))
+        assert result == expected
+
+    def test_uuid5_fallback_is_deterministic(self):
+        a = flt.resolve_session_id([], "dev-1", "session_x.jsonl")
+        b = flt.resolve_session_id([], "dev-1", "session_x.jsonl")
+        assert a == b
+
+    def test_uuid5_fallback_differs_by_device(self):
+        a = flt.resolve_session_id([], "dev-1", "session_x.jsonl")
+        b = flt.resolve_session_id([], "dev-2", "session_x.jsonl")
+        assert a != b
+
+
+class TestFilterSessionLines:
+    def test_keeps_only_allowlisted_types(self):
+        lines = [
+            _line("session_start", session_uuid="u"),
+            _line("rolling_buffer_capture", i_samples=[1, 2, 3]),
+            _line("shot_detected", ball_speed_mph=100),
+            _line("iq_blocks", blocks=[]),
+            _line("trigger_event", accepted=True),
+            _line("session_end"),
+        ]
+        result = flt.filter_session_lines(lines, device_id="dev-1")
+        kept_types = [json.loads(line)["type"] for line in result.kept_lines]
+        assert kept_types == [
+            "session_start",
+            "shot_detected",
+            "trigger_event",
+            "session_end",
+        ]
+
+    def test_keeps_both_error_and_session_error(self):
+        lines = [
+            _line("error", error="boom"),
+            _line("session_error", error="boom2"),
+        ]
+        result = flt.filter_session_lines(lines, device_id="dev-1")
+        kept_types = [json.loads(line)["type"] for line in result.kept_lines]
+        assert kept_types == ["error", "session_error"]
+
+    def test_drops_unknown_future_type_by_default(self):
+        lines = [_line("some_future_heavy_type", data="x" * 10)]
+        result = flt.filter_session_lines(lines, device_id="dev-1")
+        assert result.kept_lines == []
+
+    def test_drops_kept_line_over_32kb_and_counts_it(self):
+        big = _line("shot_detected", note="x" * (33 * 1024))
+        small = _line("shot_detected", ball_speed_mph=90)
+        result = flt.filter_session_lines([big, small], device_id="dev-1")
+        assert result.dropped_oversize == 1
+        assert len(result.kept_lines) == 1
+
+    def test_ignores_blank_and_unparseable_lines(self):
+        lines = ["", "   ", "not json", _line("shot_detected", ball_speed_mph=90)]
+        result = flt.filter_session_lines(lines, device_id="dev-1")
+        assert len(result.kept_lines) == 1
+
+    def test_manifest_has_expected_shape(self):
+        lines = [
+            _line("session_start", session_uuid="u"),
+            _line("shot_detected", ball_speed_mph=90),
+        ]
+        result = flt.filter_session_lines(lines, device_id="dev-7", client_version="9.9.9")
+        m = result.manifest
+        assert m["type"] == "upload_manifest"
+        assert m["format_version"] == 1
+        assert m["client_version"] == "9.9.9"
+        assert m["device_id"] == "dev-7"
+        assert m["filtered"] is True
+        assert set(m["kept_entry_types"]) == {"session_start", "shot_detected"}
+
+    def test_kept_entry_types_are_sorted_and_unique(self):
+        lines = [
+            _line("shot_detected"),
+            _line("shot_detected"),
+            _line("session_start"),
+        ]
+        result = flt.filter_session_lines(lines, device_id="d")
+        assert result.manifest["kept_entry_types"] == ["session_start", "shot_detected"]
+
+
+class TestBuildUploadBody:
+    def test_body_is_gzip_with_manifest_first(self):
+        lines = [
+            _line("session_start", session_uuid="u"),
+            _line("shot_detected", ball_speed_mph=90),
+        ]
+        result = flt.filter_session_lines(lines, device_id="dev-1")
+        body = flt.build_upload_body(result)
+
+        ndjson = gzip.decompress(body).decode("utf-8")
+        out_lines = ndjson.strip().split("\n")
+        first = json.loads(out_lines[0])
+        assert first["type"] == "upload_manifest"
+        assert json.loads(out_lines[1])["type"] == "session_start"
+        assert json.loads(out_lines[2])["type"] == "shot_detected"
+
+    def test_raises_when_gzip_exceeds_cap(self):
+        result = flt.FilterResult(
+            manifest={"type": "upload_manifest"},
+            kept_lines=[_line("shot_detected", ball_speed_mph=90)],
+            dropped_oversize=0,
+        )
+        # 1-byte caps make any real body too large.
+        with pytest.raises(flt.BodyTooLargeError):
+            flt.build_upload_body(result, max_gzip_bytes=1, max_inflated_bytes=1_000_000)
+
+    def test_raises_when_inflated_exceeds_cap(self):
+        result = flt.FilterResult(
+            manifest={"type": "upload_manifest"},
+            kept_lines=[_line("shot_detected", ball_speed_mph=90)],
+            dropped_oversize=0,
+        )
+        with pytest.raises(flt.BodyTooLargeError):
+            flt.build_upload_body(result, max_gzip_bytes=1_000_000, max_inflated_bytes=1)

--- a/tests/test_cloud_filtering.py
+++ b/tests/test_cloud_filtering.py
@@ -13,29 +13,6 @@ def _line(entry_type, **fields):
     return json.dumps({"ts": "2026-06-14T00:00:00", "type": entry_type, **fields})
 
 
-class TestResolveSessionId:
-    def test_uses_embedded_session_uuid_lowercased(self):
-        u = "1F0E9C2A-7B3D-4E5F-8A9B-0C1D2E3F4A5B"
-        lines = [_line("session_start", session_uuid=u)]
-        assert flt.resolve_session_id(lines, "dev-1", "session_x.jsonl") == u.lower()
-
-    def test_uuid5_fallback_when_no_session_uuid(self):
-        lines = [_line("session_start")]
-        result = flt.resolve_session_id(lines, "dev-1", "session_x.jsonl")
-        expected = str(uuid.uuid5(flt.SESSION_NAMESPACE, "dev-1:session_x.jsonl"))
-        assert result == expected
-
-    def test_uuid5_fallback_is_deterministic(self):
-        a = flt.resolve_session_id([], "dev-1", "session_x.jsonl")
-        b = flt.resolve_session_id([], "dev-1", "session_x.jsonl")
-        assert a == b
-
-    def test_uuid5_fallback_differs_by_device(self):
-        a = flt.resolve_session_id([], "dev-1", "session_x.jsonl")
-        b = flt.resolve_session_id([], "dev-2", "session_x.jsonl")
-        assert a != b
-
-
 class TestFilterSessionLines:
     def test_keeps_only_allowlisted_types(self):
         lines = [
@@ -103,6 +80,79 @@ class TestFilterSessionLines:
         ]
         result = flt.filter_session_lines(lines, device_id="d")
         assert result.manifest["kept_entry_types"] == ["session_start", "shot_detected"]
+
+
+class TestFilterSessionFile:
+    """Streaming filter that reads a file path without materializing it."""
+
+    def _write(self, path, *entries):
+        path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+
+    def test_keeps_shots_and_strips_raw_adc(self, tmp_path):
+        path = tmp_path / "session_x.jsonl"
+        self._write(
+            path,
+            {"type": "session_start", "session_uuid": "1F0E9C2A-7B3D-4E5F-8A9B-0C1D2E3F4A5B"},
+            {"type": "rolling_buffer_capture", "i_samples": [1, 2, 3], "q_samples": [4, 5]},
+            {"type": "shot_detected", "ball_speed_mph": 142},
+            {"type": "kld7_buffer", "frames": [{"radc_b64": "AAAA"}]},
+            {"type": "shot_detected", "ball_speed_mph": 99},
+            {"type": "session_end"},
+        )
+        result = flt.filter_session_file(path, device_id="dev-1")
+        kept_types = [json.loads(line)["type"] for line in result.kept_lines]
+        assert kept_types == ["session_start", "shot_detected", "shot_detected", "session_end"]
+        assert result.kept_type_counts["shot_detected"] == 2
+
+    def test_resolves_session_id_from_embedded_uuid(self, tmp_path):
+        path = tmp_path / "session_x.jsonl"
+        self._write(
+            path,
+            {"type": "session_start", "session_uuid": "1F0E9C2A-7B3D-4E5F-8A9B-0C1D2E3F4A5B"},
+            {"type": "shot_detected", "ball_speed_mph": 90},
+        )
+        result = flt.filter_session_file(path, device_id="dev-1")
+        assert result.session_id == "1f0e9c2a-7b3d-4e5f-8a9b-0c1d2e3f4a5b"
+
+    def test_session_id_uuid5_fallback_uses_filename(self, tmp_path):
+        path = tmp_path / "session_x.jsonl"
+        self._write(path, {"type": "session_start"}, {"type": "shot_detected"})
+        result = flt.filter_session_file(path, device_id="dev-1")
+        expected = str(uuid.uuid5(flt.SESSION_NAMESPACE, "dev-1:session_x.jsonl"))
+        assert result.session_id == expected
+
+    def test_does_not_load_whole_file_into_memory(self, tmp_path):
+        """Regression: filtering a large raw-ADC file must use bounded memory.
+
+        The old path read the entire file via read_text().splitlines(), peaking
+        at ~2x the file size — enough to OOM-kill the push on a Pi, dropping the
+        whole upload ("0 shots uploaded"). Streaming keeps peak ~one line.
+        """
+        import tracemalloc
+
+        path = tmp_path / "session_big.jsonl"
+        # ~20 MB of raw ADC (100 lines x ~200 KB), plus a handful of shots.
+        big = {"type": "rolling_buffer_capture", "i_samples": list(range(25000))}
+        with path.open("w") as f:
+            f.write(json.dumps({"type": "session_start", "session_uuid": "u"}) + "\n")
+            for i in range(100):
+                f.write(json.dumps(big) + "\n")
+                if i % 25 == 0:
+                    f.write(json.dumps({"type": "shot_detected", "ball_speed_mph": 90}) + "\n")
+            f.write(json.dumps({"type": "session_end"}) + "\n")
+
+        file_size = path.stat().st_size
+        assert file_size > 15 * 1024 * 1024  # sanity: the file really is large
+
+        tracemalloc.start()
+        result = flt.filter_session_file(path, device_id="d")
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        assert result.kept_type_counts["shot_detected"] == 4
+        # Streaming peaks at roughly one line; the file is >15 MB. A generous
+        # 8 MB ceiling cleanly fails the old whole-file-in-memory approach.
+        assert peak < 8 * 1024 * 1024, f"peak {peak / 1024 / 1024:.1f} MB — file not streamed"
 
 
 class TestBuildUploadBody:

--- a/tests/test_cloud_spool.py
+++ b/tests/test_cloud_spool.py
@@ -1,0 +1,127 @@
+"""Tests for the openflight-cloud spool-and-retry sidecar mechanics."""
+
+import json
+
+import pytest
+
+from openflight.cloud import spool
+
+
+def _session(tmp_path, name="session_20260614_120000_range.jsonl"):
+    path = tmp_path / name
+    path.write_text('{"type":"session_start"}\n')
+    return path
+
+
+class TestDiscovery:
+    def test_session_files_finds_only_session_jsonl(self, tmp_path):
+        _session(tmp_path, "session_a.jsonl")
+        _session(tmp_path, "session_b.jsonl")
+        (tmp_path / "radar_raw_x.log").write_text("noise")
+        (tmp_path / "other.jsonl").write_text("{}")
+        found = {p.name for p in spool.session_files(tmp_path)}
+        assert found == {"session_a.jsonl", "session_b.jsonl"}
+
+    def test_session_files_empty_when_dir_missing(self, tmp_path):
+        assert spool.session_files(tmp_path / "nope") == []
+
+    def test_pending_excludes_pushed_and_parked(self, tmp_path):
+        a = _session(tmp_path, "session_a.jsonl")
+        b = _session(tmp_path, "session_b.jsonl")
+        c = _session(tmp_path, "session_c.jsonl")
+        spool.mark_pushed(b, session_id="id-b", shot_count=3)
+        spool.mark_parked(c, reason="quota_exceeded", attempts=20, last_error="402")
+        pending = {p.name for p in spool.pending_sessions(tmp_path)}
+        assert pending == {"session_a.jsonl"}
+        assert a  # referenced
+
+
+class TestPushedMarker:
+    def test_mark_pushed_creates_sidecar(self, tmp_path):
+        path = _session(tmp_path)
+        spool.mark_pushed(path, session_id="abc", shot_count=5)
+        marker = tmp_path / (path.name + ".pushed")
+        assert marker.exists()
+        data = json.loads(marker.read_text())
+        assert data["session_id"] == "abc"
+        assert data["shot_count"] == 5
+        assert spool.is_pushed(path)
+
+    def test_mark_pushed_clears_attempt_state(self, tmp_path):
+        path = _session(tmp_path)
+        spool.record_failure(path, "5xx")
+        spool.mark_pushed(path, session_id="abc", shot_count=1)
+        assert spool.read_attempts(path) == 0
+        assert not (tmp_path / (path.name + ".state")).exists()
+
+
+class TestParkedMarker:
+    def test_mark_parked_creates_sidecar(self, tmp_path):
+        path = _session(tmp_path)
+        spool.mark_parked(path, reason="invalid_session_id", attempts=1, last_error="422")
+        marker = tmp_path / (path.name + ".parked")
+        assert marker.exists()
+        data = json.loads(marker.read_text())
+        assert data["reason"] == "invalid_session_id"
+        assert data["attempts"] == 1
+        assert data["last_error"] == "422"
+        assert spool.is_parked(path)
+
+
+class TestAttemptCounter:
+    def test_attempts_start_at_zero(self, tmp_path):
+        path = _session(tmp_path)
+        assert spool.read_attempts(path) == 0
+
+    def test_record_failure_increments_and_returns_count(self, tmp_path):
+        path = _session(tmp_path)
+        assert spool.record_failure(path, "5xx") == 1
+        assert spool.record_failure(path, "5xx") == 2
+        assert spool.read_attempts(path) == 2
+
+    def test_record_failure_stores_last_error(self, tmp_path):
+        path = _session(tmp_path)
+        spool.record_failure(path, "boom")
+        state = json.loads((tmp_path / (path.name + ".state")).read_text())
+        assert state["last_error"] == "boom"
+
+    def test_record_failure_parks_after_max_attempts(self, tmp_path):
+        path = _session(tmp_path)
+        for _ in range(spool.MAX_ATTEMPTS - 1):
+            spool.record_failure(path, "5xx")
+        assert not spool.is_parked(path)
+        spool.record_failure(path, "5xx")
+        assert spool.is_parked(path)
+        assert spool.read_attempts(path) == spool.MAX_ATTEMPTS
+
+
+class TestCooldown:
+    def test_no_cooldown_by_default(self, tmp_path):
+        path = _session(tmp_path)
+        assert spool.in_cooldown(path, now=1000.0) is False
+
+    def test_record_cooldown_blocks_until_elapsed(self, tmp_path):
+        path = _session(tmp_path)
+        spool.record_cooldown(path, "quota_exceeded", seconds=100, now=1000.0)
+        assert spool.in_cooldown(path, now=1050.0) is True
+        assert spool.in_cooldown(path, now=1101.0) is False
+
+    def test_cooldown_does_not_park(self, tmp_path):
+        path = _session(tmp_path)
+        spool.record_cooldown(path, "quota_exceeded", seconds=100, now=1000.0)
+        assert not spool.is_parked(path)
+
+
+class TestStatusSummary:
+    def test_summarizes_counts(self, tmp_path):
+        a = _session(tmp_path, "session_a.jsonl")
+        b = _session(tmp_path, "session_b.jsonl")
+        c = _session(tmp_path, "session_c.jsonl")
+        spool.mark_pushed(a, session_id="a", shot_count=1)
+        spool.mark_parked(b, reason="r", attempts=20, last_error="402")
+        assert c
+        summary = spool.summarize(tmp_path)
+        assert summary["pushed"] == 1
+        assert summary["parked"] == 1
+        assert summary["pending"] == 1
+        assert summary["total"] == 3

--- a/tests/test_cloud_spool.py
+++ b/tests/test_cloud_spool.py
@@ -112,6 +112,38 @@ class TestCooldown:
         assert not spool.is_parked(path)
 
 
+class TestClearMarkers:
+    def test_clears_parked_and_state_keeps_pushed_by_default(self, tmp_path):
+        path = _session(tmp_path)
+        spool.mark_pushed(path, "id", 1)
+        spool.mark_parked(path, reason="r", attempts=2, last_error="e")
+        spool.record_failure(path, "e")  # writes .state
+        cleared = spool.clear_markers(path)
+        assert spool.PARKED_SUFFIX in cleared
+        assert spool.STATE_SUFFIX in cleared
+        assert spool.PUSHED_SUFFIX not in cleared
+        assert spool.is_pushed(path)
+        assert not spool.is_parked(path)
+
+    def test_include_pushed_clears_everything(self, tmp_path):
+        path = _session(tmp_path)
+        spool.mark_pushed(path, "id", 1)
+        cleared = spool.clear_markers(path, include_pushed=True)
+        assert spool.PUSHED_SUFFIX in cleared
+        assert not spool.is_pushed(path)
+
+    def test_returns_empty_when_no_markers(self, tmp_path):
+        path = _session(tmp_path)
+        assert spool.clear_markers(path) == []
+
+    def test_after_clear_session_is_pending_again(self, tmp_path):
+        a = _session(tmp_path, "session_a.jsonl")
+        spool.mark_parked(a, reason="r", attempts=20, last_error="e")
+        assert a not in spool.pending_sessions(tmp_path)
+        spool.clear_markers(a)
+        assert a in spool.pending_sessions(tmp_path)
+
+
 class TestStatusSummary:
     def test_summarizes_counts(self, tmp_path):
         a = _session(tmp_path, "session_a.jsonl")

--- a/tests/test_cloud_trigger.py
+++ b/tests/test_cloud_trigger.py
@@ -1,0 +1,49 @@
+"""Tests for the non-blocking session-end push trigger."""
+
+import pytest
+
+from openflight.cloud import trigger
+from openflight.cloud.config import CloudConfig
+
+
+class TestFirePushAsync:
+    def test_fires_when_active(self, tmp_path):
+        calls = []
+        config = CloudConfig(device_token="t", device_id="i", enabled=True)
+        ok = trigger.fire_push_async(
+            config, log_dir=tmp_path, popen_fn=lambda cmd, **k: calls.append(cmd)
+        )
+        assert ok is True
+        assert len(calls) == 1
+        assert "push" in calls[0]
+
+    def test_skips_when_inactive(self, tmp_path):
+        calls = []
+        config = CloudConfig(enabled=False)
+        ok = trigger.fire_push_async(
+            config, log_dir=tmp_path, popen_fn=lambda cmd, **k: calls.append(cmd)
+        )
+        assert ok is False
+        assert calls == []
+
+    def test_swallows_spawn_errors(self, tmp_path):
+        def boom(cmd, **k):
+            raise OSError("no exec")
+
+        config = CloudConfig(device_token="t", device_id="i", enabled=True)
+        # Must never raise into the caller (server shot path).
+        assert trigger.fire_push_async(config, log_dir=tmp_path, popen_fn=boom) is False
+
+    def test_passes_config_and_log_dir(self, tmp_path):
+        calls = []
+        config = CloudConfig(device_token="t", device_id="i", enabled=True)
+        cfg_path = tmp_path / "cloud.json"
+        trigger.fire_push_async(
+            config,
+            log_dir=tmp_path,
+            config_path=cfg_path,
+            popen_fn=lambda cmd, **k: calls.append(cmd),
+        )
+        cmd = calls[0]
+        assert str(cfg_path) in cmd
+        assert str(tmp_path) in cmd


### PR DESCRIPTION
## Summary

Adds `openflight-cloud`, an opt-in CLI that pushes **filtered** session logs from the Pi to the FlightWeb cloud. Implements the wire contract in `docs/openflight-cloud-uploader-spec.md` with no dependency on FlightWeb code.

The load-bearing guarantee: **raw radar data never leaves the Pi.** Filtering is enforced client-side via an allowlist before upload (the server stores device uploads verbatim).

## What's included

- **`link` / `push` / `status`** subcommands. Linking uses the RFC 8628 device-code flow (short screen-readable code, no token copy-paste).
- **Client-side allowlist filter** — keeps `session_start/end`, `shot_detected`, `trigger_event`, `error`/`session_error`; drops raw ADC (`rolling_buffer_capture`, `kld7_buffer`, `iq_blocks`, and anything not allowlisted). Prepends an `upload_manifest`; enforces per-line/body caps.
- **Spool-and-retry** — the session dir is the queue; sidecar markers (`.pushed`/`.parked`/`.state`) survive crashes. Parks after 20 failures; quota (402) defers ~24h.
- **stdlib `urllib` client** — maps every status code to a spool action; injectable transport for tests.
- **Triggers** — systemd timer (~10 min, heals wifi outages) + a non-blocking session-end push from the server that never delays shot processing.
- **`setup.sh`** integration — offers to enable cloud sync and link the Pi.

## Notable fixes during review

- **Large raw-ADC files no longer OOM the push.** The filter now streams the file line-by-line instead of `read_text().splitlines()` — peak memory on a 213 MB session dropped from **427 MB → 4.5 MB**, keeping all shots and stripping all raw ADC. (This was the cause of "0 shots uploaded" on the Pi.)
- **`push --retry [SESSION]`** — re-attempt parked/deferred sessions, or force re-upload a specific session by name even if already sent (idempotent). `status` flags 0-shot uploads with the exact re-upload command.

## Testing

- ~100 new tests across config, filtering, spool, client, commands, CLI, and trigger (TDD throughout). Full suite: **735 passed**, ruff clean, pylint 9.87/10.
- Verified end-to-end against real session files (up to 213 MB) and the live CLI (`--dry-run`, `status`, `--retry`).

## Docs

- `docs/cloud-sync.md` (operator guide) + README section, plus the wire-contract spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)