### PR TITLE
fix(sim): GSPro shot acceptance (ShotNumber) + connector status reliability

### DIFF
--- a/docs/simulator/gspro.md
+++ b/docs/simulator/gspro.md
@@ -11,18 +11,44 @@ requirements and setup specific to GSPro.
 
 - **A GSPro license.** GSPro is paid software (subscription). The OpenConnect
   API is included with a standard license — there is no separate add-on.
+- **An OpenAPI / OpenConnect license type.** GSPro ties each license to a
+  launch-monitor type, and OpenFlight connects as a generic OpenConnect device.
+  If your license is set to a specific monitor (Foresight, Uneekor, etc.), you
+  must convert it to the **OpenAPI** type using GSPro's
+  [license conversion tool](https://gsprogolf.com/convert.html). After
+  converting, install the latest GSPro and **clear your GSPro Connect settings**
+  so the OpenAPI option is selectable (see
+  [How To Clear GSPro Connect Settings](https://gspro.gitbook.io/gspro-knowledge-base/troubleshooting-and-support/how-to-clear-gspro-connect-settings)).
 - **The GSPro Connect window.** GSPro exposes the API through its built-in
   "GSPro Connect" / OpenAPI interface, which listens on **TCP port 921**.
-- **Network reachability.** OpenFlight (the Raspberry Pi) and the PC running
-  GSPro must be on the same LAN. You need the GSPro PC's IP address.
+- **Network reachability + an open port 921.** OpenFlight (the Raspberry Pi)
+  and the PC running GSPro should be on the same LAN; you need the GSPro PC's IP
+  address. **TCP port 921 must be reachable on the GSPro PC** — allow it as an
+  inbound rule through the PC's firewall (Windows Defender Firewall by default).
+  If OpenFlight and GSPro are on *different* networks, you'd have to forward 921
+  to the GSPro PC on the router — but OpenConnect has **no authentication**
+  (below), so never expose 921 to the public internet; keep both on the same
+  trusted LAN.
 - No account/credentials are sent by OpenFlight — OpenConnect V1 has no auth.
 
 ## Setup
 
-1. **Find the GSPro PC's IP address** (e.g. `192.168.1.50`).
-   - Windows: `ipconfig` → IPv4 Address.
+1. **Convert your license to OpenAPI** (one-time). Open the
+   [GSPro license conversion tool](https://gsprogolf.com/convert.html), enter
+   your GSPro license key, and select the **OpenAPI / OpenConnect** option. Then
+   install the latest GSPro and clear your GSPro Connect settings so the OpenAPI
+   interface is selected
+   ([how to clear Connect settings](https://gspro.gitbook.io/gspro-knowledge-base/troubleshooting-and-support/how-to-clear-gspro-connect-settings)).
+   Skip this if your license is already the OpenAPI type.
 
-2. **Configure OpenFlight.** Copy the example config if you haven't already:
+2. **Find the GSPro PC's IP address and open port 921.**
+   - Windows: `ipconfig` → IPv4 Address (e.g. `192.168.1.50`).
+   - Allow inbound **TCP 921** through the GSPro PC's firewall. The GSPro
+     installer can add this rule for you; if OpenFlight's connection is refused,
+     add it manually in Windows Defender Firewall (Inbound Rules → New Rule →
+     Port → TCP → 921 → Allow).
+
+3. **Configure OpenFlight.** Copy the example config if you haven't already:
    ```bash
    cp config/sim.example.json config/sim.json
    ```
@@ -47,13 +73,13 @@ requirements and setup specific to GSPro.
    scripts/start-kiosk.sh --kld7 --sim
    ```
 
-3. **Open GSPro and start a round**, then open the **GSPro Connect** window
+4. **Open GSPro and start a round**, then open the **GSPro Connect** window
    (the OpenAPI interface). It should report "Waiting for connection".
 
-4. **Start OpenFlight.** The header GSPro pill should turn **green**
+5. **Start OpenFlight.** The header GSPro pill should turn **green**
    (connected). GSPro Connect should show the device connected.
 
-5. **Hit a shot.** It appears in GSPro within a few milliseconds, and the
+6. **Hit a shot.** It appears in GSPro within a few milliseconds, and the
    "Sent to GSPro" panel in OpenFlight shows the values sent with
    measured/estimated badges.
 
@@ -77,9 +103,16 @@ follows GSPro. Putts (`PT`) are out of scope and ignored.
 
 ## Troubleshooting
 
-- **Pill stays amber (reconnecting):** OpenFlight can't reach `host:port`.
-  Check the IP, that GSPro Connect is open, and that no firewall blocks 921.
-  OpenFlight retries automatically with backoff (1→2→4→…→30s).
+- **Pill stays amber (connecting / reconnecting):** OpenFlight can't reach
+  `host:port`. Check the IP, that GSPro Connect is open, and that **inbound TCP
+  921 is allowed through the GSPro PC's firewall**. "Connecting" means it has
+  never connected yet (often a wrong IP or a blocked port); "reconnecting" means
+  it was connected and the link dropped. OpenFlight retries automatically with
+  backoff (1→2→4→…→30s).
+- **Can't select OpenAPI in GSPro Connect, or shots are rejected:** your license
+  is likely set to another monitor type. Convert it to OpenAPI
+  ([conversion tool](https://gsprogolf.com/convert.html)) and clear your Connect
+  settings, then restart GSPro.
 - **Pill red (error):** GSPro returned an error code; hover the pill for the
   message. The connection stays up.
 - **Shots don't appear in GSPro:** confirm a round is active and the Connect
@@ -89,3 +122,6 @@ follows GSPro. Putts (`PT`) are out of scope and ignored.
 ## References
 
 - [GSPro OpenConnect V1 spec](https://gsprogolf.com/GSProConnectV1.html)
+- [GSPro license conversion tool (convert to OpenAPI)](https://gsprogolf.com/convert.html)
+- [GSPro Knowledge Base: clear GSPro Connect settings](https://gspro.gitbook.io/gspro-knowledge-base/troubleshooting-and-support/how-to-clear-gspro-connect-settings)
+- [GSPro Knowledge Base](https://gspro.gitbook.io/gspro-knowledge-base)

--- a/docs/simulator/opengolfsim.md
+++ b/docs/simulator/opengolfsim.md
@@ -76,11 +76,20 @@ still stream fine — you just set the club manually in OpenFlight.
 
 ## Troubleshooting
 
-- **Pill stays amber (reconnecting):** OpenFlight can't reach `host:port`. Verify
-  the Developer API device is selected in OGS, the IP is correct, 3111 isn't
-  firewalled, and you launched with `--sim`.
+- **Pill stays amber (connecting / reconnecting):** OpenFlight can't reach
+  `host:port`. Verify the Developer API device is selected in OGS, the IP is
+  correct, 3111 isn't firewalled, and you launched with `--sim`. ("Connecting"
+  means it has never connected yet; "reconnecting" means an established
+  connection dropped.)
 - **Shots don't appear:** confirm OGS is on a hittable screen with the Developer
   API connected. Check `sim_send` entries in the session log.
+- **First shot after connecting sometimes doesn't register:** the first shot on a
+  fresh connection occasionally doesn't play in OGS while later shots do. This
+  appears to depend on OpenGolfSim's screen/round state (it must be on a hittable
+  screen), not on OpenFlight — OpenFlight sends the shot correctly (confirm the
+  `sim_send` entry in the session log; OGS replies, e.g. `Code 200 "Club Data
+  received"`). Workaround: make sure OGS is on a hittable screen before you start,
+  and/or hit a throwaway first shot.
 - **Club shows "DR" / doesn't follow OGS:** the club-sync patch isn't applied (or
   an OGS update reverted it) — re-run `scripts/setup/opengolfsim/apply.sh`.
 

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -32,6 +32,7 @@ from .sim import (
     ShotAck,
     SimError,
     build_connectors,
+    initial_shot_counter,
     load_sim_config,
     resolve_shot,
 )
@@ -91,11 +92,13 @@ ballistics_enabled: bool = False
 # CLI flags; shots fan out to every connected connector. Player/club state is
 # shared across all of them.
 sim_connectors: List = []
-# Seed the shot counter from the clock (epoch ms) so ShotNumber strictly
-# increases across server restarts. Some sims (e.g. OpenGolfSim's Developer API)
-# reject any ShotNumber <= the highest they've seen, and that counter persists
-# across reconnects — a per-run reset to 1 would get every shot dropped.
-sim_player_state = SimPlayerState(shot_counter=int(time.time() * 1000))
+# Seed the shot counter from the clock so ShotNumber strictly increases across
+# server restarts. Some sims (e.g. OpenGolfSim's Developer API) reject any
+# ShotNumber <= the highest they've seen, and that counter persists across
+# reconnects — a per-run reset to 1 would get every shot dropped. Uses epoch
+# *seconds* (see initial_shot_counter): epoch millis overflow GSPro's 32-bit
+# ShotNumber field and every shot comes back 501 "Bad format".
+sim_player_state = SimPlayerState(shot_counter=initial_shot_counter())
 
 _DEFAULT_KLD7_RADC_TUNING = {
     "radc_speed_tolerance_mph": 10.0,

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -1330,10 +1330,34 @@ def _get_trigger_status() -> dict:
     }
 
 
+def _emit_sim_snapshot() -> None:
+    """Emit the current status of every configured simulator connector.
+
+    The UI builds its connector buttons from ``sim_status`` events, which
+    otherwise only fire on connection-state *changes* (see _sim_on_status). A
+    client that connects or refreshes after a connector already reached its
+    state would miss those events and show no button — the intermittent
+    "sometimes the sim status shows, sometimes it doesn't". Replaying a snapshot
+    on connect guarantees a button for every enabled connector (sim_connectors
+    holds only the enabled ones) carrying its live state.
+    """
+    for connector in sim_connectors:
+        socketio.emit(
+            "sim_status",
+            {
+                "target": connector.name,
+                "state": connector.state.value,
+                "host": connector.host,
+                "port": connector.port,
+            },
+        )
+
+
 @socketio.on("connect")
 def handle_connect():
     """Handle client connection."""
     print("Client connected")
+    _emit_sim_snapshot()
     if monitor:
         stats = monitor.get_session_stats()
         shots = [shot_to_dict(s) for s in monitor.get_shots()]

--- a/src/openflight/sim/__init__.py
+++ b/src/openflight/sim/__init__.py
@@ -9,6 +9,7 @@ from .codec import SimConnector, build_connector, build_connectors
 from .config import ConnectorConfig, load_sim_config
 from .resolver import resolve_shot
 from .types import (
+    SHOT_NUMBER_MAX,
     ConnectionState,
     InboundEvent,
     IncompleteShotError,
@@ -18,6 +19,7 @@ from .types import (
     ShotAck,
     SimError,
     StatusEvent,
+    initial_shot_counter,
 )
 
 __all__ = [
@@ -28,12 +30,14 @@ __all__ = [
     "PlayerState",
     "PlayerUpdate",
     "ResolvedShot",
+    "SHOT_NUMBER_MAX",
     "ShotAck",
     "SimConnector",
     "SimError",
     "StatusEvent",
     "build_connector",
     "build_connectors",
+    "initial_shot_counter",
     "load_sim_config",
     "resolve_shot",
 ]

--- a/src/openflight/sim/transport.py
+++ b/src/openflight/sim/transport.py
@@ -265,10 +265,12 @@ class TcpSimClient:
 
     def _connection_loop(self) -> None:
         attempt = 0
+        ever_connected = False
         while not self._stop_event.is_set():
             self._set_state(ConnectionState.CONNECTING)
             if self._try_connect():
                 attempt = 0
+                ever_connected = True
                 self._set_state(ConnectionState.CONNECTED)
                 self._recv_loop()
                 self._close_socket()
@@ -276,8 +278,17 @@ class TcpSimClient:
                     break
                 # Connection dropped — fall through to reconnect
             wait = self._backoff_for_attempt(attempt)
+            # Until the first successful connection, report CONNECTING during the
+            # retry backoff; RECONNECT_BACKOFF ("reconnecting") is reserved for a
+            # connection that was once established and then lost, so we never
+            # imply a connection that never happened.
+            backoff_state = (
+                ConnectionState.RECONNECT_BACKOFF
+                if ever_connected
+                else ConnectionState.CONNECTING
+            )
             self._set_state(
-                ConnectionState.RECONNECT_BACKOFF,
+                backoff_state,
                 attempt=attempt + 1,
                 next_retry_in_s=wait,
             )

--- a/src/openflight/sim/types.py
+++ b/src/openflight/sim/types.py
@@ -6,11 +6,30 @@ specific protocol — that is what makes a third simulator a single new codec.
 """
 
 import threading
+import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Optional, Union
 
 from openflight.launch_monitor import ClubType
+
+# GSPro parses ShotNumber as a signed 32-bit int; a larger value overflows it and
+# the shot is rejected with 501 "Bad format". Keep every ShotNumber at or below
+# this. (OpenConnect spec: https://gsprogolf.com/GSProConnectV1.html)
+SHOT_NUMBER_MAX = 2_147_483_647
+
+
+def initial_shot_counter() -> int:
+    """Seed for the shared shot counter: epoch *seconds*.
+
+    Seeding from the clock keeps ShotNumber strictly increasing across server
+    restarts — some sims (e.g. OpenGolfSim's Developer API) reject any
+    ShotNumber <= the highest they have seen, so a per-run reset to 1 would get
+    every shot dropped. Seconds, not milliseconds: epoch millis (~1.78e12)
+    overflow GSPro's 32-bit ShotNumber and trigger 501 "Bad format"; epoch
+    seconds (~1.78e9) stay within range until 2038.
+    """
+    return int(time.time())
 
 
 class ConnectionState(Enum):

--- a/tests/test_sim_connector.py
+++ b/tests/test_sim_connector.py
@@ -1,5 +1,6 @@
 """Tests for sim.codec — SimConnector wiring and the codec registry."""
 import json
+import socket
 import time
 
 import pytest
@@ -72,6 +73,62 @@ def test_connector_send_shot_serializes(mock_sim):
             time.sleep(0.05)
         assert mock_sim.received
         assert json.loads(mock_sim.received[0])["ShotNumber"] == 3
+    finally:
+        c.stop()
+
+
+def test_first_connect_failure_stays_connecting_not_reconnecting():
+    # Point at a closed port so every connect attempt fails. Until the client has
+    # connected at least once, retries must report CONNECTING — reporting
+    # RECONNECT_BACKOFF ("reconnecting") would falsely imply a prior connection
+    # was established and then lost.
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    closed_port = probe.getsockname()[1]
+    probe.close()
+
+    states = []
+    c = SimConnector(GSProCodec(), "127.0.0.1", closed_port,
+                     on_status=lambda name, evt: states.append(evt.state),
+                     backoff_seconds=(0.05,))
+    c.start()
+    try:
+        # Wait for at least two connect attempts (so we've gone through the
+        # post-failure backoff state, not just the very first CONNECTING).
+        deadline = time.time() + 1.5
+        while time.time() < deadline and states.count(ConnectionState.CONNECTING) < 2:
+            time.sleep(0.02)
+        assert ConnectionState.CONNECTING in states
+        assert ConnectionState.RECONNECT_BACKOFF not in states
+    finally:
+        c.stop()
+
+
+def test_reconnect_after_drop_reports_reconnecting(mock_sim):
+    # Once a real connection has been established and then dropped, retries must
+    # report RECONNECT_BACKOFF ("reconnecting").
+    states = []
+    c = SimConnector(GSProCodec(), mock_sim.host, mock_sim.port,
+                     on_status=lambda name, evt: states.append(evt.state),
+                     backoff_seconds=(0.05,))
+    c.start()
+    try:
+        assert _wait(c, ConnectionState.CONNECTED)
+        # Our side can reach CONNECTED before the server's accept() sets its
+        # client socket. Send a shot and wait for the server to receive it so we
+        # know there's a live client socket to drop (otherwise disconnect_client
+        # no-ops and the test flakes under load).
+        c.send_shot(_resolved())
+        recv_deadline = time.time() + 2.0
+        while time.time() < recv_deadline and not mock_sim.received:
+            time.sleep(0.02)
+        assert mock_sim.received
+        states.clear()
+        mock_sim.disconnect_client()
+        deadline = time.time() + 3.0
+        while time.time() < deadline and ConnectionState.RECONNECT_BACKOFF not in states:
+            time.sleep(0.02)
+        assert ConnectionState.RECONNECT_BACKOFF in states
     finally:
         c.stop()
 

--- a/tests/test_sim_server_wiring.py
+++ b/tests/test_sim_server_wiring.py
@@ -8,7 +8,7 @@ from datetime import datetime
 import pytest
 
 from openflight.launch_monitor import ClubType, Shot
-from openflight.sim.types import PlayerUpdate, ShotAck, SimError
+from openflight.sim.types import ConnectionState, PlayerUpdate, ShotAck, SimError
 
 
 @pytest.fixture
@@ -36,6 +36,9 @@ class _FakeConnector:
         self.codec = type("C", (), {"fields_for_target": lambda self: ["ball_speed", "vla"]})()
         self._connected = connected
         self.sent = []
+        self.host = "127.0.0.1"
+        self.port = 921
+        self.state = ConnectionState.CONNECTED if connected else ConnectionState.RECONNECT_BACKOFF
 
     def is_connected(self):
         return self._connected
@@ -148,6 +151,35 @@ def test_status_connected_logged_always(server, caplog):
                         host="127.0.0.1", port=921),
         )
     assert "gspro connected" in caplog.text
+
+
+def test_emit_sim_snapshot_sends_status_for_every_connector(server):
+    # The UI builds connector buttons from sim_status events, which otherwise
+    # only fire on state *changes*. A client that connects after a connector
+    # already settled would miss the event and show no button — so the server
+    # replays a snapshot on connect. Every enabled connector must get a
+    # sim_status carrying its current state, regardless of what that state is.
+    a = _FakeConnector("gspro", connected=True)
+    b = _FakeConnector("opengolfsim", connected=False)
+    b.state = ConnectionState.RECONNECT_BACKOFF
+    server.sim_connectors = [a, b]
+
+    server._emit_sim_snapshot()
+
+    by_target = {
+        a_[1]["target"]: a_[1] for a_, _k in server._emitted if a_[0] == "sim_status"
+    }
+    assert set(by_target) == {"gspro", "opengolfsim"}
+    assert by_target["gspro"]["state"] == "connected"
+    assert by_target["opengolfsim"]["state"] == "reconnecting"
+    assert by_target["gspro"]["port"] == 921
+
+
+def test_emit_sim_snapshot_noop_without_connectors(server):
+    # No connectors configured (no --sim / none enabled) → no sim_status emitted.
+    server.sim_connectors = []
+    server._emit_sim_snapshot()
+    assert not any(a_[0] == "sim_status" for a_, _k in server._emitted)
 
 
 def test_forward_swallows_send_failure(server):

--- a/tests/test_sim_transport.py
+++ b/tests/test_sim_transport.py
@@ -235,6 +235,14 @@ def test_reconnect_after_server_drop(mock_sim):
     client.start()
     try:
         assert _wait_for_state(client, ConnectionState.CONNECTED)
+        # CONNECTED on our side can precede the server's accept(); send a shot and
+        # wait for the server to receive it so there's a live client socket to
+        # drop (otherwise disconnect_client() no-ops and the test flakes).
+        client.send_raw(client._codec.build_shot(_resolved()))
+        recv_deadline = time.time() + 2.0
+        while time.time() < recv_deadline and not mock_sim.received:
+            time.sleep(0.02)
+        assert mock_sim.received
         mock_sim.disconnect_client()
         assert _wait_for_state(client, ConnectionState.RECONNECT_BACKOFF, 2.0)
         assert _wait_for_state(client, ConnectionState.CONNECTED, 3.0)
@@ -250,8 +258,12 @@ def test_backoff_progression_capped():
     client.start()
     time.sleep(0.5)
     client.stop()
+    # Before the first successful connection the client reports CONNECTING during
+    # the retry backoff (RECONNECT_BACKOFF is reserved for a connection that was
+    # established and then dropped). The backoff schedule is still carried on
+    # next_retry_in_s, so assert on the CONNECTING retries here.
     backoffs = [s.next_retry_in_s for s in statuses
-                if s.state == ConnectionState.RECONNECT_BACKOFF]
+                if s.state == ConnectionState.CONNECTING and s.next_retry_in_s > 0]
     assert len(backoffs) >= 2
     assert max(backoffs) <= 0.1
 

--- a/tests/test_sim_types.py
+++ b/tests/test_sim_types.py
@@ -1,8 +1,30 @@
 """Tests for sim.types — ConnectionState, PlayerState, inbound events."""
+import time
+
 from openflight.launch_monitor import ClubType
 from openflight.sim.types import (
     ConnectionState, PlayerState, PlayerUpdate,
+    SHOT_NUMBER_MAX, initial_shot_counter,
 )
+
+
+def test_initial_shot_counter_within_gspro_int32():
+    # GSPro parses ShotNumber as a signed 32-bit int; the seed must fit, or the
+    # shot is rejected 501 "Bad format". Epoch seconds fit; epoch millis do not.
+    n = initial_shot_counter()
+    assert 0 < n <= SHOT_NUMBER_MAX
+
+
+def test_epoch_millis_seed_would_overflow_int32():
+    # Regression: the old seed (epoch *milliseconds*) overflows GSPro's 32-bit
+    # ShotNumber field (~1.78e12 > 2.15e9) and every shot came back "Bad format".
+    assert int(time.time() * 1000) > SHOT_NUMBER_MAX
+
+
+def test_shot_numbers_stay_int32_over_a_long_session():
+    p = PlayerState(shot_counter=initial_shot_counter())
+    for _ in range(10_000):
+        assert p.next_shot_number() <= SHOT_NUMBER_MAX
 
 
 def test_connection_state_values():


### PR DESCRIPTION
## What does this PR do?

Three independent simulator-connector fixes that surfaced bringing up GSPro (and OpenGolfSim) over OpenConnect, plus docs. The connectors share one codec/transport, so the fixes apply to both:

- **ShotNumber fits GSPro's int32** — seed the shot counter from epoch **seconds** instead of milliseconds. GSPro's `ShotNumber` is a signed 32-bit int; the epoch-millis seed overflowed it and GSPro rejected **every** shot with `501 "Bad format"`. Epoch-seconds stays well under 2³¹ while still strictly increasing across restarts (some sims reject a `ShotNumber` ≤ the highest they've seen).
- **Status pills always render with `--sim`** — the UI builds its connector pills from `sim_status` events, which only fire on state *changes*. A browser that connected/refreshed after a connector had already settled missed those events and showed no pill (the intermittent "sometimes it shows, sometimes it doesn't"). The server now replays a status snapshot of every enabled connector on UI connect.
- **"Connecting" before the first connect, "Reconnecting" only after a drop** — a failed first connect fell straight through to `RECONNECT_BACKOFF`, so on launch the pill read "Reconnecting" before any connection had ever been made. The client now reports `CONNECTING` during retries until the first success, reserving `RECONNECT_BACKOFF` for a connection that was established and then lost.
- **Docs** — GSPro: document the one-time license conversion to the **OpenAPI/OpenConnect** type (and the required Connect-settings clear), and opening inbound **TCP 921** on the GSPro PC's firewall, with a no-auth security note. OpenGolfSim: a soft note that the first shot after connecting may not register depending on OGS's screen/round state (OGS-side, with a workaround).

## Why was this required?

With a real GSPro instance, no shots registered at all — every one came back `501 "Bad format"` purely because of the `ShotNumber` overflow. Once shots flowed, the connector status pill was unreliable (race on UI connect) and misleading on first launch ("Reconnecting" implying a prior connection). These are the minimum fixes to make the OpenConnect connectors usable and the status UI trustworthy.

## Automated tests

Full suite: **858 passed, 6 skipped**, pylint **9.70/10**, ruff clean.

- `tests/test_sim_types.py` — `initial_shot_counter()` is epoch-seconds, monotonic, within int32.
- `tests/test_sim_server_wiring.py` — connect snapshot emits a `sim_status` per enabled connector; no-ops with none configured.
- `tests/test_sim_connector.py` — first-connect failures report `CONNECTING` (never `RECONNECT_BACKOFF`); a real connect-then-drop reports `RECONNECT_BACKOFF`.
- `tests/test_sim_transport.py` — updated `test_backoff_progression_capped` for the connecting-before-first-connect semantics; hardened a pre-existing flaky drop-reconnect test (wait for the server to receive before dropping).

## Manual (human) testing

- **GSPro (live, OpenConnect on 921 under CrossOver):** shots accepted with `Code 200` and appear in GSPro; previously every shot returned `501 "Bad format"`. Status pill reliably appears on every UI load/refresh; first launch shows **Connecting**, flipping to **Reconnecting** only after an established connection drops.
- **OpenGolfSim (Developer API on 3111):** verified sends with a headless harness (3 mock shots → `sim_send` ×3) and that OGS responds (`Code 200 "Club Data received"`); confirmed the status-pill/connecting behavior. Noted the OGS-side first-shot quirk in the docs.

## Checklist

- [x] Single feature/fix — scoped to simulator-connector connectivity + status UX
- [x] Automated tests included
- [x] Manual testing described
- [x] Python tests pass (`uv run pytest tests/`) — 858 passed, 6 skipped
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`) — 9.70/10
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [ ] UI builds — n/a, no `ui/src` changes (server-side fixes; existing UI already renders the pills)
- [ ] UI lint — n/a
- [ ] CHANGELOG entry — n/a (no `CHANGELOG.md` on `main` yet)
- [x] No unrelated changes — the fixes plus the transport-test alignment they require and the connector docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
