### PR TITLE
Fix K-LD7 ring buffer race that silently dropped launch angles

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- K-LD7 tracker: shots could silently lose their launch angle when the
+  stream thread appended a frame while the shot path iterated the ring
+  buffer (`snapshot_buffer` / `_radc_frames_for_extraction`). CPython
+  raises `RuntimeError: deque mutated during iteration` for this, and
+  the server's broad K-LD7 exception handler swallowed it, so the shot
+  was reported without an angle and no error was visible. Buffer reads
+  now copy under a lock; appends and resets take the same lock.
+
 ### Changed
 - Spin detection: drop the autocorrelation override branch. The autocorr
   peak inside the envelope search region often lands at minimum lag

--- a/src/openflight/kld7/tracker.py
+++ b/src/openflight/kld7/tracker.py
@@ -191,6 +191,11 @@ class KLD7Tracker:
 
     def _init_ring_buffer(self):
         """Initialize or reset the ring buffer."""
+        # Guards the buffer against the stream thread appending while the
+        # shot path iterates it (deque iteration raises RuntimeError if the
+        # deque is mutated mid-iteration). Readers copy under the lock and
+        # do any per-frame work on the copy.
+        self._buffer_lock = threading.Lock()
         self._ring_buffer: deque[KLD7Frame] = deque(maxlen=self.max_buffer_frames)
 
     def connect(self) -> bool:
@@ -531,7 +536,8 @@ class KLD7Tracker:
 
     def _add_frame(self, frame: KLD7Frame):
         """Add a frame to the ring buffer."""
-        self._ring_buffer.append(frame)
+        with self._buffer_lock:
+            self._ring_buffer.append(frame)
 
     def _radc_frames_for_extraction(
         self,
@@ -544,6 +550,8 @@ class KLD7Tracker:
         time when a shot timestamp is available so stale frames from prior
         movement cannot influence this shot's angle.
         """
+        with self._buffer_lock:
+            buffered = list(self._ring_buffer)
         frames = [
             {
                 "timestamp": f.timestamp,
@@ -552,7 +560,7 @@ class KLD7Tracker:
                 "complete_timestamp": f.complete_timestamp,
                 "read_duration_ms": f.read_duration_ms,
             }
-            for f in self._ring_buffer
+            for f in buffered
             if f.radc is not None
         ]
         frames_available = len(frames)
@@ -831,8 +839,10 @@ class KLD7Tracker:
         Call this BEFORE get_angle_for_shot/reset to capture raw data
         for offline analysis alongside OPS243 shot data.
         """
+        with self._buffer_lock:
+            buffered = list(self._ring_buffer)
         frames = []
-        for frame in self._ring_buffer:
+        for frame in buffered:
             entry = {"timestamp": frame.timestamp}
             if frame.arrival_timestamp is not None:
                 entry["arrival_timestamp"] = frame.arrival_timestamp
@@ -851,4 +861,5 @@ class KLD7Tracker:
 
     def reset(self):
         """Clear the ring buffer after a shot is processed."""
-        self._ring_buffer.clear()
+        with self._buffer_lock:
+            self._ring_buffer.clear()

--- a/tests/test_kld7.py
+++ b/tests/test_kld7.py
@@ -2,6 +2,7 @@
 
 import pickle
 import sys
+import threading
 import time
 from datetime import datetime
 from pathlib import Path
@@ -417,6 +418,47 @@ class TestKLD7TrackerRingBuffer:
         snap = tracker.snapshot_buffer()
         assert len(snap) == 1
         assert "has_radc" not in snap[0]
+
+    def test_buffer_reads_are_safe_during_concurrent_appends(self):
+        """Stream-thread appends must not corrupt shot-path buffer reads.
+
+        The K-LD7 stream thread appends frames at ~34 Hz while the shot
+        path iterates the same ring buffer (snapshot_buffer and
+        _radc_frames_for_extraction). Without synchronization, CPython
+        raises ``RuntimeError: deque mutated during iteration``; the
+        server's broad exception handler swallows it and the shot
+        silently loses its launch angle.
+        """
+        tracker = self._make_tracker()
+        payload = b"\x00" * 3072
+        now = time.time()
+        # Fill to maxlen so every append also evicts (production steady
+        # state once the stream has run for buffer_seconds).
+        for i in range(tracker.max_buffer_frames):
+            tracker._add_frame(KLD7Frame(timestamp=now + i * 0.03, radc=payload))
+
+        stop = threading.Event()
+
+        def writer():
+            i = tracker.max_buffer_frames
+            while not stop.is_set():
+                tracker._add_frame(KLD7Frame(timestamp=now + i * 0.03, radc=payload))
+                i += 1
+
+        thread = threading.Thread(target=writer, daemon=True)
+        thread.start()
+        try:
+            deadline = time.monotonic() + 1.5
+            while time.monotonic() < deadline:
+                # Both reader paths the shot pipeline uses.
+                snap = tracker.snapshot_buffer()
+                assert len(snap) <= tracker.max_buffer_frames
+                frames, _, _ = tracker._radc_frames_for_extraction(shot_timestamp=now)
+                assert len(frames) <= tracker.max_buffer_frames
+        finally:
+            stop.set()
+            thread.join(timeout=5.0)
+        assert not thread.is_alive()
 
     def test_returns_none_when_no_detections(self):
         tracker = self._make_tracker()


### PR DESCRIPTION
> **Note:** This PR restores #106, which was accidentally closed and could not be reopened ("no history in common" after `main`'s history was rewritten). It is the same branch (`fix/kld7-ring-buffer-thread-safety`) at the same commit — no changes from the original.

## What does this PR do?

Fixes a thread-safety race in `KLD7Tracker` that makes shots silently lose their launch angle.

The K-LD7 stream thread appends frames to the ring buffer (`_add_frame`, ~34 Hz) while the OPS243 shot path iterates the same `deque` — both `snapshot_buffer()` and `_radc_frames_for_extraction()` loop over `self._ring_buffer` with no synchronization. When an append lands mid-iteration, CPython raises `RuntimeError: deque mutated during iteration`. The server's K-LD7 exception handling then swallows it, so the symptom in the field is a shot that intermittently has no launch angle (or a missing buffer snapshot in the session log) with nothing in the logs to explain why. The race window exists on every shot while the stream is live.

The fix is minimal and changes no behavior otherwise:

- A `threading.Lock` is created alongside the ring buffer in `_init_ring_buffer()`.
- `_add_frame()` and `reset()` mutate the deque under the lock.
- `snapshot_buffer()` and `_radc_frames_for_extraction()` copy the deque under the lock and do all per-frame work (dict building, base64 encoding) on the copy, so lock hold time stays a single O(n) list copy of a ≤170-element buffer (~µs) and the stream thread is never blocked behind serialization work.

## How was this tested?

- **Failing test first** (per the repo's bug-fix rule): added `test_buffer_reads_are_safe_during_concurrent_appends`, which fills the buffer to `maxlen` (production steady state, every append evicts) and hammers both reader paths from the test thread while a writer thread appends. **Without the fix it fails in seconds with `RuntimeError: deque mutated during iteration` at the exact production call site (`snapshot_buffer`)**; with the fix it passes 5/5 consecutive runs.
- Full suite on Linux: all tests pass.
- Full suite on Windows: 611 passed; the only failures are 9 pre-existing environment-specific tests (bash-dependent `test_start_kiosk` tests and one CRLF-sensitive TrackMan CSV test) that fail identically on a clean checkout of `main`.
- `uv run pylint src/openflight/ --fail-under=9` → 9.69/10.
- `uv run ruff check` and `ruff format --check` clean on all touched files.
- `cd ui && npm run build && npm run lint` → both pass (no UI changes; verified anyway).

## Checklist

- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [x] UI builds (`cd ui && npm run build`)
- [x] UI lint passes (`cd ui && npm run lint`)
- [x] Updated docs or CHANGELOG if needed
- [x] No unrelated changes mixed in

🤖 Generated with [Claude Code](https://claude.com/claude-code)
