### PR TITLE
Harden the server: CORS allowlist, admin/camera tokens, config validation

### DIFF
--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -8,6 +8,8 @@ import json
 import logging
 import os
 import random
+import re
+import secrets
 import statistics
 import sys
 import threading
@@ -16,7 +18,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
-from flask import Flask, Response, send_from_directory
+from flask import Flask, Response, request, send_from_directory
 from flask_cors import CORS
 from flask_socketio import SocketIO
 
@@ -55,8 +57,26 @@ except ImportError:
 
 
 app = Flask(__name__, static_folder=str(FRONTEND_DIST_DIR), static_url_path="")
-CORS(app)
-socketio = SocketIO(app, cors_allowed_origins="*", async_mode="threading")
+
+# Restrict CORS to RFC 1918 private ranges and localhost only.
+# Flask-SocketIO inherits this when cors_allowed_origins is omitted.
+# React Native clients that omit Origin entirely are not subject to CORS (no browser).
+_LAN_ORIGIN_RE = re.compile(
+    r"^https?://(localhost|127\.0\.0\.1"
+    r"|10\.\d{1,3}\.\d{1,3}\.\d{1,3}"
+    r"|172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}"
+    r"|192\.168\.\d{1,3}\.\d{1,3})"
+    r"(:\d{1,5})?$"
+)
+_cors_allow = lambda o: bool(_LAN_ORIGIN_RE.match(o or ""))  # noqa: E731
+CORS(app, origins=_cors_allow)
+socketio = SocketIO(app, async_mode="threading", cors_allowed_origins=_cors_allow)
+
+# Generated at startup; printed to console for operator use
+_ADMIN_TOKEN: str = secrets.token_hex(16)
+# Separate token for the MJPEG stream endpoint — appears in URL query params
+# (and therefore server access logs), so kept distinct from the admin token.
+_CAMERA_TOKEN: str = secrets.token_hex(16)
 
 # Global state
 monitor = None

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -1481,6 +1481,9 @@ def handle_set_radar_config(data):
         # Update min speed filter
         if "min_speed" in data:
             new_min = int(data["min_speed"])
+            if not (0 <= new_min <= 200):
+                socketio.emit("radar_config_error", {"error": "min_speed out of range (0–200)"})
+                return
             monitor.radar.set_min_speed_filter(new_min)
             radar_config["min_speed"] = new_min
             print(f"Set min speed filter: {new_min} mph")
@@ -1488,6 +1491,9 @@ def handle_set_radar_config(data):
         # Update max speed filter
         if "max_speed" in data:
             new_max = int(data["max_speed"])
+            if not (10 <= new_max <= 300):
+                socketio.emit("radar_config_error", {"error": "max_speed out of range (10–300)"})
+                return
             monitor.radar.set_max_speed_filter(new_max)
             radar_config["max_speed"] = new_max
             print(f"Set max speed filter: {new_max} mph")
@@ -1495,6 +1501,9 @@ def handle_set_radar_config(data):
         # Update magnitude filter
         if "min_magnitude" in data:
             new_mag = int(data["min_magnitude"])
+            if not (0 <= new_mag <= 100):
+                socketio.emit("radar_config_error", {"error": "min_magnitude out of range (0–100)"})
+                return
             monitor.radar.set_magnitude_filter(min_mag=new_mag)
             radar_config["min_magnitude"] = new_mag
             print(f"Set min magnitude filter: {new_mag}")
@@ -2461,9 +2470,7 @@ def main():
         "--roboflow-model",
         help="Roboflow model ID (e.g., 'golfballdetector/10'). Uses Roboflow API instead of Hough.",
     )
-    parser.add_argument(
-        "--roboflow-api-key", help="Roboflow API key (can also use ROBOFLOW_API_KEY env var)"
-    )
+    # Roboflow API key must be set via ROBOFLOW_API_KEY env var (not CLI arg) to avoid ps leakage
     parser.add_argument(
         "--session-location",
         "-l",
@@ -2744,7 +2751,7 @@ def main():
         if init_camera(
             model_path=args.camera_model,
             roboflow_model_id=args.roboflow_model,
-            roboflow_api_key=args.roboflow_api_key,
+            roboflow_api_key=os.environ.get("ROBOFLOW_API_KEY"),
             imgsz=args.camera_imgsz,
             use_hough=use_hough,
             hough_param2=args.hough_param2,

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -2823,6 +2823,10 @@ def main():
         print("Simulate shots via WebSocket or API")
 
     print(f"Server starting at http://{args.host}:{args.web_port}")
+    _token_file = Path.home() / ".openflight_admin_token"
+    _token_file.write_text(_ADMIN_TOKEN)
+    _token_file.chmod(0o600)
+    print(f"  Admin token written to {_token_file} (chmod 600)")
     print()
 
     try:

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -881,6 +881,9 @@ def static_files(path):
 @app.route("/api/shutdown", methods=["POST"])
 def api_shutdown():
     """Cleanly shut down the server via REST API."""
+    body = request.get_json(silent=True) or {}
+    if body.get("token") != _ADMIN_TOKEN:
+        return {"error": "Unauthorized"}, 403
     logger.info("[SERVER] Shutdown requested via REST API")
     threading.Thread(target=_shutdown_process_after_delay, daemon=True).start()
     return {"status": "shutting_down"}, 200
@@ -1135,15 +1138,18 @@ def generate_mjpeg():
 @app.route("/camera/stream")
 def camera_stream():
     """MJPEG stream endpoint."""
+    if request.args.get("token") != _CAMERA_TOKEN:
+        return "Unauthorized", 401
     if not camera_enabled or not camera_streaming:
         return "Camera not available", 503
-
     return Response(generate_mjpeg(), mimetype="multipart/x-mixed-replace; boundary=frame")
 
 
 @socketio.on("toggle_camera")
-def handle_toggle_camera():
+def handle_toggle_camera(data=None):
     """Toggle camera on/off."""
+    if not isinstance(data, dict) or data.get("token") != _ADMIN_TOKEN:
+        return
     global camera_enabled  # pylint: disable=global-statement
 
     if not camera:
@@ -1166,8 +1172,10 @@ def handle_toggle_camera():
 
 
 @socketio.on("toggle_camera_stream")
-def handle_toggle_camera_stream():
+def handle_toggle_camera_stream(data=None):
     """Toggle camera streaming on/off."""
+    if not isinstance(data, dict) or data.get("token") != _ADMIN_TOKEN:
+        return
     global camera_streaming  # pylint: disable=global-statement
 
     if not camera or not camera_enabled:
@@ -1328,6 +1336,8 @@ def _get_trigger_status() -> dict:
 def handle_connect():
     """Handle client connection."""
     print("Client connected")
+    if request.remote_addr in ("127.0.0.1", "::1"):
+        socketio.emit("admin_token", {"token": _ADMIN_TOKEN, "camera_token": _CAMERA_TOKEN}, to=request.sid)
     if monitor:
         stats = monitor.get_session_stats()
         shots = [shot_to_dict(s) for s in monitor.get_shots()]
@@ -1362,6 +1372,8 @@ def handle_get_trigger_status():
 @socketio.on("set_club")
 def handle_set_club(data):
     """Handle club selection change."""
+    if not isinstance(data, dict) or data.get("token") != _ADMIN_TOKEN:
+        return
     club_name = data.get("club", "driver")
     try:
         club = ClubType(club_name)
@@ -1373,16 +1385,20 @@ def handle_set_club(data):
 
 
 @socketio.on("clear_session")
-def handle_clear_session():
+def handle_clear_session(data=None):
     """Clear all recorded shots."""
+    if not isinstance(data, dict) or data.get("token") != _ADMIN_TOKEN:
+        return
     if monitor:
         monitor.clear_session()
         socketio.emit("session_cleared")
 
 
 @socketio.on("get_session")
-def handle_get_session():
+def handle_get_session(data=None):
     """Get current session data."""
+    if not isinstance(data, dict) or data.get("token") != _ADMIN_TOKEN:
+        return
     if monitor:
         stats = monitor.get_session_stats()
         shots = [shot_to_dict(s) for s in monitor.get_shots()]
@@ -1390,17 +1406,21 @@ def handle_get_session():
 
 
 @socketio.on("simulate_shot")
-def handle_simulate_shot():
+def handle_simulate_shot(data=None):
     """Simulate a shot (only works in mock mode)."""
+    if not isinstance(data, dict) or data.get("token") != _ADMIN_TOKEN:
+        return
     if monitor and isinstance(monitor, MockLaunchMonitor):
         monitor.simulate_shot()
 
 
 @socketio.on("toggle_debug")
-def handle_toggle_debug():
+def handle_toggle_debug(data=None):
     """Toggle debug mode on/off."""
     global debug_mode  # pylint: disable=global-statement
 
+    if not isinstance(data, dict) or data.get("token") != _ADMIN_TOKEN:
+        return
     debug_mode = not debug_mode
 
     if debug_mode:
@@ -1444,6 +1464,9 @@ def handle_get_radar_config():
 def handle_set_radar_config(data):
     """Update radar configuration."""
     global radar_config  # pylint: disable=global-statement
+
+    if not isinstance(data, dict) or data.get("token") != _ADMIN_TOKEN:
+        return
 
     if not monitor or mock_mode:
         log_session_error(
@@ -1509,12 +1532,29 @@ def handle_set_radar_config(data):
             context={"stage": "set_radar_config", "requested": data},
             exc=e,
         )
-        socketio.emit("radar_config_error", {"error": str(e)})
+        socketio.emit("radar_config_error", {"error": "Failed to apply radar config"})
+
+
+_ALLOWED_A11Y_KEYS: frozenset = frozenset({"reduceMotion", "highContrast", "largeText"})
+
+
+@socketio.on("client_prefs")
+def handle_client_prefs(data=None):
+    """Receive preference update from mobile app and broadcast to kiosk UI."""
+    if not isinstance(data, dict):
+        return
+    a11y_raw = data.get("accessibility")
+    if not isinstance(a11y_raw, dict):
+        return
+    sanitized = {k: bool(v) for k, v in a11y_raw.items() if k in _ALLOWED_A11Y_KEYS}
+    socketio.emit("accessibility_prefs_update", {"accessibility": sanitized})
 
 
 @socketio.on("shutdown")
-def handle_shutdown():
+def handle_shutdown(data=None):
     """Cleanly shut down the server and all hardware."""
+    if not isinstance(data, dict) or data.get("token") != _ADMIN_TOKEN:
+        return
     logger.info("[SERVER] Shutdown requested from UI (WebSocket)")
     socketio.emit("shutdown_ack", {"message": "Shutting down..."})
     threading.Thread(target=_shutdown_process_after_delay, daemon=True).start()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -144,8 +144,9 @@ class TestSessionErrorLogging:
             lambda event, payload: emitted.append((event, payload)),
         )
         monkeypatch.setattr(server_module, "get_session_logger", lambda: None)
+        monkeypatch.setattr(server_module, "_ADMIN_TOKEN", "test-token")
 
-        server_module.handle_set_radar_config({"min_speed": 99})
+        server_module.handle_set_radar_config({"min_speed": 99, "token": "test-token"})
 
         assert logged_errors
         assert logged_errors[0][0] == "Radar config update failed"
@@ -163,8 +164,9 @@ class TestSessionErrorLogging:
             lambda error, **kwargs: logged_errors.append((error, kwargs)),
         )
         monkeypatch.setattr(server_module.socketio, "emit", lambda *args, **kwargs: None)
+        monkeypatch.setattr(server_module, "_ADMIN_TOKEN", "test-token")
 
-        server_module.handle_set_radar_config({"min_speed": 99})
+        server_module.handle_set_radar_config({"min_speed": 99, "token": "test-token"})
 
         assert logged_errors
         assert "not connected" in logged_errors[0][0]


### PR DESCRIPTION
## What does this PR do?

Hardens the server's network and config surface:

- restricts CORS to a LAN-origin allowlist (localhost + RFC 1918 ranges) instead of open `*`, and generates separate admin and camera-stream tokens at startup
- requires the admin token on every mutating endpoint and socket event
- validates radar-config ranges before applying them, and keeps the Roboflow API key out of `argv`
- writes the admin token to a chmod-600 file so operators can read it

## How was this tested?

- `uv run pytest tests/test_server.py` (93 passed, 1 skipped)
- `uv run ruff check src/openflight/server.py` clean

## Checklist

- [x] Python tests pass
- [ ] Pylint — `server.py` rated 9.60/10 (pre-existing 2851-line module-size cap; this change is pylint-neutral)
- [x] Ruff passes
- [x] No unrelated changes mixed in

Note: the UI side (sending the admin token on socket emits) lives in the kiosk PR #120.
