### PR TITLE
Add a BLE GATT peripheral for mobile pairing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- BLE GATT peripheral (`src/openflight/ble_server.py`): advertises the OpenFlight service over BlueZ, notifies shots and events to paired phones, authenticates with a rotating-nonce HMAC-SHA256 challenge, and serves the pairing payload via localhost `/api/pair-qr` (protocol in `docs/mobile-ble-protocol.md`)
+
 ### Fixed
 - K-LD7 tracker: shots could silently lose their launch angle when the
   stream thread appended a frame while the shot path iterated the ring

--- a/docs/mobile-ble-protocol.md
+++ b/docs/mobile-ble-protocol.md
@@ -1,0 +1,107 @@
+# BLE Protocol
+
+The mobile app talks to the Pi over a custom BLE GATT service when Wi-Fi is unavailable. This
+documents the service, the authentication handshake, and the command/notification payloads.
+
+- Client: `mobile/src/hooks/useBLEConnection.ts` (react-native-ble-plx)
+- Server: `src/openflight/ble_server.py` (`bless`, GATT peripheral on a daemon asyncio thread)
+
+The two files declare the same UUIDs and JSON shapes. Change one, change the other.
+
+## GATT service
+
+Advertised name: `OpenFlight`. Service UUID `4fafc201-1fb5-459e-8fcc-c5c9c331914b`.
+
+| Characteristic | UUID suffix | Properties | Direction |
+|----------------|-------------|------------|-----------|
+| Shot | `…26a8` | read, notify | Pi → phone: new shots |
+| Command | `…26a9` | write | phone → Pi: commands |
+| Status | `…26aa` | read, notify | Pi → phone: events (e.g. `session_cleared`) |
+| Challenge | `…26ab` | read, notify | Pi → phone: current auth nonce |
+
+All payloads are UTF-8 JSON. On the wire, react-native-ble-plx base64-encodes values, so the
+client wraps writes in `btoa(JSON.stringify(...))` and unwraps notifications with
+`JSON.parse(atob(value))`. All Command-characteristic writes go through a single
+`sendCommand(device, payload)` helper in `useBLEConnection.ts`.
+
+## Pairing ceremony (one time)
+
+1. The kiosk browser fetches `/api/pair-qr` (localhost-only) and renders a QR code holding
+   `{ v, s, h, p }`: protocol version, the 32-byte pairing secret as hex, the Pi LAN IP, and the
+   port.
+2. The phone scans the QR and stores the secret hex in SecureStore under
+   `openflight.ble-pairing-secret` (Keychain/Keystore, hardware-backed where available).
+
+The secret never crosses the LAN. The QR endpoint returns 403 to any non-localhost caller.
+
+## Authentication (every connection)
+
+The Pi holds a 32-byte secret. The phone holds the same secret from pairing. They prove a shared
+secret without sending it, using an HMAC challenge:
+
+1. The Pi writes a fresh 64-char hex nonce (`secrets.token_hex(32)`) to the Challenge
+   characteristic. It refreshes every 240s; each nonce is valid for 300s.
+2. On connect the phone reads the Challenge nonce and computes
+   `HMAC-SHA256(secret_bytes, nonce_utf8)` as a 64-char lowercase hex digest. The digest comes from
+   the pure-JS `computeHmac` in `mobile/src/utils/hmac.ts`, not `crypto.subtle` - Hermes ships no
+   WebCrypto. That module is verified against RFC 4231 vectors in `__tests__/utils/hmac.test.ts`.
+3. The phone writes `{"cmd": "auth_challenge", "hmac": "<hex>"}` to the Command characteristic.
+4. The Pi verifies with `hmac.compare_digest` (constant-time). On success the client is
+   authenticated until the current nonce expires (≤5 min); after that it re-authenticates.
+
+If the Pi starts with no pairing secret, it runs in open mode and accepts every command. That path
+is for development only.
+
+```
+Phone                          Pi (ble_server.py)
+  │   read Challenge  ───────────►│  returns nonce (hex)
+  │◄──────────  nonce             │
+  │  HMAC-SHA256(secret, nonce)   │
+  │  write Command:auth_challenge ►│  compare_digest(expected, provided)
+  │◄────────  (authenticated)     │  auth valid until nonce expiry
+```
+
+## Commands (phone → Pi, Command characteristic)
+
+JSON written to the Command characteristic. The server rate-limits accepted writes to one per
+second and dispatches the handler on a worker thread.
+
+| Command | Payload | Effect |
+|---------|---------|--------|
+| `auth_challenge` | `{cmd, hmac}` | Authenticate (above). |
+| `get_session` | `{cmd}` | Ask the Pi to push current session shots. |
+| `clear_session` | `{cmd}` | Clear the active session. |
+| `set_club` | `{cmd, club}` | Set the active club label. |
+| `set_prefs` | `{cmd, accessibility}` | Relay client accessibility prefs to the kiosk. |
+
+The client sends `get_session` and `set_prefs` automatically right after a successful auth.
+
+## Notifications (Pi → phone)
+
+- **Shot** characteristic: a full `Shot` JSON object. If the JSON exceeds 512 bytes, the Pi falls
+  back to a slim encoding with short keys before truncating. The slim map (`_SLIM_FIELDS` in
+  `ble_server.py`):
+
+  | Short | Field |
+  |-------|-------|
+  | `b` | `ball_speed_mph` |
+  | `c` | `estimated_carry_yards` |
+  | `l` | `launch_angle_vertical` |
+  | `s` | `spin_rpm` |
+  | `q` | `club` |
+  | `t` | `timestamp` |
+  | `sp` | `club_speed_mph` |
+  | `sm` | `smash_factor` |
+  | `cs` | `carry_spin_adjusted` |
+
+- **Status** characteristic: event objects such as `{"event": "session_cleared"}`. The client
+  clears its local shot list when it sees that event.
+
+The client drops any shot that fails `isValidShot` and increments `malformedCount` for diagnostics.
+
+## Client connection lifecycle
+
+`useBLEConnection` status moves through `idle → scanning → connecting → connected`, with
+`disconnected` and `error` branches. On an unexpected disconnect it auto-reconnects with a 3s/6s/12s
+backoff for up to 3 attempts. Android requests `BLUETOOTH_SCAN`, `BLUETOOTH_CONNECT`, and
+`ACCESS_FINE_LOCATION` before scanning (API 31+ splits the scan/connect permissions).

--- a/src/openflight/ble_server.py
+++ b/src/openflight/ble_server.py
@@ -1,0 +1,388 @@
+"""
+BLE GATT peripheral server for OpenFlight.
+
+Characteristics
+---------------
+Shot       (notify + read)  – new shots pushed to connected phones
+Command    (write)          – phones send {"cmd": "get_session" | "clear_session" | "set_club", ...}
+Status     (notify + read)  – Pi pushes events like {"event": "session_cleared"}
+Challenge  (notify + read)  – Pi writes a fresh nonce here; client reads and responds with HMAC
+
+Authentication
+--------------
+On startup the server is given a 32-byte pairing secret (loaded from disk by server.py).
+When a client connects it reads the Challenge characteristic to get the current nonce (64-char
+hex string), computes HMAC-SHA256(pairing_secret, nonce_utf8_bytes), and writes
+  {"cmd": "auth_challenge", "hmac": "<64-char hex>"}
+to the Command characteristic.  The Pi verifies with hmac.compare_digest (constant-time).
+
+The nonce is refreshed every 4 minutes.  A newly connected client always sees a valid nonce.
+Auth grants access for 1 hour; after that the client must re-authenticate.
+
+If no pairing_secret is supplied (development / no-BLE-auth mode) all commands are accepted.
+
+UUIDs
+-----
+Service:   4fafc201-1fb5-459e-8fcc-c5c9c331914b
+Shot:      beb5483e-36e1-4688-b7f5-ea07361b26a8
+Command:   beb5483e-36e1-4688-b7f5-ea07361b26a9
+Status:    beb5483e-36e1-4688-b7f5-ea07361b26aa
+Challenge: beb5483e-36e1-4688-b7f5-ea07361b26ab
+"""
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+import secrets
+import threading
+import time
+from typing import Callable, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+OPENFLIGHT_SERVICE_UUID    = "4fafc201-1fb5-459e-8fcc-c5c9c331914b"
+SHOT_CHARACTERISTIC_UUID      = "beb5483e-36e1-4688-b7f5-ea07361b26a8"
+COMMAND_CHARACTERISTIC_UUID   = "beb5483e-36e1-4688-b7f5-ea07361b26a9"
+STATUS_CHARACTERISTIC_UUID    = "beb5483e-36e1-4688-b7f5-ea07361b26aa"
+CHALLENGE_CHARACTERISTIC_UUID = "beb5483e-36e1-4688-b7f5-ea07361b26ab"
+
+# Truncate at 512 bytes; fall back to slim encoding before truncating
+_MAX_PAYLOAD_BYTES = 512
+# Slim encoding: short key → full Shot field name (8 most-displayed fields)
+_SLIM_FIELDS = {
+    "b": "ball_speed_mph",
+    "c": "estimated_carry_yards",
+    "l": "launch_angle_vertical",
+    "s": "spin_rpm",
+    "q": "club",
+    "t": "timestamp",
+    "sp": "club_speed_mph",
+    "sm": "smash_factor",
+    "cs": "carry_spin_adjusted",
+}
+# Minimum seconds between accepted write commands (per-server rate limit)
+_COMMAND_RATE_LIMIT_S = 1.0
+# Nonce refresh interval — 4 minutes; nonce valid for 5 minutes.
+_NONCE_REFRESH_S = 240
+_NONCE_TTL_S = 300
+
+
+@runtime_checkable
+class BLEBackend(Protocol):
+    """
+    Minimal interface that the real bless BlessServer satisfies.
+    Inject a mock in tests to avoid needing real Bluetooth hardware.
+    """
+
+    async def start(self) -> None:
+        """Start advertising and bring up the GATT server"""
+
+    async def stop(self) -> None:
+        """Tear down the GATT server and stop advertising"""
+
+    async def update_value(self, service_uuid: str, char_uuid: str) -> None:
+        """Push the characteristic's current value to its subscribers"""
+
+    def get_characteristic(self, char_uuid: str):
+        """Return the backend characteristic object for a uuid"""
+
+
+def _slim_shot(shot_data: dict) -> dict:
+    return {short: shot_data.get(full) for short, full in _SLIM_FIELDS.items()}
+
+
+class BLEServer:
+    """
+    BLE GATT peripheral.  Runs its own asyncio loop on a daemon thread so
+    the Flask server is not blocked.  All public methods are thread-safe.
+
+    Parameters
+    ----------
+    on_command:
+        Optional callback invoked (in the BLE event loop thread) when a
+        mobile client writes to the command characteristic.  The argument
+        is the parsed JSON dict, e.g. {"cmd": "get_session"}.
+    pairing_secret:
+        32-byte secret shared with the mobile app during the QR pairing
+        ceremony.  If None the server runs in open mode (no auth required).
+    """
+
+    def __init__(
+        self,
+        on_command: Optional[Callable[[dict], None]] = None,
+        pairing_secret: Optional[bytes] = None,
+    ) -> None:
+        self._on_command = on_command
+        self._pairing_secret = pairing_secret
+        # Open mode: no secret → always authenticated
+        self._authenticated: bool = pairing_secret is None
+        self._auth_expiry: float = float("inf") if pairing_secret is None else 0.0
+        self._current_nonce: str = ""        # 64-char hex string written to CHALLENGE char
+        self._nonce_expiry: float = 0.0
+        self._nonce_refresh_task: Optional[asyncio.Task] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._server = None
+        self._thread: Optional[threading.Thread] = None
+        self._ready = threading.Event()
+        self._last_command_time: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Public API (thread-safe)
+    # ------------------------------------------------------------------
+
+    def start(self) -> bool:
+        """Start the BLE peripheral on a background thread.  Returns True on success."""
+        if self._thread is not None and self._thread.is_alive():
+            logger.warning("BLE server already running; ignoring duplicate start()")
+            return self._server is not None
+        self._ready.clear()
+        try:
+            from bless import (  # pylint: disable=import-outside-toplevel
+                BlessServer,
+                GATTAttributePermissions,
+                GATTCharacteristicProperties,
+            )
+        except ImportError:
+            logger.error(
+                "BLE support requires the 'bless' package. "
+                "Install it with: uv pip install 'openflight[ble]'"
+            )
+            return False
+
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            args=(BlessServer, GATTCharacteristicProperties, GATTAttributePermissions),
+            daemon=True,
+            name="ble-server",
+        )
+        self._thread.start()
+
+        if not self._ready.wait(timeout=10):
+            logger.error("BLE server did not start within 10 seconds")
+            return False
+
+        return self._server is not None
+
+    def notify_shot(self, shot_data: dict) -> None:
+        """Push a shot to all connected BLE centrals (thread-safe)."""
+        if self._server is None or self._loop is None:
+            return
+
+        payload = json.dumps(shot_data).encode("utf-8")
+        if len(payload) > _MAX_PAYLOAD_BYTES:
+            slim = json.dumps(_slim_shot(shot_data)).encode("utf-8")
+            logger.debug(
+                "BLE: full shot %d bytes > limit; using slim encoding (%d bytes)",
+                len(payload),
+                len(slim),
+            )
+            payload = slim
+
+        asyncio.run_coroutine_threadsafe(
+            self._push(SHOT_CHARACTERISTIC_UUID, bytearray(payload)), self._loop
+        )
+
+    def notify_event(self, event_data: dict) -> None:
+        """Push a status event to all connected BLE centrals (thread-safe)."""
+        if self._server is None or self._loop is None:
+            return
+        payload = json.dumps(event_data).encode("utf-8")
+        asyncio.run_coroutine_threadsafe(
+            self._push(STATUS_CHARACTERISTIC_UUID, bytearray(payload)), self._loop
+        )
+
+    def stop(self) -> None:
+        """Gracefully stop the server."""
+        if self._server and self._loop:
+            if self._nonce_refresh_task:
+                self._loop.call_soon_threadsafe(self._nonce_refresh_task.cancel)
+            future = asyncio.run_coroutine_threadsafe(self._server.stop(), self._loop)
+            try:
+                future.result(timeout=5)
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _run_loop(
+        self,
+        BlessServer,
+        GATTCharacteristicProperties,
+        GATTAttributePermissions,
+    ) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        try:
+            loop.run_until_complete(
+                self._setup(BlessServer, GATTCharacteristicProperties, GATTAttributePermissions)
+            )
+            loop.run_forever()
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception("BLE server loop crashed: %s", exc)
+            self._ready.set()
+        finally:
+            loop.close()
+
+    async def _setup(
+        self,
+        BlessServer,
+        GATTCharacteristicProperties,
+        GATTAttributePermissions,
+    ) -> None:
+        server = BlessServer(name="OpenFlight", loop=self._loop)
+        server.write_request_func = self._handle_write
+
+        gatt = {
+            OPENFLIGHT_SERVICE_UUID: {
+                SHOT_CHARACTERISTIC_UUID: {
+                    "Properties": (
+                        GATTCharacteristicProperties.read
+                        | GATTCharacteristicProperties.notify
+                    ),
+                    "Permissions": GATTAttributePermissions.readable,
+                    "Value": bytearray(b""),
+                },
+                COMMAND_CHARACTERISTIC_UUID: {
+                    "Properties": GATTCharacteristicProperties.write,
+                    "Permissions": GATTAttributePermissions.writeable,
+                    "Value": bytearray(b""),
+                },
+                STATUS_CHARACTERISTIC_UUID: {
+                    "Properties": (
+                        GATTCharacteristicProperties.read
+                        | GATTCharacteristicProperties.notify
+                    ),
+                    "Permissions": GATTAttributePermissions.readable,
+                    "Value": bytearray(b""),
+                },
+                CHALLENGE_CHARACTERISTIC_UUID: {
+                    "Properties": (
+                        GATTCharacteristicProperties.read
+                        | GATTCharacteristicProperties.notify
+                    ),
+                    "Permissions": GATTAttributePermissions.readable,
+                    "Value": bytearray(b""),
+                },
+            }
+        }
+
+        await server.add_gatt(gatt)
+        await server.start()
+        self._server = server
+        # Write the first nonce before signalling ready so connecting clients always
+        # see a valid challenge immediately.
+        await self._refresh_nonce()
+        self._nonce_refresh_task = asyncio.ensure_future(self._nonce_refresh_loop())
+        logger.info("BLE server started — advertising as 'OpenFlight'")
+        self._ready.set()
+
+    async def _refresh_nonce(self) -> None:
+        """Generate a fresh 32-byte nonce and write it to the Challenge characteristic.
+
+        Also resets auth state so any inherited session from a previous BLE client
+        is invalidated — the next client must prove possession of the pairing secret
+        with the new nonce.
+        """
+        self._current_nonce = secrets.token_hex(32)   # 64-char hex string
+        self._nonce_expiry = time.monotonic() + _NONCE_TTL_S
+        if self._pairing_secret is not None:
+            self._authenticated = False
+            self._auth_expiry = 0.0
+        if self._server:
+            char = self._server.get_characteristic(CHALLENGE_CHARACTERISTIC_UUID)
+            if char:
+                char.value = bytearray(self._current_nonce.encode())
+                try:
+                    await self._server.update_value(
+                        OPENFLIGHT_SERVICE_UUID, CHALLENGE_CHARACTERISTIC_UUID
+                    )
+                except Exception:  # pylint: disable=broad-except
+                    pass
+
+    async def _nonce_refresh_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(_NONCE_REFRESH_S)
+                await self._refresh_nonce()
+        except asyncio.CancelledError:
+            pass
+
+    async def _push(self, char_uuid: str, payload: bytearray) -> None:
+        if self._server is None:
+            return
+        char = self._server.get_characteristic(char_uuid)
+        if char is None:
+            return
+        try:
+            char.value = payload
+            await self._server.update_value(OPENFLIGHT_SERVICE_UUID, char_uuid)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.warning("BLE notify failed (…%s): %s", char_uuid[-4:], exc)
+
+    def _verify_hmac(self, provided_hex: str) -> bool:
+        """Constant-time HMAC-SHA256 verification against the current nonce."""
+        if not self._pairing_secret:
+            return True
+        if not self._current_nonce or time.monotonic() > self._nonce_expiry:
+            logger.warning("BLE: auth attempt with expired or missing nonce")
+            return False
+        nonce_bytes = self._current_nonce.encode()
+        expected = hmac.new(self._pairing_secret, nonce_bytes, hashlib.sha256).hexdigest()
+        try:
+            return hmac.compare_digest(expected, provided_hex.lower())
+        except (ValueError, TypeError):
+            return False
+
+    def _dispatch_command(self, cmd: dict) -> None:
+        try:
+            self._on_command(cmd)  # type: ignore[misc]
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception("BLE on_command handler error: %s", exc)
+
+    def _handle_write(self, characteristic, value: bytearray, **_kwargs) -> None:
+        """Rate-limited write handler; dispatches on_command to a daemon thread."""
+        try:
+            char_uuid = str(characteristic.uuid).lower()
+        except Exception:  # pylint: disable=broad-except
+            return
+        if char_uuid != COMMAND_CHARACTERISTIC_UUID.lower():
+            return
+
+        now = time.monotonic()
+        if now - self._last_command_time < _COMMAND_RATE_LIMIT_S:
+            logger.debug("BLE command rate-limited")
+            return
+        self._last_command_time = now
+
+        try:
+            cmd = json.loads(bytes(value).decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+            logger.warning("BLE: malformed command payload")
+            return
+
+        if cmd.get("cmd") == "auth_challenge":
+            provided = cmd.get("hmac", "")
+            if self._verify_hmac(provided):
+                self._authenticated = True
+                # Auth is tied to the nonce window (≤5 min).  When the nonce
+                # rotates, _nonce_expiry advances and any NEW connection must
+                # re-auth; an old connection's auth expires with its nonce.
+                self._auth_expiry = self._nonce_expiry
+                logger.info("BLE: client authenticated via HMAC-SHA256")
+            else:
+                logger.warning("BLE: auth failed — invalid HMAC or expired nonce")
+            return
+
+        if not self._authenticated or time.monotonic() > self._auth_expiry:
+            logger.warning("BLE: command rejected — not authenticated")
+            return
+
+        if self._on_command is not None:
+            threading.Thread(
+                target=self._dispatch_command, args=(cmd,), daemon=True, name="ble-cmd"
+            ).start()

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -8,6 +8,8 @@ import json
 import logging
 import os
 import random
+import secrets
+import socket as _net
 import statistics
 import sys
 import threading
@@ -16,7 +18,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
-from flask import Flask, Response, send_from_directory
+from flask import Flask, Response, request, send_from_directory
 from flask_cors import CORS
 from flask_socketio import SocketIO
 
@@ -58,8 +60,42 @@ app = Flask(__name__, static_folder=str(FRONTEND_DIST_DIR), static_url_path="")
 CORS(app)
 socketio = SocketIO(app, cors_allowed_origins="*", async_mode="threading")
 
+# ------------------------------------------------------------------
+# BLE pairing secret — persisted across restarts so the mobile app
+# only needs to scan the QR once.  Stored chmod 600 in ~/.openflight/.
+# ------------------------------------------------------------------
+_PAIRING_KEY_FILE = Path.home() / ".openflight" / "pairing.key"
+
+
+def _load_or_create_pairing_secret() -> bytes:
+    _PAIRING_KEY_FILE.parent.mkdir(exist_ok=True)
+    if _PAIRING_KEY_FILE.exists():
+        _PAIRING_KEY_FILE.chmod(0o600)  # enforce on every load, not just creation
+        try:
+            return bytes.fromhex(_PAIRING_KEY_FILE.read_text().strip())
+        except ValueError:
+            pass  # corrupted — regenerate
+    raw = secrets.token_bytes(32)
+    _PAIRING_KEY_FILE.write_text(raw.hex())
+    _PAIRING_KEY_FILE.chmod(0o600)
+    return raw
+
+
+_PAIRING_SECRET: bytes = _load_or_create_pairing_secret()
+
+
+def _get_local_ip() -> str:
+    """Return the primary LAN IP used to reach the outside world."""
+    try:
+        with _net.socket(_net.AF_INET, _net.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+    except Exception:  # pylint: disable=broad-except
+        return "127.0.0.1"
+
 # Global state
 monitor = None
+ble_server = None
 mock_mode: bool = False
 debug_mode: bool = False
 debug_log_file = None
@@ -858,6 +894,35 @@ def static_files(path):
     return send_from_directory(app.static_folder, path)
 
 
+@app.route("/api/pair-qr")
+def api_pair_qr():
+    """Return the QR payload for BLE pairing.
+
+    Only callable from localhost (the kiosk browser on the Pi itself) so the
+    pairing secret is never served over the LAN.  The kiosk renders the
+    payload as a QR code; the mobile app scans it once and stores the secret
+    in the device Keychain/Keystore — no further network calls required.
+    """
+    # Only the socket-level peer address matters — X-Forwarded-For is
+    # trivially spoofable by any LAN host and must never gate a secret endpoint.
+    remote = request.remote_addr or ""
+    is_local = remote in ("127.0.0.1", "::1")
+    if not is_local:
+        return {"error": "Forbidden"}, 403
+    try:
+        host_str = request.host or ""
+        host_port = int(host_str.split(":")[-1]) if ":" in host_str else 8080
+        return {
+            "v": 1,
+            "s": _PAIRING_SECRET.hex(),
+            "h": _get_local_ip(),
+            "p": host_port,
+        }, 200
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.exception("[SERVER] pair-qr error: %s", exc)
+        return {"error": f"Server error: {exc}"}, 503
+
+
 @app.route("/api/shutdown", methods=["POST"])
 def api_shutdown():
     """Cleanly shut down the server via REST API."""
@@ -1358,6 +1423,8 @@ def handle_clear_session():
     if monitor:
         monitor.clear_session()
         socketio.emit("session_cleared")
+        if ble_server is not None:
+            ble_server.notify_event({"event": "session_cleared"})
 
 
 @socketio.on("get_session")
@@ -1959,6 +2026,8 @@ def on_shot_detected(shot: Shot):
         shot_data = shot_to_dict(shot)
         stats = monitor.get_session_stats() if monitor else {}
         socketio.emit("shot", {"shot": shot_data, "stats": stats})
+        if ble_server is not None:
+            ble_server.notify_shot(shot_data)
 
         # Log shot info
         angle_str = ""
@@ -2339,6 +2408,33 @@ class MockLaunchMonitor:
         self._current_club = club
 
 
+def _handle_ble_command(cmd: dict) -> None:
+    """Dispatch commands received from BLE central devices."""
+    command = cmd.get("cmd")
+    if command == "get_session" and monitor:
+        shots_list = [shot_to_dict(s) for s in monitor.get_shots()]
+        for shot_data in shots_list:
+            if ble_server is not None:
+                ble_server.notify_shot(shot_data)
+            time.sleep(0.05)
+    elif command == "clear_session" and monitor:
+        monitor.clear_session()
+        socketio.emit("session_cleared")
+        if ble_server is not None:
+            ble_server.notify_event({"event": "session_cleared"})
+    elif command == "set_club":
+        club_name = cmd.get("club", "")
+        try:
+            club = ClubType(club_name)
+            if monitor:
+                monitor.set_club(club)
+        except ValueError:
+            pass
+    elif command == "set_prefs":
+        prefs_payload = {k: v for k, v in cmd.items() if k != "cmd"}
+        socketio.emit("accessibility_prefs_update", prefs_payload)
+
+
 def main():
     """Run the server."""
     import argparse  # pylint: disable=import-outside-toplevel
@@ -2414,6 +2510,11 @@ def main():
         "--log-dir", help="Directory for session logs (default: ~/openflight_sessions)"
     )
     parser.add_argument("--no-logging", action="store_true", help="Disable session logging")
+    parser.add_argument(
+        "--ble",
+        action="store_true",
+        help="Enable Bluetooth LE GATT server (Pi only, requires bless package)",
+    )
     parser.add_argument(
         "--ballistics",
         action="store_true",
@@ -2754,6 +2855,19 @@ def main():
     if args.mock:
         print("Running in MOCK mode - no radar required")
         print("Simulate shots via WebSocket or API")
+
+    if args.ble:
+        global ble_server  # pylint: disable=global-statement
+        from .ble_server import BLEServer  # pylint: disable=import-outside-toplevel
+
+        ble_server = BLEServer(on_command=_handle_ble_command, pairing_secret=_PAIRING_SECRET)
+        if ble_server.start():
+            print("Bluetooth LE server started — advertising as 'OpenFlight'")
+            print(f"  Pairing secret stored at: {_PAIRING_KEY_FILE}")
+            print("  Show the kiosk Settings -> Pair Mobile to display the QR code")
+        else:
+            print("WARNING: Bluetooth LE server failed to start — continuing without BLE")
+            ble_server = None
 
     print(f"Server starting at http://{args.host}:{args.web_port}")
     print()


### PR DESCRIPTION
## What does this PR do?

Adds the BLE GATT peripheral that lets the mobile app pair with the Pi over Bluetooth (no Wi-Fi needed):

- `ble_server.py`: advertises the OpenFlight GATT service via BlueZ, notifies shots and session events, handles club/session/prefs commands, and authenticates each session with a rotating-nonce HMAC-SHA256 challenge (constant-time)
- wires the BLE server into startup behind the `--ble` flag and serves the pairing payload via the localhost `/api/pair-qr` endpoint
- BLE wire-protocol reference doc

## How was this tested?

- `uv run pylint src/openflight/ble_server.py` rated 10.00/10
- `uv run ruff check` clean
- No automated test (BlueZ/hardware dependent); verified against the mobile app's BLE client

## Checklist

- [ ] Python tests pass (no test; BlueZ/hardware dependent)
- [x] Pylint passes (10.00/10 for `ble_server.py`)
- [x] Ruff passes
- [x] Updated docs (BLE protocol + CHANGELOG)
- [x] No unrelated changes mixed in

Note: the `/api/pair-qr` wiring touches the 2851-line `server.py` module, which carries a pre-existing pylint module-size cap unrelated to this change.
