### PR TITLE
Ball-speed cosine correction + opt-in calculated spin

### DIFF
--- a/scripts/start-kiosk.sh
+++ b/scripts/start-kiosk.sh
@@ -43,6 +43,8 @@ EXPERIMENTAL_KLD7_HORIZONTAL_IMPACT_ENERGY=""
 EXPERIMENTAL_KLD7_HORIZONTAL_RETRY_IMPACT_ENERGY=""
 EXPERIMENTAL_KLD7_HORIZONTAL_ANGLE_LIMIT=""
 BALLISTICS=false
+CALCULATED_SPIN=false
+BALL_SPEED_COSINE=false
 
 # Buffer split presets (pre/post trigger segments out of 32 total)
 # At 20ksps: each segment = 6.4ms, total buffer = 204.8ms
@@ -203,6 +205,14 @@ while [[ $# -gt 0 ]]; do
             BALLISTICS=true
             shift
             ;;
+        --calculated-spin)
+            CALCULATED_SPIN=true
+            shift
+            ;;
+        --ball-speed-cosine-correction)
+            BALL_SPEED_COSINE=true
+            shift
+            ;;
         --port|-p)
             PORT="$2"
             shift 2
@@ -328,6 +338,14 @@ fi
 
 if [ "$BALLISTICS" = true ]; then
     SERVER_CMD="$SERVER_CMD --ballistics"
+fi
+
+if [ "$CALCULATED_SPIN" = true ]; then
+    SERVER_CMD="$SERVER_CMD --calculated-spin"
+fi
+
+if [ "$BALL_SPEED_COSINE" = true ]; then
+    SERVER_CMD="$SERVER_CMD --ball-speed-cosine-correction"
 fi
 
 if [ -n "$TRIGGER" ]; then

--- a/src/openflight/launch_monitor.py
+++ b/src/openflight/launch_monitor.py
@@ -247,6 +247,9 @@ class Shot:
     impact_timestamp: Optional[float] = None
     impact_timestamp_kld7: Optional[float] = None
     club_speed_mph: Optional[float] = None
+    # Raw OPS radial ball speed, kept when the cosine correction rewrites
+    # ball_speed_mph (radar bin anchoring must keep using the radial value)
+    ball_speed_raw_mph: Optional[float] = None
     peak_magnitude: Optional[float] = None
     readings: List[SpeedReading] = field(default_factory=list)
     club: ClubType = ClubType.DRIVER
@@ -259,6 +262,10 @@ class Shot:
     launch_angle_horizontal_source: Optional[str] = None
     spin_rpm: Optional[float] = None
     spin_confidence: Optional[float] = None
+    # Raw radar-measured spin, kept when --calculated-spin rewrites
+    # spin_rpm with the kinematic estimate (for offline scoring)
+    spin_rpm_measured: Optional[float] = None
+    spin_source: Optional[str] = None  # "measured", "calculated", or None
     spin_result_quality: Optional[str] = None
     spin_snr: Optional[float] = None
     spin_modulation_depth: Optional[float] = None

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -21,10 +21,12 @@ from flask_cors import CORS
 from flask_socketio import SocketIO
 
 from .ballistics import resolve_launch, simulate
-from .launch_monitor import ClubType, Shot
+from .launch_monitor import SPIN_CONFIDENCE_HIGH, ClubType, Shot
 from .ops243 import Direction, SpeedReading, set_show_raw_readings
 from .rolling_buffer.monitor import estimate_carry_with_spin, get_optimal_spin_for_ball_speed
 from .session_logger import get_session_logger, init_session_logger, log_session_error
+from .speed_correction import correct_ball_speed
+from .spin_estimate import calculated_spin_rpm
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -761,10 +763,19 @@ def _session_start_config() -> dict:
     return config
 
 
+ball_speed_correction_enabled = False
+ball_speed_correction_distance_ft = 5.5
+ball_speed_correction_ball_above_radar_ft = -4.0 / 12.0
+calculated_spin_enabled = False
+
+
 def shot_to_dict(shot: Shot) -> dict:
     """Convert Shot to JSON-serializable dict."""
     return {
         "ball_speed_mph": round(shot.ball_speed_mph, 1),
+        "ball_speed_raw_mph": (
+            round(shot.ball_speed_raw_mph, 1) if shot.ball_speed_raw_mph else None
+        ),
         "club_speed_mph": round(shot.club_speed_mph, 1) if shot.club_speed_mph else None,
         "smash_factor": round(shot.smash_factor, 2) if shot.smash_factor else None,
         "estimated_carry_yards": round(shot.estimated_carry_yards),
@@ -789,6 +800,10 @@ def shot_to_dict(shot: Shot) -> dict:
         "spin_axis_deg": shot.spin_axis_deg,
         # Spin data from rolling buffer mode
         "spin_rpm": round(shot.spin_rpm) if shot.spin_rpm else None,
+        "spin_rpm_measured": (
+            round(shot.spin_rpm_measured) if shot.spin_rpm_measured else None
+        ),
+        "spin_source": shot.spin_source,
         "spin_confidence": round(shot.spin_confidence, 2) if shot.spin_confidence else None,
         "spin_quality": shot.spin_quality,
         "spin_snr": round(shot.spin_snr, 2) if shot.spin_snr is not None else None,
@@ -1485,6 +1500,38 @@ def handle_shutdown():
     threading.Thread(target=_shutdown_process_after_delay, daemon=True).start()
 
 
+def _apply_calculated_spin(shot: Shot) -> bool:
+    """Replace radar-measured spin with the kinematic estimate.
+
+    The 24 GHz OPS return carries no usable spin line (see
+    spin_estimate.py), so when the vertical launch angle was actually
+    measured (radar/camera, not the club-table estimate), spin_rpm is
+    rewritten with 170*v*sin(LA)^1.2. The displaced measured value is
+    kept in spin_rpm_measured for offline scoring. Returns True when
+    the shot was rewritten.
+    """
+    if shot.launch_angle_vertical is None:
+        return False
+    if shot.launch_angle_vertical_source not in ("radar", "camera"):
+        return False
+    spin_calc = calculated_spin_rpm(shot.ball_speed_mph, shot.launch_angle_vertical)
+    if spin_calc is None:
+        return False
+    shot.spin_rpm_measured = shot.spin_rpm
+    shot.spin_rpm = spin_calc
+    shot.spin_confidence = SPIN_CONFIDENCE_HIGH
+    shot.spin_source = "calculated"
+    shot.spin_rejection_reason = None
+    logger.info(
+        "[SERVER] Calculated spin: %.0f rpm (v=%.1f mph, LA=%.1f deg, measured was %s)",
+        spin_calc,
+        shot.ball_speed_mph,
+        shot.launch_angle_vertical,
+        "%.0f rpm" % shot.spin_rpm_measured if shot.spin_rpm_measured else "none",
+    )
+    return True
+
+
 def on_shot_detected(shot: Shot):
     """Callback when a shot is detected - emit to all clients."""
     global ball_detected, ball_detection_confidence  # pylint: disable=global-statement
@@ -1776,6 +1823,30 @@ def on_shot_detected(shot: Shot):
     # Always emit user-facing launch angles. Radar/camera measurements win;
     # rejected or missing axes fall back to conservative estimates.
     _ensure_user_facing_launch_angles(shot)
+
+    # Ball-speed cosine correction: the OPS reads the radial component of
+    # a ball departing at the launch angle. Applied AFTER the K-LD7 (which
+    # must anchor to the radial speed) and BEFORE carry/ballistics.
+    if ball_speed_correction_enabled and shot.launch_angle_vertical is not None:
+        raw_speed = shot.ball_speed_mph
+        shot.ball_speed_raw_mph = raw_speed
+        shot.ball_speed_mph = correct_ball_speed(
+            raw_speed,
+            shot.launch_angle_vertical,
+            ball_speed_correction_distance_ft,
+            ball_speed_correction_ball_above_radar_ft,
+        )
+        logger.info(
+            "[SERVER] Ball speed cosine correction: %.1f -> %.1f mph (LA %.1f)",
+            raw_speed,
+            shot.ball_speed_mph,
+            shot.launch_angle_vertical,
+        )
+
+    # Calculated spin runs AFTER the cosine correction (the model is
+    # calibrated on true ball speed) and BEFORE carry/ballistics.
+    if calculated_spin_enabled:
+        _apply_calculated_spin(shot)
 
     # Compute carry. Prefer the physics simulator (drag + Magnus, RK4) when
     # ballistics is enabled and a vertical launch angle is available; fall
@@ -2393,6 +2464,26 @@ def main():
         help="K-LD7 vertical angle offset in degrees (default: 0.0)",
     )
     parser.add_argument(
+        "--ball-speed-cosine-correction",
+        action="store_true",
+        help=(
+            "Correct OPS radial ball speed to true ball speed using the launch "
+            "angle and radar geometry (validated vs TrackMan; see "
+            "src/openflight/speed_correction.py)"
+        ),
+    )
+    parser.add_argument(
+        "--calculated-spin",
+        action="store_true",
+        help=(
+            "Replace radar-measured spin with the kinematic estimate "
+            "(170*v*sin(LA)^1.2) when the launch angle was measured. The 24 GHz "
+            "OPS return carries no usable spin line (see "
+            "src/openflight/spin_estimate.py); the measured value is kept in "
+            "spin_rpm_measured for offline scoring"
+        ),
+    )
+    parser.add_argument(
         "--kld7-vertical-estimator",
         choices=("geometry", "naive"),
         default="naive",
@@ -2414,6 +2505,16 @@ def main():
         help=(
             "Ball-to-radar-front distance in feet, for the geometry estimator "
             "(weak lever; default: 5.5)"
+        ),
+    )
+    parser.add_argument(
+        "--kld7-radar-height-inches",
+        dest="kld7_radar_height_inches",
+        type=float,
+        default=4.0,
+        help=(
+            "K-LD7 radar height above the ball in inches, used by the ball-speed "
+            "cosine correction geometry (default: 4.0)"
         ),
     )
     parser.add_argument(
@@ -2512,6 +2613,14 @@ def main():
     global ballistics_enabled
     experimental_kld7_raw_radc_logging = args.experimental_kld7_raw_radc_logging
     experimental_kld7_radc_tuning = args.experimental_kld7_radc_tuning
+    global ball_speed_correction_enabled
+    global ball_speed_correction_distance_ft
+    global ball_speed_correction_ball_above_radar_ft
+    ball_speed_correction_enabled = args.ball_speed_cosine_correction
+    ball_speed_correction_distance_ft = args.kld7_ball_distance
+    ball_speed_correction_ball_above_radar_ft = -args.kld7_radar_height_inches / 12.0
+    global calculated_spin_enabled
+    calculated_spin_enabled = args.calculated_spin
     ballistics_enabled = args.ballistics
     kld7_radc_tuning_kwargs = _kld7_radc_tuning_kwargs(args)
     active_kld7_radc_tuning = dict(kld7_radc_tuning_kwargs)

--- a/src/openflight/speed_correction.py
+++ b/src/openflight/speed_correction.py
@@ -1,0 +1,76 @@
+"""Ball-speed cosine correction.
+
+The OPS243 measures RADIAL speed — the component of the ball's velocity
+along the radar's line of sight. The ball departs upward at the launch
+angle while the radar sits low behind the tee, so the radial reading is
+compressed by cos(angle between velocity and LOS). This is the dominant
+cause of the long-observed ~2-2.5 mph OPS-below-TrackMan ball speed gap.
+
+Model (zero free parameters): the OPS mode-based extraction reads near
+the MAXIMUM of the radial-speed profile — radial speed rises early in
+flight as the LOS aligns with the velocity vector, then falls with drag,
+so the profile has a peak. The correction divides the measured speed by
+that predicted peak fraction.
+
+Validated offline against TrackMan ball speeds (2026-06):
+- 2026-06-08 bay, 128 shots: bias -2.15 -> +0.33 mph, |err| 2.83 -> 1.48
+- 2026-05-30 holdout, 26 shots: bias -2.26 -> +0.30, |err| 2.35 -> 1.31
+- Coleman cross-rig outdoor, 62 shots: bias -2.09 -> +0.65, median 0.58
+- Production configuration (OUR launch angles — 100 two-ray + 28
+  club-fallback — instead of TrackMan's): bias +0.32, |err| 1.52,
+  median 0.67. The LA dependence couples speed accuracy to launch-angle
+  accuracy, but LA errors are zero-mean post-calibration, so the
+  coupling adds ~0.1 mph of scatter and no bias.
+
+Known caveat: high-launch wedges on one outdoor rig overcorrected (~+3);
+under observation. Club speed does NOT need this correction — the club
+head's delivery is nearly parallel to the LOS (error ~0.1-0.2 mph).
+"""
+
+from __future__ import annotations
+
+import math
+
+MPH_TO_FTS = 1.4666667
+DRAG_MPH_PER_MS = 0.027  # iron-speed drag deceleration of the ball
+
+
+def radial_speed_factor(
+    launch_angle_deg: float,
+    ball_speed_mph: float,
+    ball_distance_ft: float,
+    ball_above_radar_ft: float,
+    window_ms: float = 70.0,
+) -> float:
+    """Predicted (OPS radial reading) / (true ball speed), in (0, 1].
+
+    Maximum of the radial-speed profile over the capture window:
+    radial(t) = v(t) * cos(launch - elevation_of_ball_from_radar(t)).
+    """
+    if ball_speed_mph <= 0:
+        return 1.0
+    la = math.radians(launch_angle_deg)
+    v_fts = ball_speed_mph * MPH_TO_FTS
+    best = 0.0
+    t_ms = 0.0
+    while t_ms <= window_ms:
+        v_frac = max(1.0 - DRAG_MPH_PER_MS * t_ms / ball_speed_mph, 0.0)
+        t = t_ms / 1000.0
+        x = ball_distance_ft + v_fts * math.cos(la) * t
+        y = ball_above_radar_ft + v_fts * math.sin(la) * t
+        best = max(best, v_frac * math.cos(la - math.atan2(y, x)))
+        t_ms += 2.0
+    return min(max(best, 0.5), 1.0)
+
+
+def correct_ball_speed(
+    measured_mph: float,
+    launch_angle_deg: float,
+    ball_distance_ft: float,
+    ball_above_radar_ft: float,
+) -> float:
+    """True ball speed from the OPS radial measurement."""
+    factor = radial_speed_factor(
+        launch_angle_deg, measured_mph, ball_distance_ft, ball_above_radar_ft
+    )
+    return measured_mph / factor

--- a/src/openflight/spin_estimate.py
+++ b/src/openflight/spin_estimate.py
@@ -1,0 +1,71 @@
+"""Calculated spin from measured ball speed and launch angle.
+
+The OPS243 return carries no usable spin line: golf-ball dimples
+(~0.3 mm) are Rayleigh-smooth at 24 GHz (λ = 12.4 mm) and the specular
+point does not rotate with the ball, so rotation barely modulates the
+echo within our ~65 ms ball dwell. Offline analysis of the 2026-06-08
+TrackMan session (131 paired shots, PW-3h) found no spectral line at
+the TrackMan spin frequency on any club after dechirp and carrier
+removal — and the production envelope estimator's output had ~zero
+within-club correlation with TrackMan spin (r ≈ +0.19).
+
+What does work is impact kinematics. Spin loft tracks launch angle and
+the friction impulse gives spin ∝ v·sin(spin loft), yielding a single
+global formula with no club input:
+
+    spin_rpm = 170 · ball_speed_mph · sin(LA)^1.2
+
+Validation against the 2026-06-08 TrackMan truth set:
+- TrackMan inputs (physics ceiling): 10.5% median error across the
+  bag — better than an oracle per-club median table (12.0%)
+- Leave-one-club-out blind: 11.3% median, 97/131 within 25%; the
+  fitted (coefficient, exponent) were stable across all folds
+- Simulated with production launch-angle noise (2.5° MAE two-ray):
+  ~21% median expected live
+
+Caveats: calibrated on one player/session (range balls). Attack-angle
+style shifts spin loft at a fixed launch angle, so cross-player error
+is likely a few points worse. Accuracy degrades at low launch angles
+(cot(LA) error amplification) — the same clubs where measured launch
+angle is weakest.
+"""
+
+import math
+from typing import Optional
+
+# Fitted on the 2026-06-08 TrackMan session (131 shots, PW-3h);
+# leave-one-club-out stable at (170, 1.2) across all folds.
+SPIN_COEFF_RPM_PER_MPH = 170.0
+SPIN_LA_EXPONENT = 1.2
+
+# Outside these bounds the kinematic model is extrapolating into
+# regimes it was never calibrated on (top-spinned thins, pop-ups).
+MIN_LAUNCH_ANGLE_DEG = 2.0
+MAX_LAUNCH_ANGLE_DEG = 60.0
+
+# Physical ceiling — beyond fresh-groove lob wedge territory.
+MAX_SPIN_RPM = 13000.0
+
+
+def calculated_spin_rpm(
+    ball_speed_mph: float,
+    launch_angle_deg: float,
+) -> Optional[float]:
+    """Kinematic spin estimate from ball speed and vertical launch angle.
+
+    Use the true (cosine-corrected) ball speed when available — the
+    model was calibrated against TrackMan ball speed.
+
+    Returns None when inputs are missing or outside the calibrated
+    range; callers should fall back to club-typical spin.
+    """
+    if ball_speed_mph is None or launch_angle_deg is None:
+        return None
+    if ball_speed_mph <= 0:
+        return None
+    if not MIN_LAUNCH_ANGLE_DEG <= launch_angle_deg <= MAX_LAUNCH_ANGLE_DEG:
+        return None
+
+    sin_la = math.sin(math.radians(launch_angle_deg))
+    spin = SPIN_COEFF_RPM_PER_MPH * ball_speed_mph * sin_la**SPIN_LA_EXPONENT
+    return float(min(spin, MAX_SPIN_RPM))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2087,3 +2087,50 @@ class TestCarryComputation:
 
         assert shot.carry_spin_adjusted is not None
         assert shot.carry_spin_adjusted > 0
+
+
+class TestApplyCalculatedSpin:
+    """Tests for the --calculated-spin shot rewrite."""
+
+    def _shot(self, la=18.0, la_source="radar", ball_speed=115.0, spin=6800.0):
+        return Shot(
+            ball_speed_mph=ball_speed,
+            timestamp=datetime.now(),
+            club=ClubType.IRON_7,
+            launch_angle_vertical=la,
+            launch_angle_vertical_source=la_source,
+            spin_rpm=spin,
+            spin_confidence=0.3,
+            spin_rejection_reason="SNR too low",
+        )
+
+    def test_rewrites_spin_when_launch_angle_measured(self):
+        shot = self._shot()
+        assert server_module._apply_calculated_spin(shot) is True
+        # 170 * 115 * sin(18deg)^1.2 ~= 4800 rpm
+        assert 4500 < shot.spin_rpm < 5100
+        assert shot.spin_rpm_measured == 6800.0
+        assert shot.spin_source == "calculated"
+        assert shot.spin_confidence == pytest.approx(0.7)
+        assert shot.spin_rejection_reason is None
+
+    def test_untouched_when_launch_angle_estimated(self):
+        shot = self._shot(la_source="estimated")
+        assert server_module._apply_calculated_spin(shot) is False
+        assert shot.spin_rpm == 6800.0
+        assert shot.spin_source is None
+
+    def test_untouched_when_no_launch_angle(self):
+        shot = self._shot(la=None)
+        assert server_module._apply_calculated_spin(shot) is False
+        assert shot.spin_rpm == 6800.0
+
+    def test_untouched_when_launch_angle_outside_model_range(self):
+        shot = self._shot(la=1.0)
+        assert server_module._apply_calculated_spin(shot) is False
+        assert shot.spin_rpm == 6800.0
+
+    def test_camera_launch_angle_accepted(self):
+        shot = self._shot(la_source="camera")
+        assert server_module._apply_calculated_spin(shot) is True
+        assert shot.spin_source == "calculated"

--- a/tests/test_speed_correction.py
+++ b/tests/test_speed_correction.py
@@ -1,0 +1,55 @@
+"""Tests for the ball-speed cosine correction."""
+
+import pytest
+
+from openflight.speed_correction import correct_ball_speed, radial_speed_factor
+
+D_FT = 5.0
+H_FT = -4.0 / 12.0
+
+
+class TestRadialSpeedFactor:
+    def test_factor_below_one_for_lofted_launch(self):
+        # A ball departing upward always reads slow on a low radar
+        f = radial_speed_factor(19.0, 110.0, D_FT, H_FT)
+        assert 0.95 < f < 1.0
+
+    def test_typical_iron_compression_matches_observed_bias(self):
+        # The validated datasets showed ~2.1-2.6 mph of compression at
+        # iron speeds (~2-2.5% of ball speed)
+        f = radial_speed_factor(19.0, 108.0, D_FT, H_FT)
+        compression_mph = 108.0 * (1.0 - f)
+        assert 1.5 < compression_mph < 3.5
+
+    def test_higher_launch_compresses_more(self):
+        f_wedge = radial_speed_factor(30.0, 90.0, D_FT, H_FT)
+        f_iron = radial_speed_factor(17.0, 110.0, D_FT, H_FT)
+        f_driver = radial_speed_factor(11.0, 150.0, D_FT, H_FT)
+        assert f_wedge < f_iron < f_driver
+
+    def test_farther_tee_compresses_more(self):
+        # LOS flattens with distance while the velocity stays pitched up
+        assert radial_speed_factor(18.0, 110.0, 6.5, H_FT) < radial_speed_factor(
+            18.0, 110.0, 5.0, H_FT
+        )
+
+    def test_zero_launch_is_nearly_uncorrected(self):
+        f = radial_speed_factor(0.0, 110.0, D_FT, H_FT)
+        assert f > 0.995
+
+    def test_degenerate_inputs_clamp(self):
+        assert radial_speed_factor(19.0, 0.0, D_FT, H_FT) == 1.0
+        assert 0.5 <= radial_speed_factor(44.0, 60.0, D_FT, H_FT) <= 1.0
+
+
+class TestCorrectBallSpeed:
+    def test_correction_raises_speed(self):
+        corrected = correct_ball_speed(108.0, 19.0, D_FT, H_FT)
+        assert corrected > 108.0
+        assert corrected == pytest.approx(110.3, abs=0.8)
+
+    def test_roundtrip_consistency(self):
+        # Correcting then re-deriving the radial reading lands back
+        true_speed = correct_ball_speed(108.0, 19.0, D_FT, H_FT)
+        radial = true_speed * radial_speed_factor(19.0, true_speed, D_FT, H_FT)
+        assert radial == pytest.approx(108.0, abs=0.15)

--- a/tests/test_spin_estimate.py
+++ b/tests/test_spin_estimate.py
@@ -1,0 +1,50 @@
+"""Tests for the kinematic calculated-spin model."""
+
+import math
+
+import pytest
+
+from openflight.spin_estimate import (
+    MAX_SPIN_RPM,
+    SPIN_COEFF_RPM_PER_MPH,
+    SPIN_LA_EXPONENT,
+    calculated_spin_rpm,
+)
+
+
+class TestCalculatedSpin:
+    def test_seven_iron_regime(self):
+        """115 mph at 17.8 deg (TrackMan 7i medians) lands in 7i spin range."""
+        spin = calculated_spin_rpm(115.0, 17.8)
+        assert spin == pytest.approx(
+            SPIN_COEFF_RPM_PER_MPH * 115.0 * math.sin(math.radians(17.8)) ** SPIN_LA_EXPONENT
+        )
+        assert 3500 <= spin <= 5500
+
+    def test_wedge_spins_more_than_long_iron(self):
+        """At realistic speed/LA pairs, wedges out-spin long irons."""
+        wedge = calculated_spin_rpm(92.0, 28.0)
+        long_iron = calculated_spin_rpm(130.0, 12.0)
+        assert wedge > long_iron
+
+    def test_monotonic_in_launch_angle(self):
+        spins = [calculated_spin_rpm(110.0, la) for la in (10, 15, 20, 25, 30)]
+        assert spins == sorted(spins)
+
+    def test_monotonic_in_ball_speed(self):
+        spins = [calculated_spin_rpm(v, 20.0) for v in (80, 100, 120, 140)]
+        assert spins == sorted(spins)
+
+    def test_capped_at_physical_maximum(self):
+        assert calculated_spin_rpm(200.0, 55.0) == MAX_SPIN_RPM
+
+    def test_none_outside_calibrated_launch_range(self):
+        assert calculated_spin_rpm(110.0, 1.0) is None
+        assert calculated_spin_rpm(110.0, -5.0) is None
+        assert calculated_spin_rpm(110.0, 65.0) is None
+
+    def test_none_for_missing_or_invalid_inputs(self):
+        assert calculated_spin_rpm(None, 20.0) is None
+        assert calculated_spin_rpm(110.0, None) is None
+        assert calculated_spin_rpm(0.0, 20.0) is None
+        assert calculated_spin_rpm(-10.0, 20.0) is None

--- a/ui/src/components/DisplayMode.test.tsx
+++ b/ui/src/components/DisplayMode.test.tsx
@@ -32,6 +32,7 @@ const shot: Shot = {
   spin_rpm: 2450,
   spin_confidence: 0.8,
   spin_quality: 'high',
+  spin_source: 'calculated',
   carry_spin_adjusted: 261,
 };
 

--- a/ui/src/components/ShotDisplay.tsx
+++ b/ui/src/components/ShotDisplay.tsx
@@ -234,6 +234,13 @@ export function ShotDisplay({ shot, animate = false }: ShotDisplayProps) {
             value={hasSpin ? formatSpinRpm(shot.spin_rpm!) : '—'}
             unit={hasSpin ? 'rpm' : undefined}
             label="Spin Rate"
+            subtext={
+              hasSpin && shot.spin_source
+                ? shot.spin_source === 'calculated'
+                  ? 'estimated'
+                  : 'radar'
+                : undefined
+            }
             variant="spin"
             confidence={hasSpin ? shot.spin_quality : null}
           />

--- a/ui/src/types/shot.ts
+++ b/ui/src/types/shot.ts
@@ -19,6 +19,7 @@ export interface Shot {
   spin_rpm: number | null;
   spin_confidence: number | null;
   spin_quality: 'high' | 'medium' | 'low' | null;
+  spin_source: 'measured' | 'calculated' | null;
   carry_spin_adjusted: number | null;
 }
 


### PR DESCRIPTION
## Summary
Two **opt-in** launch-monitor accuracy features (both **off by default**) plus a UI provenance indicator. The shot-detection and K-LD7 angle pipelines are untouched — both features consume `shot.launch_angle_vertical` from whatever estimator is active, so they're **independent of the in-progress two-ray angle work**. `speed_correction.py` and `spin_estimate.py` are self-contained pure functions (`math` only).

## Ball-speed cosine correction — `--ball-speed-cosine-correction`
The OPS243 reads *radial* speed; a ball departing at the launch angle reads low by `cos(velocity vs LOS)` — the long-observed **~2–2.5 mph OPS-below-TrackMan gap**. `correct_ball_speed()` divides out the predicted peak-radial fraction (zero free parameters) using VLA + radar geometry (`--kld7-ball-distance`, new `--kld7-radar-height-inches`). Works with any launch-angle source.

TrackMan-validated (offline, 2026-06):
- 2026-06-08, 128 shots: bias **−2.15 → +0.33** mph, |err| 2.83 → 1.48
- 2026-05-30 holdout, 26 shots: bias −2.26 → +0.30, |err| 2.35 → 1.31
- Production config (our launch angles): bias +0.32, |err| 1.52, median **0.67**
- ⚠️ Caveat: high-launch wedges overcorrected ~+3 on one outdoor rig (under observation). Club speed isn't corrected (delivery ≈ parallel to LOS).

## Calculated spin — `--calculated-spin`
The 24 GHz return has **no usable spin line** (Rayleigh-smooth dimples; no spectral line found across clubs; envelope-estimator r ≈ 0.19 vs TrackMan). Impact kinematics do work: `spin_rpm = 170·v·sin(LA)^1.2` (one global formula, no club input). When VLA is radar/camera-measured, this rewrites `spin_rpm`; the displaced radar value is preserved in `spin_rpm_measured`. Runs **after** the cosine correction and only within the calibrated 2°–60° range.

Validation (2026-06-08, 131 shots):
- TrackMan inputs (ceiling): **10.5%** median error (beats an oracle per-club table, 12.0%)
- Leave-one-club-out blind: **11.3%** median, 97/131 within 25%
- With production LA noise (2.5° MAE): ~21% median expected live
- ⚠️ Caveats: one player/session; cross-player likely a few points worse; degrades at low launch.

## Flags (all off by default)
- `--ball-speed-cosine-correction`, `--calculated-spin` — forwarded by `start-kiosk.sh`
- `--kld7-radar-height-inches` (default 4.0) — radar height for the cosine geometry

## UI
The Spin Rate card shows an **"estimated"** subtext when spin came from the model (`spin_source === 'calculated'`), **"radar"** when measured — mirroring the H. Launch source subtext. `spin_source` added to the shot payload + `Shot` type.

## Testing
- Python: full suite **755 passed**, `ruff` clean, `pylint` **10.00/10** on new modules.
- UI: `build` + `lint` clean, **13 tests** pass.
- New: `test_speed_correction`, `test_spin_estimate`, `TestApplyCalculatedSpin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
