### PR TITLE
Add Playwright UI end-to-end coverage

### DIFF
--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -40,3 +41,40 @@ jobs:
       - name: Lint
         run: npm run lint
         working-directory: ui
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ui/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ui
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: ui
+      - name: Run E2E tests
+        run: npm run test:e2e
+        working-directory: ui
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            ui/playwright-report
+            ui/test-results
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ htmlcov/
 # UI (Node.js)
 ui/node_modules/
 ui/dist/autoresearch-results.tsv
+ui/playwright-report/
+ui/test-results/

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.56.1",
         "@types/node": "^25.9.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -1010,6 +1011,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3011,6 +3028,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,6 +8,10 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:debug": "playwright test --debug",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
     "preview": "vite preview"
@@ -18,6 +22,7 @@
     "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.56.1",
     "@eslint/js": "^9.39.1",
     "@types/node": "^25.9.3",
     "@types/react": "^19.2.14",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+
+const PORT = 5173;
+const HOST = '127.0.0.1';
+const BASE_URL = `http://${HOST}:${PORT}`;
+const CONFIG_DIR = fileURLToPath(new URL('.', import.meta.url));
+const BACKEND_ARGS = `--mock --host ${HOST} --web-port 8080 --no-camera --no-logging`;
+const BACKEND_COMMAND =
+  process.env.CI
+    ? `python -m openflight.server ${BACKEND_ARGS}`
+    : `uv run openflight-server ${BACKEND_ARGS}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['html', { outputFolder: 'playwright-report', open: 'never' }], ['github']] : 'list',
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: [
+    {
+      command: BACKEND_COMMAND,
+      url: `http://${HOST}:8080`,
+      reuseExistingServer: !process.env.CI,
+      cwd: fileURLToPath(new URL('..', import.meta.url)),
+    },
+    {
+      command: `npm run dev -- --host ${HOST} --port ${PORT} --mode test`,
+      url: BASE_URL,
+      reuseExistingServer: !process.env.CI,
+      cwd: CONFIG_DIR,
+    },
+  ],
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/ui/tests/e2e/app.spec.ts
+++ b/ui/tests/e2e/app.spec.ts
@@ -1,0 +1,120 @@
+import { test } from '@playwright/test';
+import { expect, gotoApp, setClub, simulateShot, withControlSocket } from './helpers';
+
+test.beforeEach(async () => {
+  await withControlSocket(async (socket) => {
+    socket.emit('clear_session');
+    await new Promise<void>((resolve) => {
+      socket.once('session_cleared', () => resolve());
+    });
+    await setClub(socket, 'driver');
+  });
+});
+
+test('stays usable when websocket upgrade fails and socket.io falls back to polling', async ({ page }) => {
+  await gotoApp(page);
+
+  await expect(page.locator('.connection-status--connected')).toBeVisible();
+  await expect(page.locator('.connection-status__text')).toHaveText('Connected');
+  await expect(page.getByText('Select your club')).toBeVisible();
+});
+
+test('supports club selection choose and dismiss flows against mock backend', async ({ page }) => {
+  await gotoApp(page);
+
+  await page.getByRole('button', { name: '7i' }).click();
+  await expect(page.getByText('Select your club')).toBeHidden();
+  await expect(page.getByRole('button', { name: /Club 7i/i })).toBeVisible();
+
+  await withControlSocket(async (socket) => {
+    await simulateShot(socket);
+  });
+
+  await page.getByRole('button', { name: 'Shots' }).click();
+  await expect(page.locator('.shot-row')).toHaveCount(1);
+  await expect(page.getByText('7-iron')).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByText('Select your club')).toBeVisible();
+  await page.getByRole('button', { name: 'Close club selection' }).click();
+  await expect(page.getByRole('button', { name: /Club DR/i })).toBeVisible();
+});
+
+test('renders live shot data and mock-mode simulate flow', async ({ page }) => {
+  await gotoApp(page);
+  await page.getByRole('button', { name: 'Close club selection' }).click();
+
+  await expect(page.getByRole('button', { name: 'Simulate Shot' })).toBeVisible();
+  await page.getByRole('button', { name: 'Simulate Shot' }).click();
+
+  await expect(page.getByText('Ready for your shot')).toBeHidden();
+  await expect(page.locator('.speed-gauge__value')).not.toHaveText('--');
+  await expect(page.locator('.metric-card').filter({ hasText: 'Carry' }).locator('.metric-card__value')).not.toHaveText('--');
+});
+
+test('switches between primary navigation views', async ({ page }) => {
+  await withControlSocket(async (socket) => {
+    await simulateShot(socket);
+    await setClub(socket, '7-iron');
+    await simulateShot(socket);
+  });
+
+  await gotoApp(page);
+  await page.getByRole('button', { name: 'Close club selection' }).click();
+
+  await page.getByRole('button', { name: 'Stats' }).click();
+  await expect(page.getByText('Avg Ball (mph)')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Shots' }).click();
+  await expect(page.locator('.shot-row')).toHaveCount(2);
+  await expect(page.getByText('7-iron')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Camera' }).click();
+  await expect(page.getByRole('heading', { name: 'Camera Not Available' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Debug' }).click();
+  await expect(page.getByRole('heading', { name: 'System Status' })).toBeVisible();
+  await expect(page.getByText('mock')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Live' }).click();
+  await expect(page.getByRole('button', { name: 'Simulate Shot' })).toBeVisible();
+});
+
+test('display route shows latest shot and recent shots from mock backend session', async ({ page }) => {
+  await withControlSocket(async (socket) => {
+    await setClub(socket, 'driver');
+    await simulateShot(socket);
+    await setClub(socket, '7-iron');
+    await simulateShot(socket);
+    await setClub(socket, 'pw');
+    await simulateShot(socket);
+  });
+
+  await gotoApp(page, '/display');
+
+  await expect(page.getByText('OpenFlight Display')).toBeVisible();
+  await expect(page.getByText('Socket connected')).toBeVisible();
+  await expect(page.getByLabel('Recent shots').locator('.display-shot-chip')).toHaveCount(3);
+  await expect(page.getByLabel('Recent shots')).toContainText('pw');
+  await expect(page.getByLabel('Recent shots')).toContainText('7-iron');
+});
+
+test('unit toggle updates displayed units', async ({ page }) => {
+  await withControlSocket(async (socket) => {
+    await simulateShot(socket);
+  });
+
+  await gotoApp(page);
+  await page.getByRole('button', { name: 'Close club selection' }).click();
+
+  await expect(page.locator('.speed-gauge__unit')).toHaveText('mph');
+  await expect(page.locator('.metric-card').filter({ hasText: 'Carry' }).locator('.metric-card__unit')).toHaveText('yds');
+
+  const imperialSpeed = await page.locator('.speed-gauge__value').textContent();
+
+  await page.getByRole('button', { name: 'KMH/M' }).click();
+
+  await expect(page.locator('.speed-gauge__unit')).toHaveText('km/h');
+  await expect(page.locator('.metric-card').filter({ hasText: 'Carry' }).locator('.metric-card__unit')).toHaveText('m');
+  await expect(page.locator('.speed-gauge__value')).not.toHaveText(imperialSpeed ?? '');
+});

--- a/ui/tests/e2e/helpers.ts
+++ b/ui/tests/e2e/helpers.ts
@@ -1,0 +1,70 @@
+import { expect, type Page } from '@playwright/test';
+import { io, type Socket } from 'socket.io-client';
+
+const UI_URL = 'http://127.0.0.1:5173';
+const SOCKET_URL = 'http://127.0.0.1:8080';
+
+function connectSocket(): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = io(SOCKET_URL, {
+      transports: ['websocket', 'polling'],
+    });
+
+    const onConnect = () => {
+      socket.off('connect_error', onError);
+      resolve(socket);
+    };
+
+    const onError = (error: Error) => {
+      socket.off('connect', onConnect);
+      socket.close();
+      reject(error);
+    };
+
+    socket.once('connect', onConnect);
+    socket.once('connect_error', onError);
+  });
+}
+
+export async function withControlSocket<T>(run: (socket: Socket) => Promise<T>): Promise<T> {
+  const socket = await connectSocket();
+
+  try {
+    return await run(socket);
+  } finally {
+    socket.close();
+  }
+}
+
+export async function setClub(socket: Socket, club: string) {
+  socket.emit('set_club', { club });
+  await waitForEvent(socket, 'club_changed');
+}
+
+export async function simulateShot(socket: Socket) {
+  socket.emit('simulate_shot');
+  return waitForEvent(socket, 'shot');
+}
+
+export async function waitForEvent<T>(socket: Socket, event: string, timeoutMs = 5000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      socket.off(event, onEvent);
+      reject(new Error(`Timed out waiting for ${event}`));
+    }, timeoutMs);
+
+    const onEvent = (payload: T) => {
+      clearTimeout(timeout);
+      socket.off(event, onEvent);
+      resolve(payload);
+    };
+
+    socket.on(event, onEvent);
+  });
+}
+
+export async function gotoApp(page: Page, path = '/') {
+  await page.goto(`${UI_URL}${path}`);
+}
+
+export { expect };

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    include: ['src/**/*.test.{ts,tsx}'],
+    exclude: ['tests/e2e/**'],
+  },
 });


### PR DESCRIPTION
## What does this PR do?

Adds Playwright end-to-end coverage for the React UI and wires it into GitHub Actions.

The UI tests run against the existing mock backend instead of an embedded socket mock in `useSocket`, so production socket behavior stays unchanged and Playwright drives the app through the same backend event surface used in local mock mode.

This PR includes:
- Playwright setup in `ui/` with npm scripts for headless, headed, UI, and debug runs
- Chromium-only Playwright config with local web servers for the mock backend and Vite dev server
- E2E coverage for core flows:
  - connected app load
  - club select choose and dismiss flows
  - live shot rendering
  - mock-mode simulate flow
  - primary nav switching
  - `/display` route rendering
  - unit toggle behavior
- CI workflow updates to run UI E2E on PRs and manual workflow dispatch
- ignored Playwright artifact directories

## How was this tested?

Verified locally with:
- `cd ui && npm run lint`
- `cd ui && npm run build`
- `cd ui && npm run test`
- `cd ui && npm run test:e2e`

E2E runs against the mock backend:
- local uses `uv run openflight-server ...`
- CI uses `python -m openflight.server ...`

## Checklist

- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [x] UI builds (`cd ui && npm run build`)
- [x] UI lint passes (`cd ui && npm run lint`)
- [x] Updated docs or CHANGELOG if needed
- [x] No unrelated changes mixed in
