### PR TITLE
Update link and price for 27W USB-C Power Supply

### DIFF
--- a/docs/PARTS.md
+++ b/docs/PARTS.md
@@ -67,7 +67,7 @@ One unit is mounted vertically (launch angle), one horizontally (club path / aim
 
 | Part | Description | Link | ~Price |
 |------|-------------|------|--------|
-| **27W USB-C Power Supply** | Official Pi 5 power supply (5V 5A) | [Adafruit](https://www.adafruit.com/product/5974) | $12 |
+| **27W USB-C Power Supply** | Official Pi 5 power supply (5V 5A) | [Adafruit](https://www.adafruit.com/product/5814) | $14 |
 | MicroSD Card (32GB+) | For Pi OS and software | Any Class 10 | $10 |
 | USB-A to Micro-USB Cable | For OPS243 radar connection | Any | $5 |
 


### PR DESCRIPTION
Correcting link to Power supply on parts list.

Existing link goes to strain gauge. (Adafruit HX711 24-bit ADC for Load Cells / Strain Gauges)

New link goes to the correct 27W USB-C power supply, 5v 5A (Official Raspberry Pi 27W PD Power Supply 5.1V 5A with USB C)