### PR TITLE
feat: Swing speed training

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ scripts/start-kiosk.sh --iwr6843 \
 # With K-LD7 launch-angle geometry defaults (deprecated hardware)
 scripts/start-kiosk.sh --kld7-geometry
 
+# Swing speed training (air swings / speed sticks, no sound trigger)
+scripts/start-kiosk.sh --swing-speed
+
 # Development mode (no hardware)
 scripts/start-kiosk.sh --mock
 ```
@@ -152,6 +155,15 @@ OpenFlight also serves a fullscreen-friendly browser display for tablets, TV bro
 > and most Linux desktops do, but some smart-TV browsers don't, so use the IP there.
 
 This is browser/tab casting only. OpenFlight does not include native Cast SDK support yet.
+
+### Swing Speed Training
+
+For air swings and speed-stick training, OpenFlight can use the OPS243-A fast
+speed stream directly instead of waiting for impact audio. Start it with
+`scripts/start-kiosk.sh --swing-speed`; the server emits `swing_speed` events
+with peak club speed, rep duration, reading count, and session stats. See the
+**[Swing Speed Training Guide](docs/swing-speed-training.md)** for setup and
+tuning options.
 
 ## How It Works
 

--- a/docs/swing-speed-training.md
+++ b/docs/swing-speed-training.md
@@ -1,0 +1,115 @@
+# Swing Speed Training
+
+OpenFlight can run a club-only swing speed training mode for air swings, speed
+sticks, and overspeed training. This mode uses the OPS243-A fast speed stream
+and does not require a ball strike or SparkFun sound trigger.
+
+```bash
+scripts/start-kiosk.sh --swing-speed
+```
+
+Optional tuning:
+
+```bash
+scripts/start-kiosk.sh --swing-speed \
+  --swing-speed-threshold 35 \
+  --swing-speed-min-readings 3 \
+  --swing-speed-single-peak 60 \
+  --swing-speed-num-reports 8 \
+  --swing-speed-end-ms 1000 \
+  --swing-speed-cooldown-ms 900 \
+  --swing-speed-rejected-cooldown-ms 100
+```
+
+## How It Works
+
+The OPS243-A is configured for fast outbound speed reporting. A swing rep starts
+when outbound speed crosses the threshold, keeps collecting qualifying readings
+while the club or training stick is moving through the hitting zone, then emits
+the peak speed after a short quiet period. A rep must include multiple
+qualifying readings so a single hand-motion or noise spike does not count as a
+swing. Very fast peaks can still count from a single reading, which helps with
+short indoor swings where the club is only in the radar beam for a moment.
+
+The threshold is also applied to the OPS243 speed filter so the radar does not
+stream low-speed background movement while waiting for a swing.
+Swing speed mode requests multiple OPS speed reports and uses the fastest
+outbound candidate, since the strongest radar return can be a slower part of the
+club or body rather than the club head.
+The default `--swing-speed-num-reports 8` keeps weaker but faster club-head
+candidates in the stream.
+
+The server emits a `swing_speed` WebSocket event:
+
+```json
+{
+  "event": {
+    "peak_speed_mph": 101.4,
+    "timestamp": "2024-01-15T10:30:00",
+    "duration_ms": 348,
+    "reading_count": 9,
+    "trigger_speed_mph": 32.2,
+    "peak_magnitude": 42,
+    "unit": "mph",
+    "mode": "swing-speed"
+  },
+  "stats": {
+    "swing_count": 3,
+    "best_speed_mph": 105.2,
+    "avg_speed_mph": 101.8,
+    "last_speed_mph": 101.4
+  }
+}
+```
+
+## Radar Placement
+
+Place the OPS243-A behind the swing area and point it down the target line, the
+same general position used for launch monitor mode. The radar measures radial
+speed, so the downswing and follow-through should move mostly away from the
+radar.
+
+Some speed sticks may have a weaker radar return than a metal club head. If
+readings are inconsistent, test with a real club first to confirm setup, then
+consider a small, secure radar-reflective marker on the training device.
+
+If hand motion or room noise creates false reps, raise the threshold or require
+more readings:
+
+```bash
+scripts/start-kiosk.sh --swing-speed \
+  --swing-speed-threshold 45 \
+  --swing-speed-min-readings 4 \
+  --swing-speed-single-peak 70 \
+  --swing-speed-end-ms 1000
+```
+
+## Radar Mode
+
+Training runs the OPS243-A in CW speed-reporting mode, not rolling buffer.
+`OPS243Radar.configure_for_swing_speed_training()` owns that setup and sends
+`GS` — per [AN-010-AD](radar/AN-010-AD_API_Interface.pdf) (API Commands, p21)
+`GS` selects "CW operation only" and is the documented way out of rolling-buffer
+mode. `restore_rolling_buffer_mode()` hands the radar back with `GC`.
+
+Two things to know before changing this path:
+
+- **`GC`, not `G1`.** AN-010-AD records that rolling-buffer mode "previously was
+  G1". The older [AN-027](<radar/AN-027-A_Rolling Buffer.pdf>) app note still
+  documents the pre-rename `G1`/`G0` pair, so treat AN-010-AD as authoritative.
+  `tests/test_ops243_mode_commands.py` pins the byte sequences.
+- **Training never writes flash.** No `A!` on this path. The HOST_INT trigger
+  workaround requires the board to *boot* into rolling-buffer mode from
+  persistent memory, so persisting speed mode would break launch mode until
+  `test_rolling_buffer_persist.py --setup` was re-run.
+
+The setup is kept separate from `configure_for_speed_trigger()`, which tunes the
+radar to detect a swing and hand off to the rolling buffer for the launch
+monitor. Retuning that path must not silently change training measurements; the
+two configurations are expected to diverge.
+
+## Notes
+
+Swing speed mode is separate from launch monitor shots. It reports club-only
+training reps and does not calculate ball speed, smash factor, spin, launch
+angle, or carry.

--- a/scripts/hardware-test/debug_rolling_buffer.py
+++ b/scripts/hardware-test/debug_rolling_buffer.py
@@ -272,7 +272,7 @@ def main():
             print("  FAIL: No I/Q data received")
             print()
             print("  Troubleshooting:")
-            print("    1. Check firmware version supports GC mode (1.2.3+)")
+            print("    1. Check firmware version supports GC rolling buffer mode (1.2.3+)")
             print("    2. Try power cycling the radar")
             print("    3. Check if HOST_INT pin is floating/grounded")
 

--- a/scripts/start-kiosk.sh
+++ b/scripts/start-kiosk.sh
@@ -13,6 +13,7 @@ HOST="localhost"
 RADAR_PORT=""
 OPS_BAUD=""
 MOCK_MODE=false
+MOCK_SWING_SPEED=false
 RADAR_LOG=false
 DEBUG_MODE=false
 NO_CAMERA=true  # Camera disabled by default (K-LD7 radar handles angle)
@@ -61,6 +62,14 @@ EXPERIMENTAL_KLD7_HORIZONTAL_ANGLE_LIMIT=""
 BALLISTICS=false
 SIM=false
 CALCULATED_SPIN=false
+SWING_SPEED=false
+SWING_SPEED_THRESHOLD=""
+SWING_SPEED_MIN_READINGS=""
+SWING_SPEED_SINGLE_PEAK=""
+SWING_SPEED_NUM_REPORTS=""
+SWING_SPEED_END_MS=""
+SWING_SPEED_COOLDOWN_MS=""
+SWING_SPEED_REJECTED_COOLDOWN_MS=""
 
 # Buffer split presets (pre/post trigger segments out of 32 total)
 # At 20ksps: each segment = 6.4ms, total buffer = 204.8ms
@@ -83,6 +92,11 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --mock|-m)
             MOCK_MODE=true
+            shift
+            ;;
+        --mock-swing-speed)
+            MOCK_SWING_SPEED=true
+            SWING_SPEED=true
             shift
             ;;
         --radar-log)
@@ -285,6 +299,42 @@ while [[ $# -gt 0 ]]; do
             CALCULATED_SPIN=true
             shift
             ;;
+        --swing-speed)
+            SWING_SPEED=true
+            shift
+            ;;
+        --swing-speed-threshold)
+            SWING_SPEED_THRESHOLD="$2"
+            shift 2
+            ;;
+        --swing-speed-max)
+            SWING_SPEED_MAX="$2"
+            shift 2
+            ;;
+        --swing-speed-min-readings)
+            SWING_SPEED_MIN_READINGS="$2"
+            shift 2
+            ;;
+        --swing-speed-single-peak)
+            SWING_SPEED_SINGLE_PEAK="$2"
+            shift 2
+            ;;
+        --swing-speed-num-reports)
+            SWING_SPEED_NUM_REPORTS="$2"
+            shift 2
+            ;;
+        --swing-speed-end-ms)
+            SWING_SPEED_END_MS="$2"
+            shift 2
+            ;;
+        --swing-speed-cooldown-ms)
+            SWING_SPEED_COOLDOWN_MS="$2"
+            shift 2
+            ;;
+        --swing-speed-rejected-cooldown-ms)
+            SWING_SPEED_REJECTED_COOLDOWN_MS="$2"
+            shift 2
+            ;;
         --radar-port|--ops-port)
             RADAR_PORT="$2"
             shift 2
@@ -401,6 +451,10 @@ cd "$PROJECT_DIR"
 # Build server command
 SERVER_CMD="openflight-server --web-port $PORT"
 
+if [ "$MOCK_MODE" = true ] && [ "$SWING_SPEED" = true ]; then
+    MOCK_SWING_SPEED=true
+fi
+
 if [ -n "$RADAR_PORT" ]; then
     SERVER_CMD="$SERVER_CMD --port $RADAR_PORT"
 fi
@@ -409,7 +463,9 @@ if [ -n "$OPS_BAUD" ]; then
     SERVER_CMD="$SERVER_CMD --ops-baud $OPS_BAUD"
 fi
 
-if [ "$MOCK_MODE" = true ]; then
+if [ "$MOCK_SWING_SPEED" = true ]; then
+    SERVER_CMD="$SERVER_CMD --mock-swing-speed"
+elif [ "$MOCK_MODE" = true ]; then
     SERVER_CMD="$SERVER_CMD --mock"
 fi
 
@@ -438,11 +494,47 @@ if [ "$CALCULATED_SPIN" = true ]; then
     SERVER_CMD="$SERVER_CMD --calculated-spin"
 fi
 
-if [ -n "$TRIGGER" ]; then
+if [ "$SWING_SPEED" = true ] && [ "$MOCK_SWING_SPEED" != true ]; then
+    SERVER_CMD="$SERVER_CMD --swing-speed"
+fi
+
+if [ -n "$SWING_SPEED_THRESHOLD" ]; then
+    SERVER_CMD="$SERVER_CMD --swing-speed-threshold $SWING_SPEED_THRESHOLD"
+fi
+
+if [ -n "$SWING_SPEED_MAX" ]; then
+    SERVER_CMD="$SERVER_CMD --swing-speed-max $SWING_SPEED_MAX"
+fi
+
+if [ -n "$SWING_SPEED_MIN_READINGS" ]; then
+    SERVER_CMD="$SERVER_CMD --swing-speed-min-readings $SWING_SPEED_MIN_READINGS"
+fi
+
+if [ -n "$SWING_SPEED_SINGLE_PEAK" ]; then
+    SERVER_CMD="$SERVER_CMD --swing-speed-single-peak $SWING_SPEED_SINGLE_PEAK"
+fi
+
+if [ -n "$SWING_SPEED_NUM_REPORTS" ]; then
+    SERVER_CMD="$SERVER_CMD --swing-speed-num-reports $SWING_SPEED_NUM_REPORTS"
+fi
+
+if [ -n "$SWING_SPEED_END_MS" ]; then
+    SERVER_CMD="$SERVER_CMD --swing-speed-end-ms $SWING_SPEED_END_MS"
+fi
+
+if [ -n "$SWING_SPEED_COOLDOWN_MS" ]; then
+    SERVER_CMD="$SERVER_CMD --swing-speed-cooldown-ms $SWING_SPEED_COOLDOWN_MS"
+fi
+
+if [ -n "$SWING_SPEED_REJECTED_COOLDOWN_MS" ]; then
+    SERVER_CMD="$SERVER_CMD --swing-speed-rejected-cooldown-ms $SWING_SPEED_REJECTED_COOLDOWN_MS"
+fi
+
+if [ -n "$TRIGGER" ] && [ "$SWING_SPEED" != true ]; then
     SERVER_CMD="$SERVER_CMD --trigger $TRIGGER"
 fi
 
-if [ -n "$SOUND_PRE_TRIGGER" ]; then
+if [ -n "$SOUND_PRE_TRIGGER" ] && [ "$SWING_SPEED" != true ]; then
     SERVER_CMD="$SERVER_CMD --sound-pre-trigger $SOUND_PRE_TRIGGER"
 fi
 

--- a/src/openflight/launch_monitor.py
+++ b/src/openflight/launch_monitor.py
@@ -286,6 +286,7 @@ class Shot:
     spin_rejection_reason: Optional[str] = None
     carry_spin_adjusted: Optional[float] = None
     mode: str = "rolling-buffer"
+    player_name: str = "Player 1"
     readings_data: Optional[list] = None
     angle_source: Optional[str] = None  # "radar", "camera", "estimated", or None
     club_angle_deg: Optional[float] = None  # Club angle of attack from K-LD7 (vertical)

--- a/src/openflight/ops243.py
+++ b/src/openflight/ops243.py
@@ -220,6 +220,7 @@ class OPS243Radar:
         self._unit = "mph"
         self._json_mode = False
         self._magnitude_enabled = False
+        self._speed_read_buffer = ""
         self.last_hardware_trigger_first_byte_timestamp: Optional[float] = None
         # Most recent OPS-clock -> host-epoch sync (see read_clock_sync).
         self.last_clock_sync: Optional[dict] = None
@@ -1121,6 +1122,56 @@ class OPS243Radar:
             logger.warning("[OPS] Failed to parse reading: %r - %s", line, e)
             return None
 
+    def _parse_readings(self, line: str) -> List[SpeedReading]:
+        """Parse all readings from a radar output line.
+
+        JSON multi-object mode reports arrays ordered by magnitude. For normal
+        launch-monitor trigger detection, _parse_reading() keeps returning the
+        strongest target for backwards compatibility. Swing-speed training needs
+        every candidate so it can choose the fastest club-head-like reflection.
+        """
+        if _show_raw_readings:
+            print(f"[SERIAL] {line!r}")
+
+        try:
+            if self._json_mode and line.startswith("{"):
+                data = json.loads(line)
+                speed_data = data.get("speed", 0)
+                magnitude_data = data.get("magnitude")
+
+                if not isinstance(speed_data, list):
+                    reading = self._parse_reading(line)
+                    return [reading] if reading else []
+
+                readings = []
+                for index, raw_speed in enumerate(speed_data):
+                    speed = float(raw_speed)
+                    if speed > 0:
+                        direction = Direction.INBOUND
+                    else:
+                        direction = Direction.OUTBOUND
+
+                    magnitude = None
+                    if isinstance(magnitude_data, list) and index < len(magnitude_data):
+                        magnitude = float(magnitude_data[index])
+
+                    readings.append(
+                        SpeedReading(
+                            speed=abs(speed),
+                            direction=direction,
+                            magnitude=magnitude,
+                            timestamp=time.time(),
+                            unit=self._unit,
+                        )
+                    )
+                return readings
+
+            reading = self._parse_reading(line)
+            return [reading] if reading else []
+        except (ValueError, json.JSONDecodeError) as e:
+            logger.warning("[OPS] Failed to parse readings: %r - %s", line, e)
+            return []
+
     def save_config(self):
         """Save current configuration to persistent memory."""
         self._send_command("A!")
@@ -1270,6 +1321,60 @@ class OPS243Radar:
         )
         print("[RADAR] Settings saved to persistent memory.")
         print("[RADAR] Power cycle the board (unplug USB, wait 3s, replug).")
+
+    def restore_rolling_buffer_mode(
+        self, pre_trigger_segments: int = 16, sample_rate_ksps: int = 30
+    ):
+        """
+        Restore rolling-buffer mode after a temporary speed-mode session.
+
+        Swing-speed training uses CW speed reporting and sends GS as part of
+        that setup. Before returning the radar to launch-monitor use, put it
+        back into rolling-buffer mode using volatile commands only. Saving with
+        A! is intentionally reserved for the one-time setup path because it
+        writes persistent flash and is not needed for normal mode switching.
+        """
+        if not self.serial or not self.serial.is_open:
+            raise ConnectionError("Not connected to radar")
+
+        logger.info("[OPS] Restoring rolling buffer mode after speed mode...")
+        self.set_units(SpeedUnit.MPH)
+        logger.info("[OPS] Units: MPH")
+        self.set_transmit_power(3)
+        logger.info("[OPS] Transmit power: level 3 (reduced to avoid clipping)")
+        self.enter_rolling_buffer_mode(
+            pre_trigger_segments=pre_trigger_segments,
+            sample_rate_ksps=sample_rate_ksps,
+        )
+        self.serial.reset_input_buffer()
+        logger.info("[OPS] Rolling buffer mode restored for launch-monitor use")
+
+    def prepare_persisted_rolling_buffer(
+        self, pre_trigger_segments: int = 16, sample_rate_ksps: int = 30
+    ):
+        """
+        Prepare a radar that already booted in persisted rolling-buffer mode.
+
+        Do not send GC/A! here. The OPS243-A HOST_INT workaround requires the
+        board to boot in rolling-buffer mode from flash. If swing-speed mode
+        has put the radar into speed-reporting mode, save rolling-buffer mode
+        separately and physically power-cycle the radar before launch mode.
+        """
+        if not self.serial or not self.serial.is_open:
+            raise ConnectionError("Not connected to radar")
+
+        self.set_units(SpeedUnit.MPH)
+        logger.info("[OPS] Units: MPH")
+        self.set_transmit_power(3)
+        logger.info("[OPS] Transmit power: level 3 (reduced to avoid clipping)")
+        self.set_sample_rate(sample_rate_ksps * 1000)
+        logger.info("[OPS] Sample rate: %dksps", sample_rate_ksps)
+        self.rearm_rolling_buffer(pre_trigger_segments=pre_trigger_segments)
+        logger.info(
+            "[OPS] Persisted rolling buffer prepared (S#%d, %dksps)",
+            pre_trigger_segments,
+            sample_rate_ksps,
+        )
 
     def trigger_capture(self, timeout: Optional[float] = None) -> str:
         """
@@ -1578,6 +1683,94 @@ class OPS243Radar:
 
         logger.info("[OPS] Rolling buffer mode configured")
 
+    def configure_for_swing_speed_training(self, min_speed_mph: float = 20, num_reports: int = 1):
+        """
+        Configure the radar for standalone swing-speed training.
+
+        Training streams raw CW speed reports and never captures a rolling
+        buffer. Per AN-010-AD (API Commands, p21) GS selects "CW operation
+        only" -- the documented way out of rolling-buffer mode and the
+        OPS243-A default -- so this path sends GS and never GC/S#n/S!.
+
+        Nothing here writes flash (no A!). The HOST_INT workaround needs the
+        board to *boot* into rolling-buffer mode from persistent memory, so a
+        stray A! in this path would clobber launch mode until the setup script
+        was re-run. Use restore_rolling_buffer_mode() to hand the radar back.
+
+        Deliberately kept separate from configure_for_speed_trigger(): that
+        path tunes the radar to *detect* a swing and immediately hand off to
+        the rolling buffer, so retuning it for the launch monitor must not
+        silently change training measurements. The two configurations are
+        expected to diverge.
+
+        Args:
+            min_speed_mph: Ignore reports below this speed, filtering leg
+                movement and backswing (R>n).
+            num_reports: Speed reports per sample cycle (On). >1 surfaces
+                several candidate reflections so the caller can pick the
+                club head.
+        """
+        if not self.serial or not self.serial.is_open:
+            raise ConnectionError("Not connected to radar")
+
+        logger.info("[OPS] Configuring for swing speed training (CW speed reporting)...")
+
+        # CW mode, then idle while we reconfigure.
+        self._send_command("GS")
+        time.sleep(0.1)
+        logger.info("[OPS] GS: CW mode (standard radar signal processing)")
+
+        self._send_command("PI")
+        time.sleep(0.1)
+
+        self.set_units(SpeedUnit.MPH)
+        logger.info("[OPS] Units: MPH")
+
+        # Max transmit power: the club head is a smaller, less reflective
+        # target than a ball, and there is no rolling-buffer capture to clip.
+        self.set_transmit_power(0)
+        logger.info("[OPS] Transmit power: max (P0)")
+
+        # 30ksps -> 208mph ceiling, above any club head speed (AN-027 Table 1).
+        self.set_sample_rate(30000)
+        time.sleep(0.1)
+        logger.info("[OPS] Sample rate: 30ksps")
+
+        self.set_buffer_size(128)
+        time.sleep(0.1)
+        logger.info("[OPS] Buffer size: 128")
+
+        # X=2 (256-point FFT) trades speed resolution for report rate, keeping
+        # enough reports across the ~100ms of a swing to find its peak.
+        self.set_fft_size(2)
+        time.sleep(0.1)
+        logger.info("[OPS] FFT size: 256 (X=2)")
+
+        # Outbound only: the downswing moves away from a radar placed behind
+        # the player, so R- drops the backswing.
+        self._send_command("R-")
+        time.sleep(0.05)
+        logger.info("[OPS] Direction filter: outbound only (R-)")
+
+        self.set_min_speed_filter(min_speed_mph)
+        time.sleep(0.05)
+        logger.info("[OPS] Min speed filter: %s mph", min_speed_mph)
+
+        self.set_num_reports(num_reports)
+        time.sleep(0.05)
+        logger.info("[OPS] Reports per cycle: %d", num_reports)
+
+        self.enable_json_output(True)
+        self.enable_magnitude_report(True)
+
+        # No inter-report delay.
+        self._send_command("W0")
+        time.sleep(0.05)
+
+        self._send_command("PA")
+        time.sleep(0.1)
+        logger.info("[OPS] Swing speed training mode ready (PA)")
+
     def configure_for_speed_trigger(self):
         """
         Configure radar for fast speed detection to trigger rolling buffer capture.
@@ -1696,25 +1889,56 @@ class OPS243Radar:
             return None
 
         try:
-            # Read available data
+            # Read available data and preserve partial JSON lines for the next poll.
             raw_bytes = self.serial.read(self.serial.in_waiting)
-            line = raw_bytes.decode("ascii", errors="ignore").strip()
+            self._speed_read_buffer += raw_bytes.decode("ascii", errors="ignore")
 
-            if not line:
+            if "\n" not in self._speed_read_buffer and "\r" not in self._speed_read_buffer:
                 return None
 
-            # May have multiple lines - take the last complete one
-            lines = line.split("\n")
+            lines = self._speed_read_buffer.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+            self._speed_read_buffer = lines.pop()
+
+            # May have multiple complete lines - take the last valid one.
             for candidate in reversed(lines):
                 candidate = candidate.strip()
-                if candidate.startswith("{"):
-                    reading = self._parse_reading(candidate)
-                    if reading:
-                        return reading
+                if not candidate:
+                    continue
+                reading = self._parse_reading(candidate)
+                if reading:
+                    return reading
 
             return None
         except Exception:
             return None
+
+    def read_speed_candidates_nonblocking(self) -> List[SpeedReading]:
+        """Non-blocking speed read returning every candidate from complete lines."""
+        if not self.serial or not self.serial.is_open:
+            return []
+
+        if self.serial.in_waiting == 0:
+            return []
+
+        try:
+            raw_bytes = self.serial.read(self.serial.in_waiting)
+            self._speed_read_buffer += raw_bytes.decode("ascii", errors="ignore")
+
+            if "\n" not in self._speed_read_buffer and "\r" not in self._speed_read_buffer:
+                return []
+
+            lines = self._speed_read_buffer.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+            self._speed_read_buffer = lines.pop()
+
+            readings: List[SpeedReading] = []
+            for candidate in lines:
+                candidate = candidate.strip()
+                if candidate:
+                    readings.extend(self._parse_readings(candidate))
+
+            return readings
+        except Exception:
+            return []
 
     def __enter__(self):
         """Context manager entry."""

--- a/src/openflight/rolling_buffer/monitor.py
+++ b/src/openflight/rolling_buffer/monitor.py
@@ -289,10 +289,16 @@ class RollingBufferMonitor:
         if self.trigger_type != "speed":
             # Get pre_trigger_segments from the trigger if available
             pre_trigger_segments = getattr(self.trigger, "pre_trigger_segments", 12)
-            self.radar.configure_for_rolling_buffer(
-                pre_trigger_segments=pre_trigger_segments,
-                sample_rate_ksps=self.sample_rate_ksps,
-            )
+            if self.trigger_type == "sound":
+                self.radar.prepare_persisted_rolling_buffer(
+                    pre_trigger_segments=pre_trigger_segments,
+                    sample_rate_ksps=self.sample_rate_ksps,
+                )
+            else:
+                self.radar.configure_for_rolling_buffer(
+                    pre_trigger_segments=pre_trigger_segments,
+                    sample_rate_ksps=self.sample_rate_ksps,
+                )
             logger.info(
                 "[MONITOR] Rolling buffer mode configured with S#%d, S=%d",
                 pre_trigger_segments,

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -45,6 +45,7 @@ from .sim import (
 )
 from .speed_correction import correct_ball_speed
 from .spin_estimate import calculated_spin_rpm
+from .swing_speed import SwingSpeedEvent
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -80,8 +81,40 @@ socketio = SocketIO(app, cors_allowed_origins="*", async_mode="threading")
 monitor = None
 mock_mode: bool = False
 debug_mode: bool = False
+mock_swing_speed_mode: bool = False
 debug_log_file = None
 debug_log_path: Optional[Path] = None
+current_player_name: str = "Player 1"
+
+TRAINING_IMPLEMENT_LABELS = {
+    "driver": "Driver",
+    "superspeed-light": "SuperSpeed Light",
+    "superspeed-medium": "SuperSpeed Medium",
+    "superspeed-heavy": "SuperSpeed Heavy",
+    "speed-stick-light": "SuperSpeed Light",
+    "speed-stick-medium": "SuperSpeed Medium",
+    "speed-stick-heavy": "SuperSpeed Heavy",
+    "stack": "Stack",
+    "stack-0g": "Stack 0g",
+    "stack-60g": "Stack 60g",
+    "stack-100g": "Stack 100g",
+    "stack-120g": "Stack 120g",
+    "stack-160g": "Stack 160g",
+    "stack-180g": "Stack 180g",
+    "stack-200g": "Stack 200g",
+    "stack-220g": "Stack 220g",
+    "stack-240g": "Stack 240g",
+    "stack-260g": "Stack 260g",
+    "stack-280g": "Stack 280g",
+    "stack-300g": "Stack 300g",
+    "rypstick": "Rypstick",
+    "rypstick-0w": "Rypstick 0 Weights",
+    "rypstick-1w": "Rypstick 1 Weight",
+    "rypstick-2w": "Rypstick 2 Weights",
+    "rypstick-3w": "Rypstick 3 Weights",
+    "rypstick-3w-cw": "Rypstick 3 Weights + Counterweight",
+    "custom": "Custom",
+}
 
 # K-LD7 angle radars (vertical = launch angle, horizontal = club path)
 kld7_vertical = None
@@ -837,6 +870,7 @@ def shot_to_dict(shot: Shot) -> dict:
             round(shot.estimated_carry_range[1]),
         ],
         "club": shot.club.value,
+        "player_name": shot.player_name,
         "timestamp": shot.timestamp.isoformat(),
         "peak_magnitude": shot.peak_magnitude,
         # Launch angle data
@@ -1435,17 +1469,25 @@ def on_live_reading(reading: SpeedReading):
 def _get_trigger_status() -> dict:
     """Build trigger status payload for the UI."""
     from .rolling_buffer import RollingBufferMonitor  # pylint: disable=import-outside-toplevel
+    from .swing_speed import SwingSpeedMonitor  # pylint: disable=import-outside-toplevel
 
     is_rolling_buffer = isinstance(monitor, RollingBufferMonitor)
+    is_swing_speed = isinstance(monitor, (SwingSpeedMonitor, MockSwingSpeedMonitor))
     session_logger = get_session_logger()
     stats = session_logger.stats if session_logger else {}
 
-    mode = "mock" if mock_mode else "rolling-buffer"
+    if is_swing_speed:
+        mode = "swing-speed"
+    elif mock_mode:
+        mode = "mock"
+    else:
+        mode = "rolling-buffer"
     trigger_type = None
     radar_port = None
 
     if is_rolling_buffer:
         trigger_type = monitor.trigger_type
+    if is_rolling_buffer or is_swing_speed:
         if hasattr(monitor, "radar") and hasattr(monitor.radar, "port"):
             radar_port = monitor.radar.port
 
@@ -1458,6 +1500,44 @@ def _get_trigger_status() -> dict:
         "triggers_accepted": stats.get("triggers_accepted", 0),
         "triggers_rejected": stats.get("triggers_rejected", 0),
     }
+
+
+def _session_shots() -> list[dict]:
+    """Return current session rows in the UI's shot-shaped payload format."""
+    from .swing_speed import SwingSpeedMonitor  # pylint: disable=import-outside-toplevel
+
+    if not monitor:
+        return []
+    if isinstance(monitor, (SwingSpeedMonitor, MockSwingSpeedMonitor)):
+        return [swing_speed_to_shot_dict(event) for event in monitor.get_events()]
+    return [shot_to_dict(shot) for shot in monitor.get_shots()]
+
+
+def _delete_session_row(timestamp: str) -> bool:
+    """Delete one shot or swing-speed rep by UI timestamp."""
+    from .swing_speed import SwingSpeedMonitor  # pylint: disable=import-outside-toplevel
+
+    if not monitor or not timestamp:
+        return False
+
+    if isinstance(monitor, (SwingSpeedMonitor, MockSwingSpeedMonitor)):
+        events = getattr(monitor, "_events", None)
+        if events is None:
+            return False
+        for index, event in enumerate(events):
+            if event.timestamp.isoformat() == timestamp:
+                del events[index]
+                return True
+        return False
+
+    shots = getattr(monitor, "_shots", None)
+    if shots is None:
+        return False
+    for index, shot in enumerate(shots):
+        if shot.timestamp.isoformat() == timestamp:
+            del shots[index]
+            return True
+    return False
 
 
 def _emit_sim_snapshot() -> None:
@@ -1490,18 +1570,18 @@ def handle_connect():
     _emit_sim_snapshot()
     if monitor:
         stats = monitor.get_session_stats()
-        shots = [shot_to_dict(s) for s in monitor.get_shots()]
         socketio.emit(
             "session_state",
             {
                 "stats": stats,
-                "shots": shots,
+                "shots": _session_shots(),
                 "mock_mode": mock_mode,
                 "debug_mode": debug_mode,
                 "camera_available": camera is not None,
                 "camera_enabled": camera_enabled,
                 "camera_streaming": camera_streaming,
                 "ball_detected": ball_detected,
+                "player_name": current_player_name,
             },
         )
         socketio.emit("trigger_status", _get_trigger_status())
@@ -1532,6 +1612,34 @@ def handle_set_club(data):
         pass
 
 
+@socketio.on("set_player")
+def handle_set_player(data):
+    """Handle active player selection changes."""
+    global current_player_name  # pylint: disable=global-statement
+
+    raw_name = data.get("player_name", "Player 1") if isinstance(data, dict) else "Player 1"
+    player_name = str(raw_name).strip()[:40] or "Player 1"
+    current_player_name = player_name
+    socketio.emit("player_changed", {"player_name": current_player_name})
+
+
+@socketio.on("set_training_implement")
+def handle_set_training_implement(data):
+    """Handle swing speed training implement selection."""
+    implement = data.get("implement", "driver") if isinstance(data, dict) else "driver"
+    label = TRAINING_IMPLEMENT_LABELS.get(implement)
+    if not label:
+        socketio.emit("training_implement_error", {"error": "Unknown training implement"})
+        return
+
+    if monitor and hasattr(monitor, "set_training_implement"):
+        monitor.set_training_implement(implement, label)
+    socketio.emit(
+        "training_implement_changed",
+        {"implement": implement, "label": label},
+    )
+
+
 @socketio.on("clear_session")
 def handle_clear_session():
     """Clear all recorded shots."""
@@ -1540,19 +1648,44 @@ def handle_clear_session():
         socketio.emit("session_cleared")
 
 
+@socketio.on("upload_cloud")
+def handle_upload_cloud():
+    """Manually trigger upload of completed session logs."""
+    threading.Thread(target=_run_cloud_push_for_ui, daemon=True).start()
+
+
 @socketio.on("get_session")
 def handle_get_session():
     """Get current session data."""
     if monitor:
         stats = monitor.get_session_stats()
-        shots = [shot_to_dict(s) for s in monitor.get_shots()]
-        socketio.emit("session_state", {"stats": stats, "shots": shots})
+        socketio.emit(
+            "session_state",
+            {"stats": stats, "shots": _session_shots(), "player_name": current_player_name},
+        )
+
+
+@socketio.on("delete_shot")
+def handle_delete_shot(data):
+    """Delete one recorded shot or swing-speed rep from the current session."""
+    timestamp = data.get("timestamp") if isinstance(data, dict) else None
+    deleted = _delete_session_row(timestamp)
+
+    if not deleted:
+        socketio.emit("delete_shot_error", {"error": "Shot not found"})
+        return
+
+    stats = monitor.get_session_stats() if monitor else {}
+    socketio.emit(
+        "session_state",
+        {"stats": stats, "shots": _session_shots(), "player_name": current_player_name},
+    )
 
 
 @socketio.on("simulate_shot")
 def handle_simulate_shot():
     """Simulate a shot (only works in mock mode)."""
-    if monitor and isinstance(monitor, MockLaunchMonitor):
+    if monitor and isinstance(monitor, (MockLaunchMonitor, MockSwingSpeedMonitor)):
         monitor.simulate_shot()
 
 
@@ -1605,7 +1738,7 @@ def handle_set_radar_config(data):
     """Update radar configuration."""
     global radar_config  # pylint: disable=global-statement
 
-    if not monitor or mock_mode:
+    if not monitor or (mock_mode and not mock_swing_speed_mode):
         log_session_error(
             "Radar config update rejected: radar not connected",
             component="server",
@@ -1615,17 +1748,28 @@ def handle_set_radar_config(data):
         return
 
     try:
+        from .swing_speed import SwingSpeedMonitor  # pylint: disable=import-outside-toplevel
+
+        is_swing_speed = isinstance(monitor, (SwingSpeedMonitor, MockSwingSpeedMonitor))
+
         # Update min speed filter
         if "min_speed" in data:
             new_min = int(data["min_speed"])
             monitor.radar.set_min_speed_filter(new_min)
+            if is_swing_speed:
+                monitor.trigger_threshold_mph = float(new_min)
             radar_config["min_speed"] = new_min
             print(f"Set min speed filter: {new_min} mph")
 
-        # Update max speed filter
+        # Update max speed filter. 0 must still be forwarded: AN-010-AD (p10)
+        # defines "R<0 resets to no limit", so it is how the UI clears a
+        # previously-set ceiling. Swallowing it would leave the old ceiling
+        # active on the radar while radar_config claimed no limit.
         if "max_speed" in data:
             new_max = int(data["max_speed"])
             monitor.radar.set_max_speed_filter(new_max)
+            if is_swing_speed:
+                monitor.max_speed_mph = None if new_max <= 0 else float(new_max)
             radar_config["max_speed"] = new_max
             print(f"Set max speed filter: {new_max} mph")
 
@@ -2028,6 +2172,7 @@ def on_shot_detected(shot: Shot):
     """Callback when a shot is detected - emit to all clients."""
     global ball_detected, ball_detection_confidence  # pylint: disable=global-statement
 
+    shot.player_name = current_player_name
     logger.info("[SERVER] Shot callback: %.1f mph", shot.ball_speed_mph)
 
     iwr6843_ms = _process_iwr6843_angle(shot)
@@ -2455,6 +2600,7 @@ def on_shot_detected(shot: Shot):
                 club_path_deg=shot.club_path_deg,
                 spin_axis_deg=shot.spin_axis_deg,
                 impact_timestamp=shot.impact_timestamp,
+                player_name=shot.player_name,
                 pipeline_ms={
                     "iwr6843": (round(iwr6843_ms, 1) if iwr6843_ms is not None else None),
                     "kld7": round(kld7_ms, 1) if kld7_ms is not None else None,
@@ -2523,6 +2669,92 @@ def on_shot_detected(shot: Shot):
             print(f"[WARN] Debug logging error: {e}")
 
 
+def swing_speed_to_dict(event: SwingSpeedEvent) -> dict:
+    """Convert a swing speed training event to a UI payload."""
+    return {
+        "peak_speed_mph": round(event.peak_speed_mph, 1),
+        "timestamp": event.timestamp.isoformat(),
+        "duration_ms": round(event.duration_ms),
+        "reading_count": event.reading_count,
+        "trigger_speed_mph": round(event.trigger_speed_mph, 1),
+        "peak_magnitude": event.peak_magnitude,
+        "training_implement": event.training_implement,
+        "training_implement_label": event.training_implement_label,
+        "player_name": event.player_name,
+        "unit": event.unit,
+        "mode": event.mode,
+    }
+
+
+def swing_speed_to_shot_dict(event: SwingSpeedEvent) -> dict:
+    """Convert a swing speed event to the existing shot UI shape."""
+    peak_speed = round(event.peak_speed_mph, 1)
+    return {
+        "ball_speed_mph": peak_speed,
+        "ball_speed_raw_mph": None,
+        "club_speed_mph": peak_speed,
+        "smash_factor": None,
+        "estimated_carry_yards": 0,
+        "carry_range": [0, 0],
+        "club": event.training_implement_label,
+        "player_name": event.player_name,
+        "timestamp": event.timestamp.isoformat(),
+        "peak_magnitude": event.peak_magnitude,
+        "launch_angle_vertical": None,
+        "launch_angle_horizontal": None,
+        "launch_angle_confidence": None,
+        "launch_angle_vertical_confidence": None,
+        "launch_angle_horizontal_confidence": None,
+        "launch_angle_vertical_source": None,
+        "launch_angle_horizontal_source": None,
+        "angle_source": None,
+        "club_angle_deg": None,
+        "club_path_deg": None,
+        "spin_axis_deg": None,
+        "spin_rpm": None,
+        "spin_rpm_measured": None,
+        "spin_source": None,
+        "spin_confidence": None,
+        "spin_quality": None,
+        "spin_snr": None,
+        "spin_modulation_depth": None,
+        "spin_peak_freq_hz": None,
+        "spin_peak_freq_rpm": None,
+        "spin_seam_cycles": None,
+        "spin_at_lower_rail": None,
+        "spin_at_upper_rail": None,
+        "spin_candidates": None,
+        "spin_phase_method": None,
+        "spin_phase_rpm": None,
+        "spin_phase_snr": None,
+        "spin_phase_agreement_pct": None,
+        "spin_phase_confirmed": None,
+        "spin_rejection_reason": None,
+        "carry_spin_adjusted": None,
+        "mode": event.mode,
+        "swing_speed_duration_ms": round(event.duration_ms),
+        "swing_speed_reading_count": event.reading_count,
+        "swing_speed_trigger_mph": round(event.trigger_speed_mph, 1),
+        "training_implement": event.training_implement,
+        "training_implement_label": event.training_implement_label,
+    }
+
+
+def on_swing_speed_detected(event: SwingSpeedEvent):
+    """Handle swing speed training reps and emit them to connected clients."""
+    event.player_name = current_player_name
+    event_data = swing_speed_to_dict(event)
+    shot_data = swing_speed_to_shot_dict(event)
+    stats = monitor.get_session_stats() if monitor else {}
+    socketio.emit("swing_speed", {"event": event_data, "stats": stats})
+    socketio.emit("shot", {"shot": shot_data, "stats": stats})
+    logger.info(
+        "[SERVER] Swing speed event emitted: peak=%.1f mph, readings=%d",
+        event.peak_speed_mph,
+        event.reading_count,
+    )
+
+
 def start_monitor(
     port: Optional[str] = None,
     mock: bool = False,
@@ -2530,10 +2762,12 @@ def start_monitor(
     debug: bool = False,
     trigger_kwargs: Optional[dict] = None,
     sample_rate_ksps: int = 30,
+    swing_speed_mode: bool = False,
+    swing_speed_kwargs: Optional[dict] = None,
     ops_baud: Optional[int] = None,
 ):
     """
-    Start the launch monitor in rolling buffer mode.
+    Start the monitor in launch monitor or swing speed mode.
 
     Args:
         port: Serial port for radar
@@ -2542,7 +2776,7 @@ def start_monitor(
         debug: Enable verbose debug output
         ops_baud: Target UART baud when the OPS243 is on the GPIO header
     """
-    global monitor, mock_mode  # pylint: disable=global-statement
+    global monitor, mock_mode, mock_swing_speed_mode, radar_config  # pylint: disable=global-statement
 
     # Stop any existing monitor first
     if monitor is not None:
@@ -2550,9 +2784,22 @@ def start_monitor(
         stop_monitor()
 
     mock_mode = mock
-    if mock:
+    mock_swing_speed_mode = mock and swing_speed_mode
+
+    if mock_swing_speed_mode:
+        monitor = MockSwingSpeedMonitor(**(swing_speed_kwargs or {}))
+        print("[MODE] Mock swing speed training mode")
+    elif mock:
         # Mock mode for testing without radar
         monitor = MockLaunchMonitor()
+    elif swing_speed_mode:
+        from .swing_speed import SwingSpeedMonitor
+
+        monitor = SwingSpeedMonitor(
+            port=port,
+            **(swing_speed_kwargs or {}),
+        )
+        print("[MODE] Swing speed training mode")
     else:
         from .rolling_buffer import RollingBufferMonitor
 
@@ -2570,9 +2817,17 @@ def start_monitor(
 
     monitor.connect()
 
+    if swing_speed_mode:
+        swing_config = swing_speed_kwargs or {}
+        radar_config = {
+            **radar_config,
+            "min_speed": int(swing_config.get("trigger_threshold_mph", 30)),
+            "max_speed": int(swing_config.get("max_speed_mph") or 0),
+        }
+
     logger.info(
         "[SERVER] Starting monitor: mode=%s, trigger=%s, sample_rate=%dksps",
-        "mock" if mock else "rolling-buffer",
+        "swing-speed" if swing_speed_mode else ("mock" if mock else "rolling-buffer"),
         trigger_type,
         sample_rate_ksps,
     )
@@ -2587,8 +2842,8 @@ def start_monitor(
             camera_enabled=camera is not None,
             camera_model="hough" if (camera_tracker and camera_tracker.use_hough) else None,
             config=_session_start_config(),
-            mode="mock" if mock else "rolling-buffer",
-            trigger_type=trigger_type if not mock else None,
+            mode="swing-speed" if swing_speed_mode else ("mock" if mock else "rolling-buffer"),
+            trigger_type=None if swing_speed_mode or mock else trigger_type,
         )
         if not mock and radar_info:
             session_logger.log_connection(
@@ -2602,7 +2857,11 @@ def start_monitor(
             # anchor K-LD7 correlation to the OPS trigger_time instead of the
             # USB first-byte arrival time.
             radar = getattr(monitor, "radar", None)
-            if radar is not None and hasattr(radar, "read_clock_sync"):
+            if (
+                not swing_speed_mode
+                and radar is not None
+                and hasattr(radar, "read_clock_sync")
+            ):
                 try:
                     clock_sync = radar.read_clock_sync()
                     session_logger.log_clock_sync(
@@ -2623,7 +2882,12 @@ def start_monitor(
                 trigger_pin_bcm=iwr6843_runtime_config.get("trigger_pin_bcm"),
             )
 
-    if not mock:
+    if swing_speed_mode:
+        monitor.start(
+            event_callback=on_swing_speed_detected,
+            live_callback=on_live_reading,
+        )
+    elif not mock:
 
         def on_trigger_diagnostic(data: dict):
             """Forward trigger diagnostics to connected UI clients."""
@@ -2660,9 +2924,64 @@ def _fire_cloud_push(session_logger):
         pass
 
 
+def _run_cloud_push_for_ui():
+    """Run a manual cloud push and report the result to connected UI clients."""
+    socketio.emit("cloud_upload_status", {"state": "running", "message": "Uploading..."})
+    try:
+        from .cloud import commands
+        from .cloud.client import CloudClient
+        from .cloud.config import CloudConfig, load_config
+
+        config = load_config() or CloudConfig()
+        session_logger = get_session_logger()
+        log_dir = getattr(session_logger, "log_dir", None)
+        if log_dir is None:
+            log_dir = session_logger.DEFAULT_LOG_DIR if session_logger else None
+        if log_dir is None:
+            log_dir = Path.home() / "openflight_sessions"
+
+        messages = []
+        summary = commands.cmd_push(
+            config,
+            Path(log_dir),
+            CloudClient(config.endpoint, token=config.device_token or None),
+            out=messages.append,
+        )
+
+        if summary.get("needs_relink"):
+            state = "error"
+            message = "Cloud token rejected. Re-link this Pi."
+        elif summary.get("skipped") == "inactive":
+            state = "error"
+            message = "Cloud uploader is not linked."
+        elif summary.get("offline"):
+            state = "error"
+            message = "Cloud unreachable."
+        elif summary.get("uploaded", 0) > 0:
+            state = "complete"
+            message = f"Uploaded {summary['uploaded']} session(s)."
+        elif messages:
+            state = "complete"
+            message = messages[-1]
+        else:
+            state = "complete"
+            message = "Nothing to upload."
+
+        socketio.emit(
+            "cloud_upload_status",
+            {"state": state, "message": message, "summary": summary},
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.warning("[SERVER] Manual cloud upload failed: %s", exc, exc_info=True)
+        socketio.emit(
+            "cloud_upload_status",
+            {"state": "error", "message": str(exc)},
+        )
+
+
 def stop_monitor():
     """Stop the launch monitor."""
-    global monitor  # pylint: disable=global-statement
+    global monitor, mock_swing_speed_mode  # pylint: disable=global-statement
 
     # End session logging
     session_logger = get_session_logger()
@@ -2674,6 +2993,7 @@ def stop_monitor():
         monitor.stop()
         monitor.disconnect()
         monitor = None
+    mock_swing_speed_mode = False
 
 
 class MockLaunchMonitor:
@@ -2871,6 +3191,146 @@ class MockLaunchMonitor:
         self._current_club = club
 
 
+class _MockSwingRadar:
+    """Tiny radar facade so UI tuning can exercise the swing speed controls."""
+
+    port = "mock"
+    baud = 0
+
+    def set_min_speed_filter(self, value):  # pylint: disable=unused-argument
+        """Accept mock lower speed updates."""
+
+    def set_max_speed_filter(self, value):  # pylint: disable=unused-argument
+        """Accept mock upper speed updates."""
+
+    def set_magnitude_filter(self, min_mag=0, max_mag=0):  # pylint: disable=unused-argument
+        """Accept mock magnitude updates."""
+
+    def set_transmit_power(self, level):  # pylint: disable=unused-argument
+        """Accept mock transmit power updates."""
+
+
+class MockSwingSpeedMonitor:
+    """Mock swing speed monitor for UI development without OPS hardware."""
+
+    def __init__(
+        self,
+        trigger_threshold_mph: float = 30.0,
+        max_speed_mph: Optional[float] = 130.0,
+        min_readings: int = 3,
+        single_reading_peak_mph: float = 60.0,
+        **kwargs,  # pylint: disable=unused-argument
+    ):
+        self.trigger_threshold_mph = float(trigger_threshold_mph)
+        self.max_speed_mph = None if max_speed_mph is None else float(max_speed_mph)
+        self.min_readings = int(min_readings)
+        self.single_reading_peak_mph = float(single_reading_peak_mph)
+        self.radar = _MockSwingRadar()
+        self._events: List[SwingSpeedEvent] = []
+        self._running = False
+        self._event_callback = None
+        self.training_implement = "driver"
+        self.training_implement_label = "Driver"
+
+    def connect(self):
+        """Connect to mock radar."""
+        return True
+
+    def disconnect(self):
+        """Disconnect from mock radar."""
+        self.stop()
+
+    def start(self, event_callback=None, live_callback=None):  # pylint: disable=unused-argument
+        """Start mock swing speed monitoring."""
+        self._event_callback = event_callback
+        self._running = True
+        print("Mock swing speed monitor started - simulate swings via WebSocket")
+
+    def stop(self):
+        """Stop mock monitoring."""
+        self._running = False
+
+    def get_radar_info(self):
+        """Return mock radar metadata."""
+        return {"Version": "mock-swing-speed"}
+
+    def simulate_shot(self, peak_speed: float = None):
+        """Simulate a club-only swing speed rep."""
+        lower = max(20.0, float(self.trigger_threshold_mph))
+        upper = float(self.max_speed_mph) if self.max_speed_mph is not None else 130.0
+        upper = max(lower + 1.0, upper)
+
+        if peak_speed is None:
+            center = min(max(lower + 35.0, 95.0), upper - 4.0)
+            peak_speed = random.gauss(center, 6.0)
+
+        peak_speed = max(lower, min(upper, float(peak_speed)))
+        trigger_speed = max(lower, min(peak_speed, peak_speed - random.uniform(12.0, 24.0)))
+        reading_count = random.randint(max(1, self.min_readings), max(self.min_readings + 3, 8))
+
+        event = SwingSpeedEvent(
+            peak_speed_mph=peak_speed,
+            timestamp=datetime.now(),
+            duration_ms=random.uniform(850.0, 1800.0),
+            reading_count=reading_count,
+            trigger_speed_mph=trigger_speed,
+            peak_magnitude=random.uniform(80.0, 450.0),
+            training_implement=self.training_implement,
+            training_implement_label=self.training_implement_label,
+        )
+        self._events.append(event)
+
+        if self._event_callback:
+            self._event_callback(event)
+
+        return event
+
+    def get_shots(self) -> List[Shot]:
+        """Swing speed mode has no ball-flight shots."""
+        return []
+
+    def get_events(self) -> List[SwingSpeedEvent]:
+        """Get all simulated swing speed reps."""
+        return list(self._events)
+
+    def get_session_stats(self) -> dict:
+        """Get swing speed session statistics."""
+        if not self._events:
+            return {
+                "shot_count": 0,
+                "avg_ball_speed": 0,
+                "max_ball_speed": 0,
+                "min_ball_speed": 0,
+                "avg_club_speed": None,
+                "avg_smash_factor": None,
+                "avg_carry_est": 0,
+            }
+
+        speeds = [event.peak_speed_mph for event in self._events]
+        return {
+            "shot_count": len(self._events),
+            "avg_ball_speed": statistics.mean(speeds),
+            "max_ball_speed": max(speeds),
+            "min_ball_speed": min(speeds),
+            "std_dev": statistics.stdev(speeds) if len(speeds) > 1 else 0,
+            "avg_club_speed": statistics.mean(speeds),
+            "avg_smash_factor": None,
+            "avg_carry_est": 0,
+        }
+
+    def clear_session(self):
+        """Clear all simulated swing speed reps."""
+        self._events = []
+
+    def set_club(self, club: ClubType):  # pylint: disable=unused-argument
+        """Accept club changes for API compatibility."""
+
+    def set_training_implement(self, implement: str, label: str):
+        """Set the training implement stamped onto future mock reps."""
+        self.training_implement = implement
+        self.training_implement_label = label
+
+
 def main():
     """Run the server."""
     import argparse  # pylint: disable=import-outside-toplevel
@@ -2889,6 +3349,11 @@ def main():
         ),
     )
     parser.add_argument("--mock", "-m", action="store_true", help="Run in mock mode without radar")
+    parser.add_argument(
+        "--mock-swing-speed",
+        action="store_true",
+        help="Run swing speed training mode with simulated reps and no OPS radar",
+    )
     parser.add_argument("--host", default="0.0.0.0", help="Host to bind to (default: 0.0.0.0)")
     parser.add_argument(
         "--web-port", type=int, default=8080, help="Web server port (default: 8080)"
@@ -2978,6 +3443,59 @@ def main():
         choices=["polling", "threshold", "speed", "sound"],
         default="polling",
         help="Trigger strategy (default: polling)",
+    )
+    parser.add_argument(
+        "--swing-speed",
+        action="store_true",
+        help="Run club-only swing speed training mode (no impact or ball required)",
+    )
+    parser.add_argument(
+        "--swing-speed-threshold",
+        type=float,
+        default=30.0,
+        help="Outbound speed threshold that starts a swing speed rep (default: 30 mph)",
+    )
+    parser.add_argument(
+        "--swing-speed-max",
+        type=float,
+        default=130.0,
+        help="Maximum plausible swing speed accepted from OPS reports; use 0 to disable (default: 130 mph)",
+    )
+    parser.add_argument(
+        "--swing-speed-min-readings",
+        type=int,
+        default=3,
+        help="Minimum qualifying radar readings required to count a swing speed rep (default: 3)",
+    )
+    parser.add_argument(
+        "--swing-speed-single-peak",
+        type=float,
+        default=60.0,
+        help="Peak speed that can count as a swing from one radar reading (default: 60 mph)",
+    )
+    parser.add_argument(
+        "--swing-speed-num-reports",
+        type=int,
+        default=8,
+        help="Number of OPS speed candidates to report per sample cycle (default: 8)",
+    )
+    parser.add_argument(
+        "--swing-speed-end-ms",
+        type=float,
+        default=1000.0,
+        help="Milliseconds below threshold before ending a swing speed rep (default: 1000)",
+    )
+    parser.add_argument(
+        "--swing-speed-cooldown-ms",
+        type=float,
+        default=750.0,
+        help="Cooldown after a swing speed rep before accepting another (default: 750)",
+    )
+    parser.add_argument(
+        "--swing-speed-rejected-cooldown-ms",
+        type=float,
+        default=100.0,
+        help="Cooldown after an ignored short motion before re-arming (default: 100)",
     )
     parser.add_argument(
         "--sound-pre-trigger",
@@ -3254,6 +3772,14 @@ def main():
     # launch angle), so require it whenever the K-LD7 radars are enabled.
     if args.kld7 and args.kld7_mount_tilt is None:
         parser.error("--kld7-mount-tilt is required when --kld7 is passed")
+    if args.mock_swing_speed:
+        args.mock = True
+        args.swing_speed = True
+    elif args.swing_speed and args.mock:
+        parser.error(
+            "--swing-speed requires real OPS243 radar hardware; use --mock-swing-speed for UI testing"
+        )
+
     if args.iwr6843 and args.kld7:
         parser.error("--iwr6843 and vertical --kld7 cannot both own launch angle")
     if args.iwr6843 and args.kld7_horizontal:
@@ -3341,6 +3867,16 @@ def main():
     # Start the monitor
     # Build trigger-specific kwargs (pre_trigger_segments always passed)
     trigger_kwargs = {"pre_trigger_segments": args.sound_pre_trigger}
+    swing_speed_kwargs = {
+        "trigger_threshold_mph": args.swing_speed_threshold,
+        "max_speed_mph": None if args.swing_speed_max <= 0 else args.swing_speed_max,
+        "min_readings": args.swing_speed_min_readings,
+        "single_reading_peak_mph": args.swing_speed_single_peak,
+        "num_reports": args.swing_speed_num_reports,
+        "end_quiet_ms": args.swing_speed_end_ms,
+        "cooldown_ms": args.swing_speed_cooldown_ms,
+        "rejected_cooldown_ms": args.swing_speed_rejected_cooldown_ms,
+    }
 
     # Initialize camera BEFORE starting monitor (so session log is accurate)
     if not args.no_camera:
@@ -3461,6 +3997,8 @@ def main():
         debug=args.debug,
         trigger_kwargs=trigger_kwargs,
         sample_rate_ksps=args.sample_rate,
+        swing_speed_mode=args.swing_speed,
+        swing_speed_kwargs=swing_speed_kwargs,
         ops_baud=args.ops_baud,
     )
 
@@ -3480,6 +4018,8 @@ def main():
     if args.mock:
         print("Running in MOCK mode - no radar required")
         print("Simulate shots via WebSocket or API")
+    if args.swing_speed:
+        print("Running in SWING SPEED mode - no ball impact trigger required")
 
     print(f"Server starting at http://{args.host}:{args.web_port}")
     print()

--- a/src/openflight/session_logger.py
+++ b/src/openflight/session_logger.py
@@ -363,6 +363,7 @@ class SessionLogger:
         spin_axis_deg: Optional[float] = None,
         pipeline_ms: Optional[Dict] = None,
         impact_timestamp: Optional[float] = None,
+        player_name: Optional[str] = None,
     ):
         """
         Log a detected shot with all metrics.
@@ -410,6 +411,7 @@ class SessionLogger:
             "smash_factor": smash_factor,
             "estimated_carry_yards": estimated_carry_yards,
             "club": club,
+            "player_name": player_name,
             "peak_magnitude": peak_magnitude,
             "readings_count": readings_count,
             "readings": readings,

--- a/src/openflight/swing_speed.py
+++ b/src/openflight/swing_speed.py
@@ -1,0 +1,283 @@
+"""Swing speed training monitor using OPS243 speed streaming."""
+
+import logging
+import statistics
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, List, Optional
+
+from .ops243 import Direction, OPS243Radar, SpeedReading
+from .session_logger import log_session_error
+
+logger = logging.getLogger("openflight.swing_speed")
+
+
+@dataclass
+class SwingSpeedEvent:
+    """A single club-only swing speed training rep."""
+
+    peak_speed_mph: float
+    timestamp: datetime
+    duration_ms: float
+    reading_count: int
+    trigger_speed_mph: float
+    peak_magnitude: Optional[float] = None
+    training_implement: str = "driver"
+    training_implement_label: str = "Driver"
+    player_name: str = "Player 1"
+    unit: str = "mph"
+    mode: str = "swing-speed"
+
+
+class SwingSpeedMonitor:
+    """Monitor OPS243 speed readings and emit club-only swing speed reps."""
+
+    def __init__(
+        self,
+        port: Optional[str] = None,
+        trigger_threshold_mph: float = 30.0,
+        max_speed_mph: Optional[float] = 130.0,
+        min_readings: int = 3,
+        single_reading_peak_mph: float = 60.0,
+        num_reports: int = 8,
+        end_quiet_ms: float = 1000.0,
+        cooldown_ms: float = 750.0,
+        rejected_cooldown_ms: float = 100.0,
+        poll_interval_ms: float = 2.0,
+    ):
+        self.radar = OPS243Radar(port=port)
+        self.trigger_threshold_mph = trigger_threshold_mph
+        self.max_speed_mph = max_speed_mph
+        self.min_readings = min_readings
+        self.single_reading_peak_mph = single_reading_peak_mph
+        self.num_reports = num_reports
+        self.end_quiet_ms = end_quiet_ms
+        self.cooldown_ms = cooldown_ms
+        self.rejected_cooldown_ms = rejected_cooldown_ms
+        self.poll_interval_ms = poll_interval_ms
+
+        self._running = False
+        self._thread: Optional[threading.Thread] = None
+        self._event_callback: Optional[Callable[[SwingSpeedEvent], None]] = None
+        self._live_callback: Optional[Callable[[SpeedReading], None]] = None
+        self._events: List[SwingSpeedEvent] = []
+        self.training_implement = "driver"
+        self.training_implement_label = "Driver"
+
+    def connect(self) -> bool:
+        """Connect to the radar and configure CW speed reporting for training.
+
+        Uses the dedicated training path rather than the launch monitor's
+        configure_for_speed_trigger(), which exists to detect a swing and hand
+        off to the rolling buffer. Training never captures a rolling buffer.
+        """
+        self.radar.connect()
+        self.radar.configure_for_swing_speed_training(
+            min_speed_mph=self.trigger_threshold_mph,
+            num_reports=self.num_reports,
+        )
+        logger.info(
+            "[SWING_SPEED] Monitor ready (threshold=%.1f mph, max=%s, reports=%d, end_quiet=%.0fms)",
+            self.trigger_threshold_mph,
+            "%.1f mph" % self.max_speed_mph if self.max_speed_mph is not None else "off",
+            self.num_reports,
+            self.end_quiet_ms,
+        )
+        return True
+
+    def disconnect(self):
+        """Disconnect from the radar."""
+        self.stop()
+        try:
+            self.radar.restore_rolling_buffer_mode()
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.warning("[SWING_SPEED] Failed to restore rolling buffer mode: %s", exc)
+        self.radar.disconnect()
+
+    def get_radar_info(self) -> dict:
+        """Get radar module information."""
+        return self.radar.get_info()
+
+    def start(
+        self,
+        event_callback: Optional[Callable[[SwingSpeedEvent], None]] = None,
+        live_callback: Optional[Callable[[SpeedReading], None]] = None,
+    ):
+        """Start monitoring for swing speed reps."""
+        self._event_callback = event_callback
+        self._live_callback = live_callback
+        self._running = True
+        self._thread = threading.Thread(target=self._capture_loop, daemon=True)
+        self._thread.start()
+        logger.info("[SWING_SPEED] Monitor started")
+
+    def stop(self):
+        """Stop monitoring."""
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+        logger.info("[SWING_SPEED] Monitor stopped")
+
+    def get_events(self) -> List[SwingSpeedEvent]:
+        """Return a copy of recorded swing speed events."""
+        return list(self._events)
+
+    def get_shots(self) -> list:
+        """Return no launch-monitor shots for compatibility with server handlers."""
+        return []
+
+    def clear_session(self):
+        """Clear recorded swing speed events."""
+        self._events.clear()
+
+    def set_club(self, _club):
+        """Ignore club selection changes in club-only training mode."""
+        return None
+
+    def set_training_implement(self, implement: str, label: str):
+        """Set the training implement stamped onto future swing speed reps."""
+        self.training_implement = implement
+        self.training_implement_label = label
+
+    def get_session_stats(self) -> dict:
+        """Get summary statistics for the current swing speed session."""
+        if not self._events:
+            return {
+                "swing_count": 0,
+                "best_speed_mph": 0,
+                "avg_speed_mph": 0,
+                "last_speed_mph": 0,
+            }
+
+        speeds = [event.peak_speed_mph for event in self._events]
+        return {
+            "swing_count": len(self._events),
+            "best_speed_mph": round(max(speeds), 1),
+            "avg_speed_mph": round(statistics.mean(speeds), 1),
+            "last_speed_mph": round(speeds[-1], 1),
+        }
+
+    def _capture_loop(self):
+        """Capture speed-stream readings and group them into swing events."""
+        active_readings: List[SpeedReading] = []
+        trigger_speed = 0.0
+        swing_start = 0.0
+        last_active = 0.0
+        cooldown_until = 0.0
+
+        while self._running:
+            try:
+                now = time.time()
+                readings = self.radar.read_speed_candidates_nonblocking()
+                if not readings:
+                    single_reading = self.radar.read_speed_nonblocking()
+                    readings = [single_reading] if single_reading else []
+
+                reading = self._select_swing_reading(readings)
+                if reading and self._live_callback:
+                    self._live_callback(reading)
+
+                qualifies = (
+                    reading is not None
+                    and reading.direction == Direction.OUTBOUND
+                    and reading.speed >= self.trigger_threshold_mph
+                    and self._within_max_speed(reading.speed)
+                )
+
+                if now < cooldown_until:
+                    time.sleep(self.poll_interval_ms / 1000.0)
+                    continue
+
+                if qualifies:
+                    if not active_readings:
+                        swing_start = reading.timestamp or now
+                        trigger_speed = reading.speed
+                        logger.info("[SWING_SPEED] Swing started at %.1f mph", trigger_speed)
+                    active_readings.append(reading)
+                    last_active = reading.timestamp or now
+                elif active_readings and (now - last_active) * 1000.0 >= self.end_quiet_ms:
+                    peak_speed = max(reading.speed for reading in active_readings)
+                    strong_single_peak = peak_speed >= self.single_reading_peak_mph
+                    if len(active_readings) < self.min_readings and not strong_single_peak:
+                        logger.info(
+                            "[SWING_SPEED] Ignored short motion: %d readings, peak=%.1f mph",
+                            len(active_readings),
+                            peak_speed,
+                        )
+                        active_readings = []
+                        cooldown_until = now + self.rejected_cooldown_ms / 1000.0
+                        continue
+
+                    event = self._build_event(
+                        readings=active_readings,
+                        trigger_speed=trigger_speed,
+                        swing_start=swing_start,
+                        swing_end=last_active,
+                    )
+                    self._events.append(event)
+                    logger.info(
+                        "[SWING_SPEED] Swing detected: peak=%.1f mph, readings=%d",
+                        event.peak_speed_mph,
+                        event.reading_count,
+                    )
+                    if self._event_callback:
+                        self._event_callback(event)
+
+                    active_readings = []
+                    cooldown_until = now + self.cooldown_ms / 1000.0
+
+                time.sleep(self.poll_interval_ms / 1000.0)
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.error("[SWING_SPEED] Capture loop error: %s", exc, exc_info=True)
+                log_session_error(
+                    "Swing speed capture loop error",
+                    component="swing_speed_monitor",
+                    exc=exc,
+                )
+                time.sleep(1.0)
+
+    def _select_swing_reading(self, readings: List[SpeedReading]) -> Optional[SpeedReading]:
+        """Select the fastest outbound candidate for swing speed training."""
+        outbound = [
+            reading
+            for reading in readings
+            if reading
+            and reading.direction == Direction.OUTBOUND
+            and reading.speed >= self.trigger_threshold_mph
+            and self._within_max_speed(reading.speed)
+        ]
+        if not outbound:
+            return None
+        return max(outbound, key=lambda reading: reading.speed)
+
+    def _within_max_speed(self, speed_mph: float) -> bool:
+        """Return true when a speed is below the configured plausible ceiling."""
+        return self.max_speed_mph is None or speed_mph <= self.max_speed_mph
+
+    def _build_event(
+        self,
+        readings: List[SpeedReading],
+        trigger_speed: float,
+        swing_start: float,
+        swing_end: float,
+    ) -> SwingSpeedEvent:
+        """Create a SwingSpeedEvent from the completed swing window."""
+        peak = max(readings, key=lambda item: item.speed)
+        peak_magnitude = max(
+            (reading.magnitude for reading in readings if reading.magnitude is not None),
+            default=None,
+        )
+        return SwingSpeedEvent(
+            peak_speed_mph=peak.speed,
+            timestamp=datetime.fromtimestamp(peak.timestamp or time.time()),
+            duration_ms=max(0.0, (swing_end - swing_start) * 1000.0),
+            reading_count=len(readings),
+            trigger_speed_mph=trigger_speed,
+            peak_magnitude=peak_magnitude,
+            training_implement=self.training_implement,
+            training_implement_label=self.training_implement_label,
+            unit=peak.unit,
+        )

--- a/tests/test_ops243.py
+++ b/tests/test_ops243.py
@@ -139,6 +139,168 @@ class TestParseReading:
         assert reading.direction == Direction.INBOUND
 
 
+class _ChunkedSpeedSerial:
+    """Serial stand-in that returns speed-stream chunks over multiple polls."""
+
+    is_open = True
+
+    def __init__(self, chunks):
+        self._chunks = [chunk.encode("ascii") for chunk in chunks]
+
+    @property
+    def in_waiting(self):
+        if not self._chunks:
+            return 0
+        return len(self._chunks[0])
+
+    def read(self, _size):
+        return self._chunks.pop(0)
+
+
+class TestReadSpeedNonblocking:
+    """Tests for non-blocking speed stream reads."""
+
+    def test_buffers_partial_json_until_complete_line(self):
+        """Split JSON lines should not be parsed until the newline arrives."""
+        radar = OPS243Radar.__new__(OPS243Radar)
+        radar.serial = _ChunkedSpeedSerial(
+            [
+                '{"magnitude":286.57, ',
+                '"speed":-71.81}\n',
+            ]
+        )
+        radar._json_mode = True
+        radar._unit = "mph"
+        radar._magnitude_enabled = True
+        radar._speed_read_buffer = ""
+
+        assert radar.read_speed_nonblocking() is None
+
+        reading = radar.read_speed_nonblocking()
+
+        assert reading is not None
+        assert reading.speed == 71.81
+        assert reading.direction == Direction.OUTBOUND
+        assert reading.magnitude == 286.57
+
+    def test_returns_last_valid_complete_line(self):
+        """When several lines arrive together, the newest valid reading wins."""
+        radar = OPS243Radar.__new__(OPS243Radar)
+        radar.serial = _ChunkedSpeedSerial(
+            [
+                '{"magnitude":21.0, "speed":-21.22}\n'
+                '{"magnitude":90.0, "speed":-44.07}\n'
+            ]
+        )
+        radar._json_mode = True
+        radar._unit = "mph"
+        radar._magnitude_enabled = True
+        radar._speed_read_buffer = ""
+
+        reading = radar.read_speed_nonblocking()
+
+        assert reading is not None
+        assert reading.speed == 44.07
+        assert reading.magnitude == 90.0
+
+    def test_multi_candidate_reader_returns_all_array_speeds(self):
+        """Multi-object JSON should expose all speed candidates."""
+        radar = OPS243Radar.__new__(OPS243Radar)
+        radar.serial = _ChunkedSpeedSerial(
+            [
+                '{"magnitude":[900.0, 120.0, 80.0], '
+                '"speed":[-55.0, -101.0, 42.0]}\n'
+            ]
+        )
+        radar._json_mode = True
+        radar._unit = "mph"
+        radar._magnitude_enabled = True
+        radar._speed_read_buffer = ""
+
+        readings = radar.read_speed_candidates_nonblocking()
+
+        assert [reading.speed for reading in readings] == [55.0, 101.0, 42.0]
+        assert readings[0].direction == Direction.OUTBOUND
+        assert readings[1].direction == Direction.OUTBOUND
+        assert readings[2].direction == Direction.INBOUND
+
+
+class TestPreparePersistedRollingBuffer:
+    """Tests for returning from speed mode to sound-trigger launch mode."""
+
+    def test_prepare_rearms_without_restoring_or_saving(self, monkeypatch):
+        """Normal sound mode should not force GC/A! on a healthy persisted radar."""
+        calls = []
+
+        class FakeSerial:
+            is_open = True
+
+        radar = OPS243Radar.__new__(OPS243Radar)
+        radar.serial = FakeSerial()
+
+        monkeypatch.setattr(radar, "set_units", lambda unit: calls.append(("set_units", unit.value)))
+        monkeypatch.setattr(radar, "set_transmit_power", lambda value: calls.append(("set_transmit_power", value)))
+        monkeypatch.setattr(radar, "set_sample_rate", lambda value: calls.append(("set_sample_rate", value)))
+        monkeypatch.setattr(
+            radar,
+            "rearm_rolling_buffer",
+            lambda pre_trigger_segments: calls.append(("rearm_rolling_buffer", pre_trigger_segments)),
+        )
+        monkeypatch.setattr(
+            radar,
+            "restore_rolling_buffer_mode",
+            lambda **kwargs: calls.append(("restore_rolling_buffer_mode", kwargs)),
+        )
+
+        radar.prepare_persisted_rolling_buffer(pre_trigger_segments=16, sample_rate_ksps=30)
+
+        assert calls == [
+            ("set_units", "US"),
+            ("set_transmit_power", 3),
+            ("set_sample_rate", 30000),
+            ("rearm_rolling_buffer", 16),
+        ]
+
+    def test_restore_rolling_buffer_mode_does_not_save_to_flash(self, monkeypatch):
+        """Runtime mode switching should not send A! or write persistent flash."""
+        calls = []
+
+        class FakeSerial:
+            is_open = True
+
+            def write(self, data):
+                calls.append(("write", data))
+
+            def flush(self):
+                calls.append(("flush", None))
+
+            def reset_input_buffer(self):
+                calls.append(("reset_input_buffer", None))
+
+        radar = OPS243Radar.__new__(OPS243Radar)
+        radar.serial = FakeSerial()
+
+        monkeypatch.setattr(radar, "set_units", lambda unit: calls.append(("set_units", unit.value)))
+        monkeypatch.setattr(radar, "set_transmit_power", lambda value: calls.append(("set_transmit_power", value)))
+        monkeypatch.setattr(
+            radar,
+            "enter_rolling_buffer_mode",
+            lambda pre_trigger_segments, sample_rate_ksps: calls.append(
+                ("enter_rolling_buffer_mode", pre_trigger_segments, sample_rate_ksps)
+            ),
+        )
+
+        radar.restore_rolling_buffer_mode(pre_trigger_segments=16, sample_rate_ksps=30)
+
+        assert ("write", b"A!") not in calls
+        assert calls == [
+            ("set_units", "US"),
+            ("set_transmit_power", 3),
+            ("enter_rolling_buffer_mode", 16, 30),
+            ("reset_input_buffer", None),
+        ]
+
+
 class TestFFTSize:
     """Tests for FFT size configuration."""
 

--- a/tests/test_ops243_mode_commands.py
+++ b/tests/test_ops243_mode_commands.py
@@ -1,0 +1,198 @@
+"""OPS243-A mode commands must match the current API reference.
+
+AN-010-AD (API Commands, p21) is authoritative on mode control:
+
+    GS  CW Mode            Sets CW operation only          (OPS243-A default)
+    GC  Rolling Buffer     Sets Rolling Buffer Mode on (GS to disable),
+                           *previously was G1*
+
+The older AN-027 Rolling Buffer app note still documents the pre-rename
+G1/G0 pair, and a swing-speed branch once renamed the whole driver to match
+it -- silently reverting the production launch-monitor path to deprecated
+mnemonics. These tests pin the byte sequences so the two docs can't be
+confused again, and so swing-speed training stays off the rolling-buffer
+path entirely.
+"""
+
+import pytest
+
+from openflight.ops243 import OPS243Radar
+
+DEPRECATED_MODE_COMMANDS = (b"G1", b"G0")
+
+
+class RecordingSerial:
+    """Fake serial port that records writes and answers queries quietly."""
+
+    def __init__(self):
+        self.is_open = True
+        self.writes = []
+
+    @property
+    def in_waiting(self):
+        return 0
+
+    def read(self, _n):
+        return b""
+
+    def reset_input_buffer(self):
+        pass
+
+    def write(self, data):
+        self.writes.append(data)
+
+    def flush(self):
+        pass
+
+
+@pytest.fixture(name="radar")
+def _radar(monkeypatch):
+    """A radar wired to a recording port, with sleeps and reads stubbed out."""
+    monkeypatch.setattr("openflight.ops243.time.sleep", lambda _s: None)
+    instance = OPS243Radar.__new__(OPS243Radar)
+    instance.serial = RecordingSerial()
+    instance._unit = "mph"
+    instance._json_mode = False
+    instance._magnitude_enabled = False
+    instance._speed_read_buffer = ""
+    # _send_command reads a reply; keep it silent so tests only observe writes.
+    monkeypatch.setattr(OPS243Radar, "_read_reply", lambda _self, *_a, **_kw: "")
+    return instance
+
+
+def _sent(radar):
+    """Concatenated bytes written to the port."""
+    return b"".join(radar.serial.writes)
+
+
+# --- rolling buffer keeps the current mnemonic -------------------------------
+
+
+def test_enter_rolling_buffer_uses_gc_not_deprecated_g1(radar):
+    """Rolling buffer is GC per AN-010-AD; G1 is the pre-rename spelling."""
+    radar.enter_rolling_buffer_mode(pre_trigger_segments=16, sample_rate_ksps=30)
+
+    sent = _sent(radar)
+    assert b"GC" in sent, f"expected GC to enter rolling buffer, sent: {radar.serial.writes!r}"
+    for deprecated in DEPRECATED_MODE_COMMANDS:
+        assert deprecated not in sent, (
+            f"{deprecated!r} is the deprecated mnemonic (AN-027); "
+            f"AN-010-AD renamed it. Sent: {radar.serial.writes!r}"
+        )
+
+
+def test_disable_rolling_buffer_uses_gs_not_deprecated_g0(radar):
+    """GS is the documented way out of rolling buffer, back to CW."""
+    radar.disable_rolling_buffer()
+
+    sent = _sent(radar)
+    assert b"GS" in sent, f"expected GS to leave rolling buffer, sent: {radar.serial.writes!r}"
+    assert b"G0" not in sent, "G0 only appears in the superseded AN-027 app note"
+
+
+def test_switch_to_rolling_buffer_uses_gc(radar):
+    """The fast speed-trigger handoff into rolling buffer also uses GC."""
+    radar.switch_to_rolling_buffer()
+
+    sent = _sent(radar)
+    assert b"GC" in sent
+    for deprecated in DEPRECATED_MODE_COMMANDS:
+        assert deprecated not in sent
+
+
+# --- swing-speed training is a separate, CW-only path -----------------------
+
+
+def test_swing_speed_training_selects_cw_mode(radar):
+    """Training reports raw CW speeds, so it must select GS."""
+    radar.configure_for_swing_speed_training()
+
+    sent = _sent(radar)
+    assert b"GS" in sent, f"training must select CW mode (GS), sent: {radar.serial.writes!r}"
+    for deprecated in DEPRECATED_MODE_COMMANDS:
+        assert deprecated not in sent
+
+
+def test_swing_speed_training_never_enters_rolling_buffer(radar):
+    """Training must not arm the rolling buffer: no GC, no S#n, no S! trigger."""
+    radar.configure_for_swing_speed_training()
+
+    for command in (b"GC", b"S#", b"S!"):
+        assert command not in _sent(radar), (
+            f"{command!r} is a rolling-buffer command and must not appear in the "
+            f"training path. Sent: {radar.serial.writes!r}"
+        )
+
+
+def test_swing_speed_training_never_writes_flash(radar):
+    """A! writes persistent memory; only the one-time setup path may do that.
+
+    A stray A! here would overwrite the persisted rolling-buffer boot state
+    that the HOST_INT workaround depends on, breaking launch mode until the
+    setup script was re-run.
+    """
+    radar.configure_for_swing_speed_training()
+
+    assert b"A!" not in _sent(radar), (
+        "training must not persist config to flash — it would clobber the "
+        f"persisted rolling-buffer boot state. Sent: {radar.serial.writes!r}"
+    )
+
+
+def test_swing_speed_training_activates_and_applies_thresholds(radar):
+    """Training ends active (PA) with the caller's speed filter and report count."""
+    radar.configure_for_swing_speed_training(min_speed_mph=45, num_reports=3)
+
+    sent = _sent(radar)
+    assert b"R>45" in sent, f"expected R>45 min-speed filter, sent: {radar.serial.writes!r}"
+    assert b"O3" in sent, f"expected O3 for 3 reports, sent: {radar.serial.writes!r}"
+    assert sent.rstrip().endswith(b"PA") or b"PA" in sent, "training must leave the radar active"
+
+
+def test_swing_speed_training_requires_connection():
+    """Configuring a disconnected radar must fail loudly, not silently no-op."""
+    instance = OPS243Radar.__new__(OPS243Radar)
+    instance.serial = None
+
+    with pytest.raises(ConnectionError):
+        instance.configure_for_swing_speed_training()
+
+
+# --- the restore path returns to rolling buffer without touching flash ------
+
+
+def test_persisted_startup_sends_no_mode_switch_at_all(radar):
+    """The default sound-trigger startup must not transition radar modes.
+
+    This is the production launch-monitor path. The OPS243-A flips HOST_INT
+    pin mode when it changes modes at runtime, so the board is persisted into
+    rolling-buffer mode with A! and power-cycled once (CLAUDE.md "Radar
+    Setup"); startup then only re-arms. A GC/PI here would re-introduce the
+    runtime transition the whole workaround exists to avoid.
+
+    TestRollingBufferStartupMode asserts the *dispatch* (which radar method
+    the monitor picks) with a MagicMock radar, so it cannot see the bytes.
+    This pins the bytes.
+    """
+    radar.prepare_persisted_rolling_buffer(pre_trigger_segments=16, sample_rate_ksps=30)
+
+    sent = _sent(radar)
+    for mode_switch in (b"GC", b"GS", b"PI", b"A!"):
+        assert mode_switch not in sent, (
+            f"{mode_switch!r} is a mode switch/flash write and must not appear on the "
+            f"persisted startup path. Sent: {radar.serial.writes!r}"
+        )
+    # It must still actually re-arm, or the sound trigger never fires.
+    assert b"PA" in sent, f"startup must re-arm with PA, sent: {radar.serial.writes!r}"
+    assert b"S#16" in sent, f"startup must set the trigger split, sent: {radar.serial.writes!r}"
+
+
+def test_restore_rolling_buffer_uses_gc_and_no_flash_write(radar):
+    """Returning from training re-enters rolling buffer volatilely."""
+    radar.restore_rolling_buffer_mode(pre_trigger_segments=16, sample_rate_ksps=30)
+
+    sent = _sent(radar)
+    assert b"GC" in sent
+    for deprecated in DEPRECATED_MODE_COMMANDS:
+        assert deprecated not in sent
+    assert b"A!" not in sent, "mode switching must not write flash"

--- a/tests/test_rolling_buffer.py
+++ b/tests/test_rolling_buffer.py
@@ -2852,6 +2852,40 @@ class TestShutdownPreservesRollingBuffer:
         )
 
 
+class TestRollingBufferStartupMode:
+    """Startup should respect the persisted HOST_INT rolling-buffer workaround."""
+
+    def test_sound_trigger_prepares_persisted_buffer_without_runtime_gc(self):
+        from openflight.rolling_buffer import RollingBufferMonitor
+
+        monitor = RollingBufferMonitor(port=None, trigger_type="sound", pre_trigger_segments=16)
+        monitor.radar = MagicMock()
+
+        assert monitor.connect() is True
+
+        monitor.radar.connect.assert_called_once()
+        monitor.radar.prepare_persisted_rolling_buffer.assert_called_once_with(
+            pre_trigger_segments=16,
+            sample_rate_ksps=30,
+        )
+        assert not monitor.radar.configure_for_rolling_buffer.called
+
+    def test_non_sound_trigger_can_configure_rolling_buffer_runtime(self):
+        from openflight.rolling_buffer import RollingBufferMonitor
+
+        monitor = RollingBufferMonitor(port=None, trigger_type="manual", pre_trigger_segments=12)
+        monitor.radar = MagicMock()
+
+        assert monitor.connect() is True
+
+        monitor.radar.connect.assert_called_once()
+        monitor.radar.configure_for_rolling_buffer.assert_called_once_with(
+            pre_trigger_segments=12,
+            sample_rate_ksps=30,
+        )
+        assert not monitor.radar.prepare_persisted_rolling_buffer.called
+
+
 class TestSpinWindowTrimming:
     """The spin window must end where ball signal ends (net impact), not at
     the end of the capture — the amplitude cliff plus dead air corrupts the

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,11 +15,15 @@ from openflight.launch_monitor import ClubType, Shot
 from openflight.ops243 import UART_BAUD_COMMANDS
 from openflight.server import (
     MockLaunchMonitor,
+    MockSwingSpeedMonitor,
     estimate_launch_angle,
     on_shot_detected,
     radar_launch_is_plausible,
     shot_to_dict,
+    swing_speed_to_shot_dict,
+    swing_speed_to_dict,
 )
+from openflight.swing_speed import SwingSpeedEvent
 
 
 class TestShutdownCleanup:
@@ -705,6 +709,7 @@ class TestShotToDict:
         assert result["ball_speed_mph"] == 150.5
         assert result["club_speed_mph"] == 103.2
         assert result["club"] == "driver"
+        assert result["player_name"] == "Player 1"
         assert result["timestamp"] == "2024-01-15T10:30:00"
         assert "estimated_carry_yards" in result
         assert "carry_range" in result
@@ -793,6 +798,327 @@ class TestShotToDict:
         assert result["spin_phase_agreement_pct"] == 2.1
         assert result["spin_phase_confirmed"] is True
         assert result["spin_rejection_reason"] == "SNR too low (2.96, need 3.0)"
+
+
+class TestSwingSpeedMode:
+    """Tests for swing speed training server helpers."""
+
+    def test_swing_speed_to_dict(self):
+        """Swing speed event payloads should be rounded and UI-friendly."""
+        event = SwingSpeedEvent(
+            peak_speed_mph=101.44,
+            timestamp=datetime(2024, 1, 15, 10, 30, 0),
+            duration_ms=347.8,
+            reading_count=9,
+            trigger_speed_mph=32.25,
+            peak_magnitude=42,
+        )
+
+        result = swing_speed_to_dict(event)
+
+        assert result == {
+            "peak_speed_mph": 101.4,
+            "timestamp": "2024-01-15T10:30:00",
+            "duration_ms": 348,
+            "reading_count": 9,
+            "trigger_speed_mph": 32.2,
+            "peak_magnitude": 42,
+            "training_implement": "driver",
+            "training_implement_label": "Driver",
+            "player_name": "Player 1",
+            "unit": "mph",
+            "mode": "swing-speed",
+        }
+
+    def test_swing_speed_to_shot_dict_supports_existing_ui(self):
+        """Swing speed events should also map to the normal shot event shape."""
+        event = SwingSpeedEvent(
+            peak_speed_mph=101.44,
+            timestamp=datetime(2024, 1, 15, 10, 30, 0),
+            duration_ms=347.8,
+            reading_count=9,
+            trigger_speed_mph=32.25,
+            peak_magnitude=42,
+        )
+
+        result = swing_speed_to_shot_dict(event)
+
+        assert result["ball_speed_mph"] == 101.4
+        assert result["club_speed_mph"] == 101.4
+        assert result["club"] == "Driver"
+        assert result["estimated_carry_yards"] == 0
+        assert result["carry_range"] == [0, 0]
+        assert result["mode"] == "swing-speed"
+        assert result["swing_speed_reading_count"] == 9
+        assert result["swing_speed_trigger_mph"] == 32.2
+        assert result["training_implement"] == "driver"
+        assert result["training_implement_label"] == "Driver"
+        assert result["player_name"] == "Player 1"
+
+    def test_set_player_updates_future_swing_speed_payloads(self, monkeypatch):
+        """Selected UI player should be stamped on subsequent swing speed reps."""
+        emitted = []
+        monkeypatch.setattr(server_module, "current_player_name", "Player 1")
+        monkeypatch.setattr(server_module.socketio, "emit", lambda *args, **kwargs: emitted.append(args))
+
+        server_module.handle_set_player({"player_name": "David"})
+        event = SwingSpeedEvent(
+            peak_speed_mph=101.44,
+            timestamp=datetime(2024, 1, 15, 10, 30, 0),
+            duration_ms=347.8,
+            reading_count=9,
+            trigger_speed_mph=32.25,
+        )
+        server_module.on_swing_speed_detected(event)
+
+        assert server_module.current_player_name == "David"
+        shot_payload = next(payload for name, payload in emitted if name == "shot")
+        assert shot_payload["shot"]["player_name"] == "David"
+
+    def test_start_monitor_uses_swing_speed_monitor(self, monkeypatch):
+        """Swing speed mode should start a club-only monitor and callback."""
+        started = {}
+        session = {}
+
+        class FakeSwingSpeedMonitor:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.radar = SimpleNamespace(baud=57600)
+
+            def connect(self):
+                started["connected"] = True
+
+            def get_radar_info(self):
+                return {"Version": "test"}
+
+            def start(self, event_callback=None, live_callback=None):
+                started["event_callback"] = event_callback
+                started["live_callback"] = live_callback
+
+            def stop(self):
+                started["stopped"] = True
+
+            def disconnect(self):
+                started["disconnected"] = True
+
+        class FakeSessionLogger:
+            def start_session(self, **kwargs):
+                session.update(kwargs)
+
+            def end_session(self):
+                pass
+
+            def log_connection(self, **kwargs):
+                session["connection"] = kwargs
+
+            def log_clock_sync(self, **kwargs):
+                session["clock_sync"] = kwargs
+
+        monkeypatch.setattr(server_module, "monitor", None)
+        monkeypatch.setattr(server_module, "camera", None)
+        monkeypatch.setattr(server_module, "camera_tracker", None)
+        monkeypatch.setattr(server_module, "get_session_logger", lambda: FakeSessionLogger())
+        monkeypatch.setattr(
+            "openflight.swing_speed.SwingSpeedMonitor",
+            FakeSwingSpeedMonitor,
+        )
+
+        server_module.start_monitor(
+            port="/dev/ops",
+            swing_speed_mode=True,
+            swing_speed_kwargs={
+                "trigger_threshold_mph": 35.0,
+                "max_speed_mph": 125.0,
+                "min_readings": 4,
+                "single_reading_peak_mph": 65.0,
+                "num_reports": 8,
+                "rejected_cooldown_ms": 50.0,
+            },
+        )
+
+        assert server_module.monitor.kwargs == {
+            "port": "/dev/ops",
+            "trigger_threshold_mph": 35.0,
+            "max_speed_mph": 125.0,
+            "min_readings": 4,
+            "single_reading_peak_mph": 65.0,
+            "num_reports": 8,
+            "rejected_cooldown_ms": 50.0,
+        }
+        assert started["connected"] is True
+        assert started["event_callback"] is server_module.on_swing_speed_detected
+        assert started["live_callback"] is server_module.on_live_reading
+        assert session["mode"] == "swing-speed"
+        assert session["trigger_type"] is None
+
+        server_module.stop_monitor()
+
+    def test_start_monitor_uses_mock_swing_speed_monitor(self, monkeypatch):
+        """Mock swing speed mode should exercise the swing speed UI without hardware."""
+        session = {}
+
+        class FakeSessionLogger:
+            def start_session(self, **kwargs):
+                session.update(kwargs)
+
+            def end_session(self):
+                pass
+
+        monkeypatch.setattr(server_module, "monitor", None)
+        monkeypatch.setattr(server_module, "camera", None)
+        monkeypatch.setattr(server_module, "camera_tracker", None)
+        monkeypatch.setattr(server_module, "get_session_logger", lambda: FakeSessionLogger())
+
+        server_module.start_monitor(
+            mock=True,
+            swing_speed_mode=True,
+            swing_speed_kwargs={
+                "trigger_threshold_mph": 70.0,
+                "max_speed_mph": 125.0,
+                "min_readings": 5,
+            },
+        )
+
+        assert isinstance(server_module.monitor, MockSwingSpeedMonitor)
+        assert server_module.mock_mode is True
+        assert server_module.mock_swing_speed_mode is True
+        assert server_module.monitor.trigger_threshold_mph == 70.0
+        assert server_module.monitor.max_speed_mph == 125.0
+        assert server_module.monitor.min_readings == 5
+        assert session["mode"] == "swing-speed"
+        assert session["trigger_type"] is None
+
+        server_module.stop_monitor()
+
+    def test_mock_swing_speed_simulates_bounded_event(self):
+        """Mock swing speed reps should respect configured lower and upper gates."""
+        emitted = []
+        monitor = MockSwingSpeedMonitor(
+            trigger_threshold_mph=75.0,
+            max_speed_mph=110.0,
+            min_readings=5,
+        )
+
+        monitor.start(event_callback=emitted.append)
+        event = monitor.simulate_shot()
+
+        assert emitted == [event]
+        assert 75.0 <= event.peak_speed_mph <= 110.0
+        assert event.reading_count >= 5
+        assert monitor.get_session_stats()["shot_count"] == 1
+
+    def test_mock_swing_speed_stamps_training_implement(self):
+        """Mock reps should use the selected training implement metadata."""
+        monitor = MockSwingSpeedMonitor()
+
+        assert server_module.TRAINING_IMPLEMENT_LABELS["rypstick-3w-cw"] == "Rypstick 3 Weights + Counterweight"
+
+        monitor.set_training_implement("rypstick-3w-cw", "Rypstick 3 Weights + Counterweight")
+        event = monitor.simulate_shot(peak_speed=95.0)
+        shot = swing_speed_to_shot_dict(event)
+
+        assert event.training_implement == "rypstick-3w-cw"
+        assert event.training_implement_label == "Rypstick 3 Weights + Counterweight"
+        assert shot["club"] == "Rypstick 3 Weights + Counterweight"
+
+    def test_delete_session_row_removes_mock_swing_speed_event(self, monkeypatch):
+        """Deleting a swing-speed UI row should remove the matching event."""
+        monitor = MockSwingSpeedMonitor(
+            trigger_threshold_mph=75.0,
+            max_speed_mph=110.0,
+            min_readings=5,
+        )
+        first = monitor.simulate_shot(peak_speed=95.0)
+        second = monitor.simulate_shot(peak_speed=101.0)
+
+        monkeypatch.setattr(server_module, "monitor", monitor)
+
+        assert server_module._delete_session_row(first.timestamp.isoformat()) is True
+        remaining = server_module._session_shots()
+
+        assert len(remaining) == 1
+        assert remaining[0]["timestamp"] == second.timestamp.isoformat()
+        assert remaining[0]["club"] == "Driver"
+
+    def test_set_radar_config_updates_swing_speed_gates(self, monkeypatch):
+        """UI tuning should update live swing-speed lower and upper gates."""
+        calls = []
+        emitted = []
+
+        class StubRadar:
+            def set_min_speed_filter(self, value):
+                calls.append(("min", value))
+
+            def set_max_speed_filter(self, value):
+                calls.append(("max", value))
+
+        class StubSwingSpeedMonitor:
+            radar = StubRadar()
+            trigger_threshold_mph = 70.0
+            max_speed_mph = 125.0
+
+        monkeypatch.setattr(server_module, "monitor", StubSwingSpeedMonitor())
+        monkeypatch.setattr(server_module, "mock_mode", False)
+        monkeypatch.setattr(server_module, "radar_config", {"min_speed": 70, "max_speed": 125})
+        monkeypatch.setattr(server_module, "get_session_logger", lambda: None)
+        monkeypatch.setattr(
+            server_module.socketio,
+            "emit",
+            lambda event, payload: emitted.append((event, payload)),
+        )
+        monkeypatch.setattr(
+            server_module,
+            "log_session_error",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "openflight.swing_speed.SwingSpeedMonitor",
+            StubSwingSpeedMonitor,
+        )
+
+        server_module.handle_set_radar_config({"min_speed": 55, "max_speed": 115})
+
+        assert calls == [("min", 55), ("max", 115)]
+        assert server_module.monitor.trigger_threshold_mph == 55.0
+        assert server_module.monitor.max_speed_mph == 115.0
+        assert emitted[-1] == ("radar_config", {"min_speed": 55, "max_speed": 115})
+
+
+    def test_set_radar_config_forwards_zero_max_speed_to_clear_the_filter(self, monkeypatch):
+        """max_speed 0 must still reach the radar on the default launch path.
+
+        AN-010-AD (p10) defines "R<0 resets to no limit", so 0 is how the UI
+        clears a previously-set ceiling -- the default DebugPanel slider allows
+        it (min=0). Skipping the command leaves the old ceiling active on the
+        radar while radar_config reports 0, silently dropping fast shots.
+        """
+        calls = []
+
+        class StubRadar:
+            def set_min_speed_filter(self, value):
+                calls.append(("min", value))
+
+            def set_max_speed_filter(self, value):
+                calls.append(("max", value))
+
+        class StubMonitor:
+            radar = StubRadar()
+
+        monkeypatch.setattr(server_module, "monitor", StubMonitor())
+        monkeypatch.setattr(server_module, "mock_mode", False)
+        monkeypatch.setattr(server_module, "mock_swing_speed_mode", False)
+        monkeypatch.setattr(server_module, "radar_config", {"min_speed": 10, "max_speed": 150})
+        monkeypatch.setattr(server_module, "get_session_logger", lambda: None)
+        monkeypatch.setattr(server_module.socketio, "emit", lambda *_a, **_kw: None)
+        monkeypatch.setattr(server_module, "log_session_error", lambda *_a, **_kw: None)
+
+        server_module.handle_set_radar_config({"max_speed": 0})
+
+        assert ("max", 0) in calls, (
+            "R<0 is the documented reset-to-no-limit; suppressing it leaves the "
+            f"previous ceiling active on the radar. Calls: {calls}"
+        )
+        assert server_module.radar_config["max_speed"] == 0
 
 
 class TestEstimateLaunchAngle:

--- a/tests/test_start_kiosk.py
+++ b/tests/test_start_kiosk.py
@@ -118,6 +118,61 @@ def test_kld7_angle_offset_override_wins():
     assert "--kld7-angle-offset 1.5" not in command
 
 
+def test_swing_speed_flags_forwarded():
+    """Swing speed training flags should reach the server command."""
+    result = _dry_run(
+        "--swing-speed",
+        "--swing-speed-threshold",
+        "35",
+        "--swing-speed-max",
+        "125",
+        "--swing-speed-min-readings",
+        "4",
+        "--swing-speed-single-peak",
+        "65",
+        "--swing-speed-num-reports",
+        "8",
+        "--swing-speed-end-ms",
+        "300",
+        "--swing-speed-cooldown-ms",
+        "900",
+        "--swing-speed-rejected-cooldown-ms",
+        "50",
+    )
+    command = result.stdout.strip()
+
+    assert "--swing-speed" in command
+    assert "--swing-speed-threshold 35" in command
+    assert "--swing-speed-max 125" in command
+    assert "--swing-speed-min-readings 4" in command
+    assert "--swing-speed-single-peak 65" in command
+    assert "--swing-speed-num-reports 8" in command
+    assert "--swing-speed-end-ms 300" in command
+    assert "--swing-speed-cooldown-ms 900" in command
+    assert "--swing-speed-rejected-cooldown-ms 50" in command
+
+
+def test_mock_swing_speed_flag_forwards_mock_mode():
+    """Mock swing speed should use the server's no-hardware training mode."""
+    result = _dry_run("--mock-swing-speed", "--swing-speed-threshold", "45")
+    command = result.stdout.strip()
+
+    assert "--mock-swing-speed" in command
+    assert "--swing-speed-threshold 45" in command
+    assert "--swing-speed " not in f"{command} "
+    assert "--mock " not in f"{command} "
+
+
+def test_mock_and_swing_speed_flags_collapse_to_mock_swing_speed():
+    """The friendly --mock --swing-speed combo should avoid the server error path."""
+    result = _dry_run("--mock", "--swing-speed")
+    command = result.stdout.strip()
+
+    assert "--mock-swing-speed" in command
+    assert "--swing-speed " not in f"{command} "
+    assert "--mock " not in f"{command} "
+
+
 def test_kld7_vertical_raw_flag_forwarded():
     """--kld7-vertical-raw reaches the server as the renamed raw flag."""
     result = _dry_run("--kld7", "--kld7-mount-tilt", "10", "--kld7-vertical-raw")

--- a/tests/test_swing_speed.py
+++ b/tests/test_swing_speed.py
@@ -1,0 +1,189 @@
+"""Tests for swing speed training mode."""
+
+from datetime import datetime
+
+from openflight.ops243 import Direction, SpeedReading
+from openflight.swing_speed import SwingSpeedEvent, SwingSpeedMonitor
+
+
+def test_build_event_uses_peak_outbound_speed_and_magnitude():
+    """A completed swing window should report peak speed and peak magnitude."""
+    monitor = SwingSpeedMonitor(trigger_threshold_mph=30)
+    readings = [
+        SpeedReading(
+            speed=44.0,
+            direction=Direction.OUTBOUND,
+            magnitude=12,
+            timestamp=100.00,
+        ),
+        SpeedReading(
+            speed=88.4,
+            direction=Direction.OUTBOUND,
+            magnitude=36,
+            timestamp=100.08,
+        ),
+        SpeedReading(
+            speed=73.2,
+            direction=Direction.OUTBOUND,
+            magnitude=24,
+            timestamp=100.13,
+        ),
+    ]
+
+    event = monitor._build_event(  # pylint: disable=protected-access
+        readings=readings,
+        trigger_speed=44.0,
+        swing_start=100.00,
+        swing_end=100.13,
+    )
+
+    assert event.peak_speed_mph == 88.4
+    assert event.trigger_speed_mph == 44.0
+    assert round(event.duration_ms) == 130
+    assert event.reading_count == 3
+    assert event.peak_magnitude == 36
+    assert event.mode == "swing-speed"
+
+
+def test_session_stats_for_swing_speed_events():
+    """Swing speed sessions should summarize rep count, best, average, and last."""
+    monitor = SwingSpeedMonitor()
+    monitor._events = [  # pylint: disable=protected-access
+        SwingSpeedEvent(
+            peak_speed_mph=95.0,
+            timestamp=datetime.now(),
+            duration_ms=320,
+            reading_count=5,
+            trigger_speed_mph=35.0,
+        ),
+        SwingSpeedEvent(
+            peak_speed_mph=101.4,
+            timestamp=datetime.now(),
+            duration_ms=340,
+            reading_count=7,
+            trigger_speed_mph=37.0,
+        ),
+        SwingSpeedEvent(
+            peak_speed_mph=99.2,
+            timestamp=datetime.now(),
+            duration_ms=300,
+            reading_count=6,
+            trigger_speed_mph=34.0,
+        ),
+    ]
+
+    assert monitor.get_session_stats() == {
+        "swing_count": 3,
+        "best_speed_mph": 101.4,
+        "avg_speed_mph": 98.5,
+        "last_speed_mph": 99.2,
+    }
+
+
+def test_min_readings_default_rejects_single_spike():
+    """The default gate should reject one-off hand-motion or noise spikes."""
+    monitor = SwingSpeedMonitor()
+
+    assert monitor.min_readings == 3
+    assert monitor.max_speed_mph == 130.0
+    assert monitor.single_reading_peak_mph == 60.0
+    assert monitor.num_reports == 8
+    assert monitor.end_quiet_ms == 1000.0
+    assert monitor.rejected_cooldown_ms == 100.0
+
+
+def test_connect_applies_threshold_to_radar_filter(monkeypatch):
+    """Swing mode should not stream low-speed background readings from the OPS."""
+    calls = []
+
+    class FakeRadar:
+        def __init__(self, port=None):
+            self.port = port
+
+        def connect(self):
+            calls.append(("connect", None))
+
+        def configure_for_swing_speed_training(self, min_speed_mph=None, num_reports=None):
+            calls.append(("configure_for_swing_speed_training", (min_speed_mph, num_reports)))
+
+    monkeypatch.setattr("openflight.swing_speed.OPS243Radar", FakeRadar)
+
+    monitor = SwingSpeedMonitor(port="COM4", trigger_threshold_mph=45.0)
+
+    assert monitor.connect() is True
+    # Training owns its own radar setup; it must not route through the launch
+    # monitor's configure_for_speed_trigger() (which hands off to the rolling
+    # buffer), and the threshold/report count go in as arguments.
+    assert calls == [
+        ("connect", None),
+        ("configure_for_swing_speed_training", (45.0, 8)),
+    ]
+
+
+def test_disconnect_restores_rolling_buffer_mode(monkeypatch):
+    """Leaving swing speed mode should put the OPS back into launch-monitor mode."""
+    calls = []
+
+    class FakeRadar:
+        def __init__(self, port=None):
+            self.port = port
+
+        def restore_rolling_buffer_mode(self):
+            calls.append("restore_rolling_buffer_mode")
+
+        def disconnect(self):
+            calls.append("disconnect")
+
+    monkeypatch.setattr("openflight.swing_speed.OPS243Radar", FakeRadar)
+
+    monitor = SwingSpeedMonitor(port="COM4")
+    monitor.disconnect()
+
+    assert calls == ["restore_rolling_buffer_mode", "disconnect"]
+
+
+def test_select_swing_reading_uses_fastest_outbound_candidate():
+    """Swing speed should prefer the fastest outbound return, not the strongest one."""
+    monitor = SwingSpeedMonitor(trigger_threshold_mph=45.0)
+    readings = [
+        SpeedReading(
+            speed=56.0,
+            direction=Direction.OUTBOUND,
+            magnitude=1200.0,
+        ),
+        SpeedReading(
+            speed=103.0,
+            direction=Direction.OUTBOUND,
+            magnitude=180.0,
+        ),
+        SpeedReading(
+            speed=120.0,
+            direction=Direction.INBOUND,
+            magnitude=900.0,
+        ),
+    ]
+
+    selected = monitor._select_swing_reading(readings)  # pylint: disable=protected-access
+
+    assert selected is readings[1]
+
+
+def test_select_swing_reading_rejects_speeds_above_configured_max():
+    """Impossible high candidates from OPS multi-report mode should be ignored."""
+    monitor = SwingSpeedMonitor(trigger_threshold_mph=70.0, max_speed_mph=125.0)
+    readings = [
+        SpeedReading(
+            speed=143.4,
+            direction=Direction.OUTBOUND,
+            magnitude=90.0,
+        ),
+        SpeedReading(
+            speed=104.1,
+            direction=Direction.OUTBOUND,
+            magnitude=220.0,
+        ),
+    ]
+
+    selected = monitor._select_swing_reading(readings)  # pylint: disable=protected-access
+
+    assert selected is readings[1]

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,6 +5,7 @@ import { useSystemStore } from './stores/useSystemStore';
 import { useShotStore } from './stores/useShotStore';
 import { useCameraStore } from './stores/useCameraStore';
 import { useDebugStore } from './stores/useDebugStore';
+import { usePlayerStore } from './stores/usePlayerStore';
 import { socketService } from './services/socketService';
 import { ShotDisplay } from './components/ShotDisplay';
 import { StatsView } from './components/StatsView';
@@ -16,8 +17,11 @@ import { SimStatus } from './components/SimStatus';
 import { SimShotBadges } from './components/SimShotBadges';
 import { ClubPicker } from './components/ClubPicker';
 import { ClubSelectScreen } from './components/ClubSelectScreen';
+import { TrainingImplementPicker } from './components/TrainingImplementPicker';
+import { PlayerPicker } from './components/PlayerPicker';
 import { BallDetectionIndicator } from './components/BallDetectionIndicator';
 import { DisplayMode } from './components/DisplayMode';
+import { unlockAudioCue } from './utils/audioCue';
 import {
   useLaunchDaddy,
   LaunchDaddyOverlay,
@@ -85,6 +89,7 @@ function AppContent() {
     }))
   );
   const cameraStatus = useCameraStore((state) => state.cameraStatus);
+  const selectedPlayer = usePlayerStore((state) => state.selectedPlayer);
   const { debugReadings, debugShotLogs, radarConfig, triggerDiagnostics, triggerStatus } = useDebugStore(
     useShallow((state) => ({
       debugReadings: state.debugReadings,
@@ -97,6 +102,7 @@ function AppContent() {
 
   const [currentView, setCurrentView] = useState<View>('live');
   const [selectedClub, setSelectedClub] = useState('driver');
+  const [selectedTrainingImplement, setSelectedTrainingImplement] = useState('driver');
   // Reflect a server-pushed club change (e.g. the club changed in the connected
   // simulator) in the local picker, without echoing back to the server. Done
   // during render (React's "adjust state when an input changes" pattern) rather
@@ -114,6 +120,8 @@ function AppContent() {
   const { isLaunchDaddyMode, isExploding, triggerExplosion, handleSecretTap } = useLaunchDaddy();
   const { unitSystem, setUnitSystem } = useUnitPreference();
   const isDisplayRoute = typeof window !== 'undefined' && window.location.pathname.replace(/\/$/, '') === '/display';
+  const isSwingSpeedMode = triggerStatus.mode === 'swing-speed';
+
 
   // Trigger explosion when a new shot is detected in Launch Daddy mode
   useEffect(() => {
@@ -123,9 +131,25 @@ function AppContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- shotVersion triggers the effect; isNewShot is only a guard
   }, [shotVersion, isLaunchDaddyMode, triggerExplosion]);
 
+  useEffect(() => {
+    const unlock = () => unlockAudioCue();
+    window.addEventListener('pointerdown', unlock, { once: true });
+    window.addEventListener('keydown', unlock, { once: true });
+
+    return () => {
+      window.removeEventListener('pointerdown', unlock);
+      window.removeEventListener('keydown', unlock);
+    };
+  }, []);
+
   const handleClubChange = (club: string) => {
     setSelectedClub(club);
     socketService.setClub(club);
+  };
+
+  const handleTrainingImplementChange = (implement: string) => {
+    setSelectedTrainingImplement(implement);
+    socketService.setTrainingImplement(implement);
   };
 
   if (isDisplayRoute) {
@@ -188,7 +212,15 @@ function AppContent() {
               KMH/M
             </button>
           </div>
-          <ClubPicker selectedClub={selectedClub} onClubChange={handleClubChange} />
+          <PlayerPicker />
+          {isSwingSpeedMode ? (
+            <TrainingImplementPicker
+              selectedImplement={selectedTrainingImplement}
+              onImplementChange={handleTrainingImplementChange}
+            />
+          ) : (
+            <ClubPicker selectedClub={selectedClub} onClubChange={handleClubChange} />
+          )}
           <BallDetectionIndicator
             available={cameraStatus.available}
             enabled={cameraStatus.enabled}
@@ -283,17 +315,24 @@ function AppContent() {
         {currentView === 'live' && (
           <div className="live-view">
             {isNewShot && <div key={shotVersion} className="shot-flash" />}
-            <ShotDisplay key={shotVersion} shot={latestShot} animate={isNewShot} />
+            <ShotDisplay
+              key={shotVersion}
+              shot={latestShot}
+              shots={shots}
+              animate={isNewShot}
+              activePlayerName={selectedPlayer}
+              activeTrainingImplement={isSwingSpeedMode ? selectedTrainingImplement : undefined}
+            />
             {debugMode && <SimShotBadges latestSimShots={latestSimShots} />}
             {mockMode && (
               <button className="simulate-button" onClick={() => socketService.simulateShot()}>
-                Simulate Shot
+                {isSwingSpeedMode ? 'Simulate Swing' : 'Simulate Shot'}
               </button>
             )}
           </div>
         )}
         {currentView === 'stats' && <StatsView shots={shots} onClearSession={() => socketService.clearSession()} />}
-        {currentView === 'shots' && <ShotList shots={shots} />}
+        {currentView === 'shots' && <ShotList shots={shots} onDeleteShot={(timestamp) => socketService.deleteShot(timestamp)} />}
         {currentView === 'camera' && (
           <CameraFeed
             cameraStatus={cameraStatus}

--- a/ui/src/components/ClubPicker.css
+++ b/ui/src/components/ClubPicker.css
@@ -43,6 +43,13 @@
   font-size: 1.125rem;
 }
 
+.club-picker__value--player {
+  max-width: 7rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .club-picker__arrow {
   width: 14px;
   height: 14px;
@@ -90,6 +97,10 @@
   animation: dropdown-enter 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
+.club-picker__dropdown--player {
+  min-width: 280px;
+}
+
 @keyframes dropdown-enter {
   from {
     opacity: 0;
@@ -125,6 +136,21 @@
   gap: var(--space-xs);
 }
 
+.club-picker__grid--families {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.club-picker__section-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+}
+
+.club-picker__section-header .club-picker__section-title {
+  margin-bottom: 0;
+}
+
 .club-picker__option {
   padding: var(--space-sm);
   background: var(--color-bg-card);
@@ -153,6 +179,90 @@
   border-color: var(--color-gold);
   color: var(--color-gold);
   box-shadow: 0 0 12px rgba(212, 175, 55, 0.2);
+}
+
+.club-picker__option--family {
+  border-color: rgba(212, 175, 55, 0.18);
+  color: var(--color-gold);
+}
+
+.club-picker__player-list {
+  display: grid;
+  gap: var(--space-xs);
+}
+
+.club-picker__player-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-xs);
+}
+
+.club-picker__option--player {
+  min-height: 40px;
+  text-align: left;
+}
+
+.club-picker__remove,
+.club-picker__add {
+  min-height: 40px;
+  padding: 0 var(--space-sm);
+  background: transparent;
+  border: 1px solid rgba(245, 240, 230, 0.12);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.club-picker__remove:hover,
+.club-picker__add:hover {
+  color: var(--color-gold);
+  border-color: rgba(212, 175, 55, 0.35);
+}
+
+.club-picker__add-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-xs);
+  margin-top: var(--space-md);
+}
+
+.club-picker__input {
+  min-height: 40px;
+  min-width: 0;
+  padding: 0 var(--space-sm);
+  background: rgba(5, 5, 8, 0.45);
+  border: 1px solid rgba(245, 240, 230, 0.12);
+  border-radius: var(--radius-sm);
+  color: var(--color-cream);
+  font-size: 0.875rem;
+}
+
+.club-picker__input:focus {
+  outline: none;
+  border-color: rgba(212, 175, 55, 0.4);
+  box-shadow: 0 0 0 2px rgba(212, 175, 55, 0.12);
+}
+
+.club-picker__back {
+  padding: var(--space-xs) var(--space-sm);
+  background: transparent;
+  border: 1px solid rgba(245, 240, 230, 0.12);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.club-picker__back:hover {
+  color: var(--color-gold);
+  border-color: rgba(212, 175, 55, 0.35);
 }
 
 /* Responsive for 7" screen - bottom sheet style */

--- a/ui/src/components/DebugPanel.tsx
+++ b/ui/src/components/DebugPanel.tsx
@@ -294,6 +294,8 @@ export function DebugPanel({
 }: DebugPanelProps) {
   const [activeTab, setActiveTab] = useState<DebugTab>('status');
   const isRollingBuffer = triggerStatus.mode === 'rolling-buffer';
+  const isSwingSpeed = triggerStatus.mode === 'swing-speed';
+  const tuningDisabled = mockMode && !isSwingSpeed;
   const lastDiag = triggerDiagnostics.length > 0 ? triggerDiagnostics[triggerDiagnostics.length - 1] : null;
 
   // Show last 20 triggers, newest first
@@ -359,26 +361,54 @@ export function DebugPanel({
         {activeTab === 'tuning' && (
           <div className="debug-panel__section">
             <h4>Radar Tuning</h4>
-            {mockMode && <p className="debug-panel__mock-warning">Radar tuning disabled in mock mode</p>}
+            {tuningDisabled && <p className="debug-panel__mock-warning">Radar tuning disabled in mock mode</p>}
+            {mockMode && isSwingSpeed && (
+              <p className="debug-panel__mock-warning">Mock swing speed sliders shape simulated reps only</p>
+            )}
             <div className="debug-panel__controls">
-              <SliderControl
-                label="Min Speed"
-                value={radarConfig.min_speed}
-                min={0}
-                max={50}
-                unit=" mph"
-                disabled={mockMode}
-                onChange={(v) => onUpdateConfig({ min_speed: v })}
-              />
-              <SliderControl
-                label="Min Magnitude"
-                value={radarConfig.min_magnitude}
-                min={0}
-                max={2000}
-                step={50}
-                disabled={mockMode}
-                onChange={(v) => onUpdateConfig({ min_magnitude: v })}
-              />
+              {isSwingSpeed ? (
+                <>
+                  <SliderControl
+                    label="Lower Speed"
+                    value={radarConfig.min_speed}
+                    min={30}
+                    max={100}
+                    unit=" mph"
+                    disabled={false}
+                    onChange={(v) => onUpdateConfig({ min_speed: v })}
+                  />
+                  <SliderControl
+                    label="Upper Speed"
+                    value={radarConfig.max_speed}
+                    min={90}
+                    max={170}
+                    unit=" mph"
+                    disabled={false}
+                    onChange={(v) => onUpdateConfig({ max_speed: v })}
+                  />
+                </>
+              ) : (
+                <>
+                  <SliderControl
+                    label="Min Speed"
+                    value={radarConfig.min_speed}
+                    min={0}
+                    max={50}
+                    unit=" mph"
+                    disabled={tuningDisabled}
+                    onChange={(v) => onUpdateConfig({ min_speed: v })}
+                  />
+                  <SliderControl
+                    label="Min Magnitude"
+                    value={radarConfig.min_magnitude}
+                    min={0}
+                    max={2000}
+                    step={50}
+                    disabled={tuningDisabled}
+                    onChange={(v) => onUpdateConfig({ min_magnitude: v })}
+                  />
+                </>
+              )}
               <SliderControl
                 label="TX Power"
                 value={radarConfig.transmit_power}
@@ -388,7 +418,11 @@ export function DebugPanel({
                 onChange={(v) => onUpdateConfig({ transmit_power: v })}
               />
             </div>
-            <p className="debug-panel__hint">TX Power: 0 = max range, 7 = min range</p>
+            <p className="debug-panel__hint">
+              {isSwingSpeed
+                ? 'Lower speed updates the OPS filter; upper speed rejects implausible high swing-speed outliers.'
+                : 'TX Power: 0 = max range, 7 = min range'}
+            </p>
           </div>
         )}
       </div>

--- a/ui/src/components/DisplayMode.tsx
+++ b/ui/src/components/DisplayMode.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { CameraStatus } from '../stores/useCameraStore';
 import type { Shot } from '../types/shot';
+import { computeSwingSpeedStats, getSwingSpeedMph, isSwingSpeedShot } from '../types/shot';
 import { useUnitPreference } from '../state/useUnitPreference';
 import { formatDistance, formatSpeed, getDistanceUnit, getSpeedUnit } from '../utils/units';
 import { getServerOrigin } from '../utils/serverOrigin';
@@ -118,7 +119,29 @@ function DisplayMetricCard({ metric, featured = false }: { metric: DisplayMetric
 export function DisplayMode({ connected, cameraStatus, latestShot, shots }: DisplayModeProps) {
   const [failedCameraKey, setFailedCameraKey] = useState<string | null>(null);
   const { unitSystem } = useUnitPreference();
-  const metrics = buildMetrics(latestShot, unitSystem);
+  const isSwingSpeedSession = latestShot ? isSwingSpeedShot(latestShot) : false;
+  const swingStats = computeSwingSpeedStats(shots);
+  const metrics = isSwingSpeedSession
+    ? [
+        {
+          label: 'Last Swing',
+          value: formatSpeed(swingStats.last_speed_mph, unitSystem, 1),
+          unit: getSpeedUnit(unitSystem),
+        },
+        {
+          label: 'Best',
+          value: formatSpeed(swingStats.best_speed_mph, unitSystem, 1),
+          unit: getSpeedUnit(unitSystem),
+          detail: 'this session',
+        },
+        {
+          label: 'Average',
+          value: formatSpeed(swingStats.avg_speed_mph, unitSystem, 1),
+          unit: getSpeedUnit(unitSystem),
+        },
+        { label: 'Swings', value: String(swingStats.count) },
+      ]
+    : buildMetrics(latestShot, unitSystem);
   const recentShots = shots.slice(-RECENT_SHOT_COUNT).reverse();
   const cameraKey = `${cameraStatus.available}-${cameraStatus.streaming}`;
   const cameraError = failedCameraKey === cameraKey;
@@ -158,7 +181,7 @@ export function DisplayMode({ connected, cameraStatus, latestShot, shots }: Disp
 
         <div className="display-mode__shot-panel">
           <div className="display-mode__eyebrow">OpenFlight Display</div>
-          <h1 className="display-mode__title">{latestShot ? latestShot.club : 'Ready'}</h1>
+          <h1 className="display-mode__title">{isSwingSpeedSession ? 'Swing Speed' : latestShot ? latestShot.club : 'Ready'}</h1>
           <div className="display-mode__primary-grid">
             <DisplayMetricCard metric={metrics[0]} featured />
             <DisplayMetricCard metric={metrics[1]} featured />
@@ -178,14 +201,19 @@ export function DisplayMode({ connected, cameraStatus, latestShot, shots }: Disp
           recentShots.map((shot, index) => (
             <div className="display-shot-chip" key={shot.timestamp}>
               <span className="display-shot-chip__number">#{shots.length - index}</span>
-              <span className="display-shot-chip__club">{shot.club}</span>
-              <span className="display-shot-chip__stat">
-                {formatSpeed(shot.ball_speed_mph, unitSystem, 0)} {getSpeedUnit(unitSystem)}
+              <span className="display-shot-chip__club">
+                {isSwingSpeedShot(shot) ? shot.training_implement_label ?? shot.club : shot.club}
               </span>
               <span className="display-shot-chip__stat">
-                {formatDistance(shot.carry_spin_adjusted ?? shot.estimated_carry_yards, unitSystem, 0)}{' '}
-                {getDistanceUnit(unitSystem)}
+                {formatSpeed(isSwingSpeedShot(shot) ? getSwingSpeedMph(shot) : shot.ball_speed_mph, unitSystem, 0)}{' '}
+                {getSpeedUnit(unitSystem)}
               </span>
+              {!isSwingSpeedShot(shot) && (
+                <span className="display-shot-chip__stat">
+                  {formatDistance(shot.carry_spin_adjusted ?? shot.estimated_carry_yards, unitSystem, 0)}{' '}
+                  {getDistanceUnit(unitSystem)}
+                </span>
+              )}
             </div>
           ))
         )}

--- a/ui/src/components/PlayerPicker.tsx
+++ b/ui/src/components/PlayerPicker.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import { usePlayerStore } from '../stores/usePlayerStore';
+import { useSystemStore } from '../stores/useSystemStore';
+import { socketService } from '../services/socketService';
+import './ClubPicker.css';
+
+export function PlayerPicker() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [newPlayer, setNewPlayer] = useState('');
+  const { players, selectedPlayer, addPlayer, removePlayer, selectPlayer } = usePlayerStore();
+  const connected = useSystemStore((state) => state.connected);
+  const serverPlayerName = useSystemStore((state) => state.serverPlayerName);
+
+  useEffect(() => {
+    if (connected) {
+      socketService.setPlayer(selectedPlayer);
+    }
+  }, [connected, selectedPlayer]);
+
+  useEffect(() => {
+    if (serverPlayerName && serverPlayerName !== selectedPlayer) {
+      selectPlayer(serverPlayerName);
+    }
+  }, [serverPlayerName, selectedPlayer, selectPlayer]);
+
+  const handleSelect = (playerName: string) => {
+    selectPlayer(playerName);
+    socketService.setPlayer(playerName);
+    setIsOpen(false);
+  };
+
+  const handleAdd = () => {
+    const playerName = addPlayer(newPlayer);
+    socketService.setPlayer(playerName);
+    setNewPlayer('');
+    setIsOpen(false);
+  };
+
+  const handleRemove = (playerName: string) => {
+    removePlayer(playerName);
+    if (playerName === selectedPlayer) {
+      const nextPlayer = players.find((player) => player !== playerName) ?? 'Player 1';
+      socketService.setPlayer(nextPlayer);
+    }
+  };
+
+  return (
+    <div className="club-picker club-picker--player">
+      <button className="club-picker__trigger" onClick={() => setIsOpen(!isOpen)} aria-expanded={isOpen}>
+        <span className="club-picker__label">Player</span>
+        <span className="club-picker__value club-picker__value--player">{selectedPlayer}</span>
+        <svg
+          className={`club-picker__arrow ${isOpen ? 'club-picker__arrow--open' : ''}`}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <>
+          <div className="club-picker__overlay" onClick={() => setIsOpen(false)} />
+          <div className="club-picker__dropdown club-picker__dropdown--player">
+            <div className="club-picker__section">
+              <span className="club-picker__section-title">Players</span>
+              <div className="club-picker__player-list">
+                {players.map((playerName) => (
+                  <div className="club-picker__player-row" key={playerName}>
+                    <button
+                      className={`club-picker__option club-picker__option--player ${
+                        selectedPlayer === playerName ? 'club-picker__option--selected' : ''
+                      }`}
+                      onClick={() => handleSelect(playerName)}
+                    >
+                      {playerName}
+                    </button>
+                    {players.length > 1 && (
+                      <button
+                        className="club-picker__remove"
+                        type="button"
+                        aria-label={`Remove ${playerName}`}
+                        title="Remove"
+                        onClick={() => handleRemove(playerName)}
+                      >
+                        X
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="club-picker__add-row">
+              <input
+                className="club-picker__input"
+                type="text"
+                placeholder="Add player"
+                value={newPlayer}
+                maxLength={40}
+                onChange={(event) => setNewPlayer(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    handleAdd();
+                  }
+                }}
+              />
+              <button className="club-picker__add" type="button" onClick={handleAdd}>
+                Add
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/ShotDisplay.css
+++ b/ui/src/components/ShotDisplay.css
@@ -69,6 +69,18 @@
   flex: 1.2;
 }
 
+.shot-display--swing-speed {
+  border-color: rgba(212, 175, 55, 0.22);
+}
+
+.shot-display--swing-speed .shot-display__primary {
+  flex: 1;
+}
+
+.shot-display__metrics--swing-speed {
+  flex: 1;
+}
+
 /* Speed Gauge */
 .speed-gauge {
   position: relative;

--- a/ui/src/components/ShotDisplay.tsx
+++ b/ui/src/components/ShotDisplay.tsx
@@ -1,12 +1,16 @@
 import { useMemo } from 'react';
 import type { Shot, SpinQuality } from '../types/shot';
+import { computeSwingSpeedStats, getSwingSpeedMph, isSwingSpeedShot } from '../types/shot';
 import { useUnitPreference } from '../state/useUnitPreference';
 import { formatCarryRange, formatDistance, formatSpeed, getDistanceUnit, getSpeedUnit } from '../utils/units';
 import './ShotDisplay.css';
 
 interface ShotDisplayProps {
   shot: Shot | null;
+  shots?: Shot[];
   animate?: boolean;
+  activePlayerName?: string;
+  activeTrainingImplement?: string;
 }
 
 const GAUGE_MIN = 0;
@@ -128,12 +132,26 @@ function getLaunchAngleQuality(confidence: number | null): 'high' | 'medium' | '
   return 'low';
 }
 
-export function ShotDisplay({ shot, animate = false }: ShotDisplayProps) {
+export function ShotDisplay({
+  shot,
+  shots = [],
+  animate = false,
+  activePlayerName,
+  activeTrainingImplement,
+}: ShotDisplayProps) {
   const { unitSystem } = useUnitPreference();
   const carryRange = useMemo(() => {
     if (!shot) return null;
     return formatCarryRange(shot.carry_range, unitSystem);
   }, [shot, unitSystem]);
+  const swingStats = useMemo(
+    () =>
+      computeSwingSpeedStats(shots, {
+        playerName: activePlayerName,
+        trainingImplement: activeTrainingImplement,
+      }),
+    [shots, activePlayerName, activeTrainingImplement]
+  );
 
   const displayCarry = shot?.carry_spin_adjusted ?? shot?.estimated_carry_yards ?? 0;
   const carrySubtext = shot?.carry_spin_adjusted ? 'spin-adjusted' : carryRange || undefined;
@@ -150,8 +168,57 @@ export function ShotDisplay({ shot, animate = false }: ShotDisplayProps) {
             </div>
             <div className="golf-ball-indicator__shadow" />
           </div>
-          <p className="shot-display__waiting-text">Ready for your shot</p>
-          <p className="shot-display__waiting-hint">Position ball in front of radar</p>
+          <p className="shot-display__waiting-text">Ready</p>
+          <p className="shot-display__waiting-hint">Start a shot or swing speed session</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isSwingSpeedShot(shot)) {
+    const lastSpeed = getSwingSpeedMph(shot);
+    const readingDetail =
+      shot.swing_speed_reading_count !== undefined ? `${shot.swing_speed_reading_count} radar readings` : undefined;
+
+    return (
+      <div className={`shot-display shot-display--swing-speed ${animate ? 'shot-display--animate' : ''}`}>
+        <div className="shot-display__layout">
+          <div className="shot-display__primary">
+            <SpeedGauge
+              speedMph={lastSpeed}
+              label="Last Swing"
+              displayValue={formatSpeed(lastSpeed, unitSystem, 1)}
+              unit={getSpeedUnit(unitSystem)}
+            />
+          </div>
+
+          <div className="shot-display__metrics shot-display__metrics--swing-speed">
+            <MetricCard
+              value={formatSpeed(swingStats.best_speed_mph, unitSystem, 1)}
+              unit={getSpeedUnit(unitSystem)}
+              label="Best"
+              subtext="player + implement"
+              variant="primary"
+            />
+            <MetricCard
+              value={formatSpeed(swingStats.avg_speed_mph, unitSystem, 1)}
+              unit={getSpeedUnit(unitSystem)}
+              label="Average"
+              subtext={`${swingStats.count} swings`}
+              variant="secondary"
+            />
+            <MetricCard value={swingStats.count} label="Swing Count" subtext={readingDetail} variant="secondary" />
+            <MetricCard
+              value={shot.training_implement_label ?? shot.club}
+              label="Implement"
+              subtext={
+                shot.swing_speed_trigger_mph !== undefined
+                  ? `${formatSpeed(shot.swing_speed_trigger_mph, unitSystem, 1)} ${getSpeedUnit(unitSystem)} trigger`
+                  : 'selected'
+              }
+              variant="secondary"
+            />
+          </div>
         </div>
       </div>
     );

--- a/ui/src/components/ShotList.css
+++ b/ui/src/components/ShotList.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  gap: var(--space-sm);
 }
 
 .shot-list--empty {
@@ -13,11 +14,90 @@
   font-size: 1rem;
 }
 
+.shot-list__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  background: rgba(245, 240, 230, 0.03);
+  border: 1px solid rgba(245, 240, 230, 0.08);
+  border-radius: var(--radius-md);
+  flex-shrink: 0;
+}
+
+.shot-list__title,
+.shot-list__subtitle {
+  display: block;
+}
+
+.shot-list__title {
+  color: var(--color-cream);
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.shot-list__subtitle {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  margin-top: 2px;
+}
+
+.shot-list__export {
+  padding: var(--space-sm) var(--space-md);
+  background: rgba(212, 175, 55, 0.1);
+  border: 1px solid rgba(212, 175, 55, 0.25);
+  border-radius: var(--radius-sm);
+  color: var(--color-gold);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  min-height: 38px;
+}
+
+.shot-list__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-shrink: 0;
+}
+
+.shot-list__export:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
+.shot-list__export:active {
+  transform: scale(0.97);
+}
+
 .shot-list__rows {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
   flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding-right: var(--space-xs);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(212, 175, 55, 0.45) transparent;
+}
+
+.shot-list__rows::-webkit-scrollbar {
+  width: 8px;
+}
+
+.shot-list__rows::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.shot-list__rows::-webkit-scrollbar-thumb {
+  background: rgba(212, 175, 55, 0.35);
+  border-radius: var(--radius-sm);
 }
 
 /* Shot Row */
@@ -38,6 +118,26 @@
   border-color: rgba(212, 175, 55, 0.15);
 }
 
+.shot-row--swing-speed {
+  border-color: rgba(212, 175, 55, 0.16);
+  background: linear-gradient(90deg, rgba(212, 175, 55, 0.08), var(--color-bg-card));
+}
+
+.shot-row--validation {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-sm);
+  min-height: 126px;
+}
+
+.shot-row__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
 .shot-row__number {
   font-family: var(--font-body);
   font-size: 0.875rem;
@@ -56,6 +156,24 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   min-width: 3.5rem;
+  text-align: center;
+}
+
+.shot-row__player {
+  max-width: 7rem;
+  min-width: 4rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-cream);
+  background: rgba(96, 165, 250, 0.12);
+  border: 1px solid rgba(96, 165, 250, 0.22);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-sm);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   text-align: center;
 }
 
@@ -94,50 +212,93 @@
   color: var(--color-gold);
 }
 
-/* Pagination */
-.pagination {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-md);
-  padding-top: var(--space-md);
+.shot-row__delete {
   flex-shrink: 0;
-}
-
-.pagination__button {
-  padding: var(--space-sm) var(--space-lg);
+  padding: var(--space-xs) var(--space-sm);
   background: transparent;
-  border: 1px solid rgba(212, 175, 55, 0.25);
+  border: 1px solid rgba(245, 240, 230, 0.12);
   border-radius: var(--radius-sm);
-  color: var(--color-gold);
-  font-size: 0.8125rem;
+  color: var(--text-muted);
+  font-size: 0.6875rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   cursor: pointer;
   transition: all var(--transition-smooth);
-  min-height: 42px;
-  min-width: 80px;
+  min-height: 34px;
+  min-width: 64px;
   touch-action: manipulation;
 }
 
-.pagination__button:active:not(:disabled) {
+.shot-row__delete:hover {
+  color: var(--color-gold);
+  border-color: rgba(212, 175, 55, 0.35);
+  background: rgba(212, 175, 55, 0.08);
+}
+
+.shot-row__delete:active {
   transform: scale(0.95);
   background: rgba(212, 175, 55, 0.1);
 }
 
-.pagination__button:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
-  color: var(--text-muted);
-  border-color: rgba(245, 240, 230, 0.1);
+.shot-row__validation {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) minmax(90px, 0.55fr) minmax(62px, 0.35fr) minmax(220px, 1.35fr);
+  gap: var(--space-sm);
+  align-items: end;
+  padding-top: var(--space-xs);
+  border-top: 1px solid rgba(245, 240, 230, 0.06);
 }
 
-.pagination__info {
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: var(--text-secondary);
-  min-width: 3rem;
-  text-align: center;
+.validation-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.validation-field span,
+.validation-diff__label {
+  color: var(--text-muted);
+  font-size: 0.5625rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.validation-field input,
+.validation-field select {
+  width: 100%;
+  height: 34px;
+  min-height: 34px;
+  padding: 0 var(--space-sm);
+  background: rgba(0, 0, 0, 0.18);
+  border: 1px solid rgba(245, 240, 230, 0.1);
+  border-radius: var(--radius-sm);
+  color: var(--color-cream);
+  font-size: 0.875rem;
+}
+
+.validation-field input:focus,
+.validation-field select:focus {
+  outline: none;
+  border-color: rgba(212, 175, 55, 0.45);
+}
+
+.validation-diff {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 34px;
+  min-height: 34px;
+}
+
+.validation-diff__value {
+  color: var(--color-gold);
+  font-family: var(--font-display);
+  font-size: 1.125rem;
+  line-height: 1;
 }
 
 /* Landscape 7" screen (800x480) */
@@ -147,8 +308,12 @@
   }
 
   .shot-row {
-    padding: var(--space-sm) var(--space-md);
+    padding: 0.45rem var(--space-md);
     min-height: 50px;
+  }
+
+  .shot-list__toolbar {
+    padding: var(--space-xs) var(--space-sm);
   }
 
   .shot-row__number {
@@ -159,6 +324,13 @@
   .shot-row__club {
     font-size: 0.6875rem;
     min-width: 3rem;
+    padding: 2px var(--space-xs);
+  }
+
+  .shot-row__player {
+    max-width: 5.5rem;
+    min-width: 3.25rem;
+    font-size: 0.625rem;
     padding: 2px var(--space-xs);
   }
 
@@ -174,15 +346,41 @@
     max-width: 4rem;
   }
 
-  .pagination {
-    padding-top: var(--space-sm);
-    gap: var(--space-sm);
+  .shot-row__delete {
+    min-height: 32px;
+    min-width: 58px;
+    font-size: 0.75rem;
   }
 
-  .pagination__button {
-    padding: var(--space-xs) var(--space-md);
-    min-height: 38px;
-    min-width: 70px;
+  .shot-row--validation {
+    gap: 0.35rem;
+    min-height: 104px;
+  }
+
+  .shot-row__validation {
+    grid-template-columns: minmax(170px, 1fr) minmax(76px, 0.48fr) minmax(52px, 0.32fr) minmax(170px, 1.05fr);
+    gap: var(--space-xs);
+  }
+
+  .validation-field span,
+  .validation-diff__label {
+    font-size: 0.5rem;
+  }
+
+  .validation-field input,
+  .validation-field select {
+    height: 26px;
+    min-height: 26px;
+    padding: 0 var(--space-xs);
     font-size: 0.75rem;
+  }
+
+  .validation-diff {
+    height: 26px;
+    min-height: 26px;
+  }
+
+  .validation-diff__value {
+    font-size: 0.95rem;
   }
 }

--- a/ui/src/components/ShotList.tsx
+++ b/ui/src/components/ShotList.tsx
@@ -1,14 +1,18 @@
-import { useMemo, useState, memo } from 'react';
+import { useMemo, memo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import type { Shot } from '../types/shot';
+import { getSwingSpeedMph, isSwingSpeedShot } from '../types/shot';
 import { useUnitPreference } from '../state/useUnitPreference';
+import { socketService } from '../services/socketService';
+import { useSystemStore } from '../stores/useSystemStore';
+import { getEmptyValidationEntry, useValidationStore, type ValidationEntry } from '../stores/useValidationStore';
 import type { UnitSystem } from '../utils/units';
 import { formatDistance, formatSpeed, getDistanceUnit } from '../utils/units';
 import './ShotList.css';
 
-const SHOTS_PER_PAGE = 5;
-
 interface ShotListProps {
   shots: Shot[];
+  onDeleteShot: (timestamp: string) => void;
 }
 
 interface ShotRowProps {
@@ -16,12 +20,187 @@ interface ShotRowProps {
   shotNumber: number;
   unitSystem: UnitSystem;
   distanceUnit: string;
+  onDeleteShot: (timestamp: string) => void;
+  validation: ValidationEntry;
+  onUpdateValidation: (timestamp: string, patch: Partial<ValidationEntry>) => void;
 }
 
-const ShotRow = memo(function ShotRow({ shot, shotNumber, unitSystem, distanceUnit }: ShotRowProps) {
+function csvValue(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return '';
+  const text = String(value);
+  return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+function buildValidationCsv(shots: Shot[], entries: Record<string, ValidationEntry>): string {
+  const headers = [
+    'shot_number',
+    'timestamp',
+    'player',
+    'mode',
+    'implement',
+    'openflight_speed_mph',
+    'comparator_device',
+    'comparator_speed_mph',
+    'difference_mph',
+    'reading_count',
+    'trigger_speed_mph',
+    'duration_ms',
+    'peak_magnitude',
+    'notes',
+  ];
+
+  const rows = shots.map((shot, index) => {
+    const validation = entries[shot.timestamp] ?? getEmptyValidationEntry();
+    const comparatorSpeed = Number.parseFloat(validation.comparatorSpeed);
+    const openflightSpeed = isSwingSpeedShot(shot) ? getSwingSpeedMph(shot) : shot.ball_speed_mph;
+    const difference = Number.isFinite(comparatorSpeed) ? openflightSpeed - comparatorSpeed : null;
+
+    return [
+      index + 1,
+      shot.timestamp,
+      shot.player_name ?? '',
+      shot.mode ?? '',
+      shot.training_implement_label ?? shot.club,
+      openflightSpeed.toFixed(1),
+      validation.comparatorDevice,
+      validation.comparatorSpeed,
+      difference === null ? '' : difference.toFixed(1),
+      shot.swing_speed_reading_count ?? '',
+      shot.swing_speed_trigger_mph ?? '',
+      shot.swing_speed_duration_ms ?? '',
+      shot.peak_magnitude ?? '',
+      validation.notes,
+    ].map(csvValue);
+  });
+
+  return [headers.map(csvValue), ...rows].map((row) => row.join(',')).join('\n');
+}
+
+function downloadCsv(filename: string, content: string) {
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+const DeleteButton = ({ shot, onDeleteShot }: Pick<ShotRowProps, 'shot' | 'onDeleteShot'>) => (
+  <button
+    className="shot-row__delete"
+    type="button"
+    aria-label={`Delete shot ${shot.timestamp}`}
+    title="Delete"
+    onClick={() => onDeleteShot(shot.timestamp)}
+  >
+    Delete
+  </button>
+);
+
+const ShotRow = memo(function ShotRow({
+  shot,
+  shotNumber,
+  unitSystem,
+  distanceUnit,
+  onDeleteShot,
+  validation,
+  onUpdateValidation,
+}: ShotRowProps) {
+  if (isSwingSpeedShot(shot)) {
+    const implementLabel = shot.training_implement_label ?? shot.club;
+    const comparatorSpeed = Number.parseFloat(validation.comparatorSpeed);
+    const difference = Number.isFinite(comparatorSpeed) ? getSwingSpeedMph(shot) - comparatorSpeed : null;
+
+    return (
+      <div className="shot-row shot-row--swing-speed shot-row--validation">
+        <div className="shot-row__summary">
+          <span className="shot-row__number">#{shotNumber}</span>
+          <span className="shot-row__player">{shot.player_name ?? 'Player 1'}</span>
+          <span className="shot-row__club">{implementLabel}</span>
+          <span className="shot-row__stat">
+            <span className="shot-row__value">{formatSpeed(getSwingSpeedMph(shot), unitSystem, 1)}</span>
+            <span className="shot-row__label">speed</span>
+          </span>
+          <span className="shot-row__stat">
+            <span className="shot-row__value">{shot.swing_speed_reading_count ?? '--'}</span>
+            <span className="shot-row__label">reads</span>
+          </span>
+          <span className="shot-row__stat">
+            <span className="shot-row__value">
+              {shot.swing_speed_trigger_mph !== undefined ? formatSpeed(shot.swing_speed_trigger_mph, unitSystem, 1) : '--'}
+            </span>
+            <span className="shot-row__label">trigger</span>
+          </span>
+          <span className="shot-row__stat shot-row__stat--carry">
+            <span className="shot-row__value">
+              {shot.swing_speed_duration_ms !== undefined ? `${Math.round(shot.swing_speed_duration_ms)}` : '--'}
+            </span>
+            <span className="shot-row__label">ms</span>
+          </span>
+          <DeleteButton shot={shot} onDeleteShot={onDeleteShot} />
+        </div>
+        <div className="shot-row__validation">
+          <label className="validation-field">
+            <span>Device</span>
+            <select
+              value={validation.comparatorDevice}
+              onChange={(event) => onUpdateValidation(shot.timestamp, { comparatorDevice: event.target.value })}
+            >
+              <option value="">Device</option>
+              <option value="Stack Radar">Stack Radar</option>
+              <option value="PRGR">PRGR</option>
+              <option value="TrackMan">TrackMan</option>
+              <option value="Full Swing">Full Swing</option>
+              <option value="Other">Other</option>
+            </select>
+          </label>
+          <label className="validation-field validation-field--speed">
+            <span>Speed</span>
+            <input
+              type="number"
+              inputMode="decimal"
+              min="0"
+              step="0.1"
+              placeholder="mph"
+              value={validation.comparatorSpeed}
+              onChange={(event) => onUpdateValidation(shot.timestamp, { comparatorSpeed: event.target.value })}
+            />
+          </label>
+          <div className="validation-diff">
+            <span className="validation-diff__value">{difference === null ? '--' : `${difference >= 0 ? '+' : ''}${difference.toFixed(1)}`}</span>
+            <span className="validation-diff__label">diff</span>
+          </div>
+          <label className="validation-field validation-field--notes">
+            <span>Notes</span>
+            <input
+              type="text"
+              placeholder="notes..."
+              value={validation.notes}
+              onChange={(event) => onUpdateValidation(shot.timestamp, { notes: event.target.value })}
+            />
+          </label>
+        </div>
+      </div>
+    );
+  }
+
+  const launchAngle = isNumber(shot.launch_angle_vertical) ? `${shot.launch_angle_vertical.toFixed(1)}°` : '--';
+  const spinRate = isNumber(shot.spin_rpm)
+    ? shot.spin_rpm.toLocaleString('en-US', { maximumFractionDigits: 0 })
+    : '--';
+  const carryDistance = isNumber(shot.estimated_carry_yards)
+    ? formatDistance(shot.estimated_carry_yards, unitSystem, 0)
+    : '--';
+
   return (
     <div className="shot-row">
       <span className="shot-row__number">#{shotNumber}</span>
+      <span className="shot-row__player">{shot.player_name ?? 'Player 1'}</span>
       <span className="shot-row__club">{shot.club}</span>
       <span className="shot-row__stat">
         <span className="shot-row__value">{formatSpeed(shot.ball_speed_mph, unitSystem, 1)}</span>
@@ -34,39 +213,49 @@ const ShotRow = memo(function ShotRow({ shot, shotNumber, unitSystem, distanceUn
         <span className="shot-row__label">club</span>
       </span>
       <span className="shot-row__stat">
-        <span className="shot-row__value">
-          {shot.launch_angle_vertical !== null ? `${shot.launch_angle_vertical.toFixed(1)}°` : '—'}
-        </span>
+        <span className="shot-row__value">{launchAngle}</span>
         <span className="shot-row__label">launch</span>
       </span>
       <span className="shot-row__stat">
-        <span className="shot-row__value">
-          {shot.spin_rpm !== null ? shot.spin_rpm.toLocaleString('en-US', { maximumFractionDigits: 0 }) : '—'}
-        </span>
+        <span className="shot-row__value">{spinRate}</span>
         <span className="shot-row__label">spin</span>
       </span>
       <span className="shot-row__stat shot-row__stat--carry">
-        <span className="shot-row__value">{formatDistance(shot.estimated_carry_yards, unitSystem, 0)}</span>
+        <span className="shot-row__value">{carryDistance}</span>
         <span className="shot-row__label">{distanceUnit}</span>
       </span>
+      <DeleteButton shot={shot} onDeleteShot={onDeleteShot} />
     </div>
   );
 });
 
-export function ShotList({ shots }: ShotListProps) {
-  const [page, setPage] = useState(0);
+export function ShotList({ shots, onDeleteShot }: ShotListProps) {
   const { unitSystem } = useUnitPreference();
   const distanceUnit = getDistanceUnit(unitSystem);
+  const { entries, updateEntry, removeEntry } = useValidationStore();
+  const { cloudUploadState, cloudUploadMessage } = useSystemStore(
+    useShallow((state) => ({
+      cloudUploadState: state.cloudUploadState,
+      cloudUploadMessage: state.cloudUploadMessage,
+    }))
+  );
 
-  const totalPages = Math.ceil(shots.length / SHOTS_PER_PAGE);
+  const visibleShots = useMemo(() => [...shots].reverse(), [shots]);
+  const validationCount = useMemo(
+    () => shots.filter((shot) => entries[shot.timestamp]?.comparatorSpeed).length,
+    [entries, shots]
+  );
 
-  const pageShots = useMemo(() => {
-    const reversed = [...shots].reverse();
-    const startIndex = page * SHOTS_PER_PAGE;
-    return reversed.slice(startIndex, startIndex + SHOTS_PER_PAGE);
-  }, [shots, page]);
+  const handleExport = () => {
+    const csv = buildValidationCsv(shots, entries);
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    downloadCsv(`openflight-validation-${stamp}.csv`, csv);
+  };
 
-  const startIndex = page * SHOTS_PER_PAGE;
+  const handleDeleteShot = (timestamp: string) => {
+    removeEntry(timestamp);
+    onDeleteShot(timestamp);
+  };
 
   if (shots.length === 0) {
     return (
@@ -78,39 +267,36 @@ export function ShotList({ shots }: ShotListProps) {
 
   return (
     <div className="shot-list">
+      <div className="shot-list__toolbar">
+        <div>
+          <span className="shot-list__title">Validation</span>
+          <span className="shot-list__subtitle">
+            {cloudUploadMessage || `${validationCount} / ${shots.length} comparator speeds entered`}
+          </span>
+        </div>
+        <div className="shot-list__actions">
+          <button className="shot-list__export" onClick={() => socketService.uploadCloud()} disabled={cloudUploadState === 'running'}>
+            {cloudUploadState === 'running' ? 'Uploading' : 'Upload Cloud'}
+          </button>
+          <button className="shot-list__export" onClick={handleExport}>
+            Export CSV
+          </button>
+        </div>
+      </div>
       <div className="shot-list__rows">
-        {pageShots.map((shot, index) => (
+        {visibleShots.map((shot, index) => (
           <ShotRow
-            key={shot.timestamp}
+            key={`${shot.timestamp}-${index}`}
             shot={shot}
-            shotNumber={shots.length - startIndex - index}
+            shotNumber={shots.length - index}
             unitSystem={unitSystem}
             distanceUnit={distanceUnit}
+            onDeleteShot={handleDeleteShot}
+            validation={entries[shot.timestamp] ?? getEmptyValidationEntry()}
+            onUpdateValidation={updateEntry}
           />
         ))}
       </div>
-
-      {totalPages > 1 && (
-        <div className="pagination">
-          <button
-            className="pagination__button"
-            onClick={() => setPage((p) => Math.max(0, p - 1))}
-            disabled={page === 0}
-          >
-            Prev
-          </button>
-          <span className="pagination__info">
-            {page + 1} / {totalPages}
-          </span>
-          <button
-            className="pagination__button"
-            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-            disabled={page === totalPages - 1}
-          >
-            Next
-          </button>
-        </div>
-      )}
     </div>
   );
 }

--- a/ui/src/components/StatsView.css
+++ b/ui/src/components/StatsView.css
@@ -54,6 +54,10 @@
   flex: 1;
 }
 
+.stats-grid--swing-speed {
+  grid-template-columns: repeat(4, 1fr);
+}
+
 .stat-card {
   display: flex;
   flex-direction: column;
@@ -130,6 +134,10 @@
 
   .stats-grid {
     gap: var(--space-xs);
+  }
+
+  .stats-grid--swing-speed {
+    grid-template-columns: repeat(2, 1fr);
   }
 
   .stat-card {

--- a/ui/src/components/StatsView.tsx
+++ b/ui/src/components/StatsView.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useUnitPreference } from '../state/useUnitPreference';
 import type { Shot } from '../types/shot';
-import { computeStats, getUniqueClubs } from '../types/shot';
+import { computeStats, computeSwingSpeedStats, getUniqueClubs, isSwingSpeedShot } from '../types/shot';
 import { formatDistance, formatSpeed, getDistanceUnit, getSpeedUnit } from '../utils/units';
 import './StatsView.css';
 
@@ -32,6 +32,8 @@ export function StatsView({ shots, onClearSession }: StatsViewProps) {
   }, [shots, selectedClub]);
 
   const stats = useMemo(() => computeStats(filteredShots), [filteredShots]);
+  const isSwingSpeedSession = filteredShots.length > 0 && filteredShots.every(isSwingSpeedShot);
+  const swingStats = useMemo(() => computeSwingSpeedStats(filteredShots), [filteredShots]);
 
   if (shots.length === 0) {
     return (
@@ -61,7 +63,27 @@ export function StatsView({ shots, onClearSession }: StatsViewProps) {
         ))}
       </div>
 
-      <div className="stats-grid">
+      {isSwingSpeedSession ? (
+        <div className="stats-grid stats-grid--swing-speed">
+          <div className="stat-card">
+            <span className="stat-card__value">{swingStats.count}</span>
+            <span className="stat-card__label">Swings</span>
+          </div>
+          <div className="stat-card stat-card--primary">
+            <span className="stat-card__value">{formatSpeed(swingStats.last_speed_mph, unitSystem, 1)}</span>
+            <span className="stat-card__label">Last ({speedUnit})</span>
+          </div>
+          <div className="stat-card stat-card--primary">
+            <span className="stat-card__value">{formatSpeed(swingStats.best_speed_mph, unitSystem, 1)}</span>
+            <span className="stat-card__label">Best ({speedUnit})</span>
+          </div>
+          <div className="stat-card">
+            <span className="stat-card__value">{formatSpeed(swingStats.avg_speed_mph, unitSystem, 1)}</span>
+            <span className="stat-card__label">Average ({speedUnit})</span>
+          </div>
+        </div>
+      ) : (
+        <div className="stats-grid">
         <div className="stat-card">
           <span className="stat-card__value">{stats.shot_count}</span>
           <span className="stat-card__label">Shots</span>
@@ -91,6 +113,7 @@ export function StatsView({ shots, onClearSession }: StatsViewProps) {
           </div>
         )}
       </div>
+      )}
 
       <button className="clear-button" onClick={onClearSession}>
         Clear Session

--- a/ui/src/components/TrainingImplementPicker.tsx
+++ b/ui/src/components/TrainingImplementPicker.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { TRAINING_IMPLEMENTS, getTrainingImplementLabel, getTrainingImplementsByGroup } from '../data/trainingImplements';
+import './ClubPicker.css';
+
+interface TrainingImplementPickerProps {
+  selectedImplement: string;
+  onImplementChange: (implement: string) => void;
+}
+
+export function TrainingImplementPicker({ selectedImplement, onImplementChange }: TrainingImplementPickerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeGroup, setActiveGroup] = useState<string | null>(null);
+  const selectedLabel = getTrainingImplementLabel(selectedImplement);
+  const groupedImplements = getTrainingImplementsByGroup();
+  const topLevelOptions = TRAINING_IMPLEMENTS.filter((item) => item.group === 'General');
+  const nestedGroups = ['SuperSpeed', 'TheStack', 'Rypstick'];
+
+  const handleSelect = (implement: string) => {
+    onImplementChange(implement);
+    setIsOpen(false);
+    setActiveGroup(null);
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setActiveGroup(null);
+  };
+
+  return (
+    <div className="club-picker">
+      <button className="club-picker__trigger" onClick={() => setIsOpen(!isOpen)} aria-expanded={isOpen}>
+        <span className="club-picker__label">Swing</span>
+        <span className="club-picker__value">{selectedLabel}</span>
+        <svg
+          className={`club-picker__arrow ${isOpen ? 'club-picker__arrow--open' : ''}`}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <>
+          <div className="club-picker__overlay" onClick={handleClose} />
+          <div className="club-picker__dropdown">
+            {activeGroup === null ? (
+              <div className="club-picker__section">
+                <span className="club-picker__section-title">Training</span>
+                <div className="club-picker__grid club-picker__grid--families">
+                  {topLevelOptions.map((item) => (
+                    <button
+                      key={item.id}
+                      className={`club-picker__option ${
+                        selectedImplement === item.id ? 'club-picker__option--selected' : ''
+                      }`}
+                      onClick={() => handleSelect(item.id)}
+                    >
+                      {item.label}
+                    </button>
+                  ))}
+                  {nestedGroups.map((group) => (
+                    <button
+                      key={group}
+                      className="club-picker__option club-picker__option--family"
+                      onClick={() => setActiveGroup(group)}
+                    >
+                      {group}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="club-picker__section">
+                <div className="club-picker__section-header">
+                  <button className="club-picker__back" onClick={() => setActiveGroup(null)}>
+                    Back
+                  </button>
+                  <span className="club-picker__section-title">{activeGroup}</span>
+                </div>
+                <div className="club-picker__grid">
+                  {(groupedImplements[activeGroup] ?? []).map((item) => (
+                    <button
+                      key={item.id}
+                      className={`club-picker__option ${
+                        selectedImplement === item.id ? 'club-picker__option--selected' : ''
+                      }`}
+                      onClick={() => handleSelect(item.id)}
+                    >
+                      {item.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/data/trainingImplements.ts
+++ b/ui/src/data/trainingImplements.ts
@@ -1,0 +1,43 @@
+export interface TrainingImplement {
+  id: string;
+  label: string;
+  group: string;
+}
+
+export const TRAINING_IMPLEMENTS: TrainingImplement[] = [
+  { id: 'driver', label: 'Driver', group: 'General' },
+  { id: 'custom', label: 'Custom', group: 'General' },
+  { id: 'superspeed-light', label: 'SuperSpeed Light', group: 'SuperSpeed' },
+  { id: 'superspeed-medium', label: 'SuperSpeed Medium', group: 'SuperSpeed' },
+  { id: 'superspeed-heavy', label: 'SuperSpeed Heavy', group: 'SuperSpeed' },
+  { id: 'stack', label: 'Stack', group: 'TheStack' },
+  { id: 'stack-0g', label: 'Stack 0g', group: 'TheStack' },
+  { id: 'stack-60g', label: 'Stack 60g', group: 'TheStack' },
+  { id: 'stack-100g', label: 'Stack 100g', group: 'TheStack' },
+  { id: 'stack-120g', label: 'Stack 120g', group: 'TheStack' },
+  { id: 'stack-160g', label: 'Stack 160g', group: 'TheStack' },
+  { id: 'stack-180g', label: 'Stack 180g', group: 'TheStack' },
+  { id: 'stack-200g', label: 'Stack 200g', group: 'TheStack' },
+  { id: 'stack-220g', label: 'Stack 220g', group: 'TheStack' },
+  { id: 'stack-240g', label: 'Stack 240g', group: 'TheStack' },
+  { id: 'stack-260g', label: 'Stack 260g', group: 'TheStack' },
+  { id: 'stack-280g', label: 'Stack 280g', group: 'TheStack' },
+  { id: 'stack-300g', label: 'Stack 300g', group: 'TheStack' },
+  { id: 'rypstick', label: 'Rypstick', group: 'Rypstick' },
+  { id: 'rypstick-0w', label: 'Rypstick 0 Weights', group: 'Rypstick' },
+  { id: 'rypstick-1w', label: 'Rypstick 1 Weight', group: 'Rypstick' },
+  { id: 'rypstick-2w', label: 'Rypstick 2 Weights', group: 'Rypstick' },
+  { id: 'rypstick-3w', label: 'Rypstick 3 Weights', group: 'Rypstick' },
+  { id: 'rypstick-3w-cw', label: 'Rypstick 3 Weights + Counterweight', group: 'Rypstick' },
+];
+
+export function getTrainingImplementLabel(id: string): string {
+  return TRAINING_IMPLEMENTS.find((item) => item.id === id)?.label ?? 'Driver';
+}
+
+export function getTrainingImplementsByGroup(): Record<string, TrainingImplement[]> {
+  return TRAINING_IMPLEMENTS.reduce<Record<string, TrainingImplement[]>>((groups, item) => {
+    groups[item.group] = [...(groups[item.group] ?? []), item];
+    return groups;
+  }, {});
+}

--- a/ui/src/services/socketService.ts
+++ b/ui/src/services/socketService.ts
@@ -3,8 +3,9 @@ import { useSystemStore } from '../stores/useSystemStore';
 import { useShotStore } from '../stores/useShotStore';
 import { useCameraStore, type CameraStatus } from '../stores/useCameraStore';
 import { useDebugStore } from '../stores/useDebugStore';
-import type { Shot, SessionStats, SessionState, TriggerDiagnostic, TriggerStatus } from '../types/shot';
+import { isSwingSpeedShot, type Shot, type SessionStats, type SessionState, type TriggerDiagnostic, type TriggerStatus } from '../types/shot';
 import type { DebugReading, RadarConfig, DebugShotLog, SimShotInfo, SimStatus } from '../types/socket';
+import { playSwingCapturedCue } from '../utils/audioCue';
 import { getServerOrigin } from '../utils/serverOrigin';
 
 const SOCKET_URL = getServerOrigin();
@@ -37,6 +38,7 @@ class SocketService {
       useSystemStore.getState().setConnected(true);
       this.socket?.emit('get_session');
       this.socket?.emit('get_trigger_status');
+      this.socket?.emit('get_radar_config');
     });
 
     this.socket.on('disconnect', () => {
@@ -47,7 +49,16 @@ class SocketService {
     this.socket.on('shot', (data: { shot: Shot; stats: SessionStats }) => {
       // Need to get latest state of addShot to prevent stale closures
       useShotStore.getState().addShot(data.shot);
+      if (isSwingSpeedShot(data.shot)) {
+        playSwingCapturedCue();
+      }
     });
+
+    // Swing-speed mode also emits a normal `shot` event, handled above, so the
+    // rep is already recorded. This listener is registered without a payload to
+    // document that `swing_speed` is deliberately ignored here rather than
+    // forgotten -- handling it too would double-count the rep.
+    this.socket.on('swing_speed', () => {});
 
     this.socket.on('sim_status', (data: SimStatus) => {
       useSystemStore.getState().setSimStatus(data);
@@ -69,6 +80,10 @@ class SocketService {
       useSystemStore.getState().setServerClub(data.club);
     });
 
+    this.socket.on('player_changed', (data: { player_name: string }) => {
+      useSystemStore.getState().setServerPlayerName(data.player_name);
+    });
+
     this.socket.on(
       'session_state',
       (
@@ -79,6 +94,7 @@ class SocketService {
           camera_enabled?: boolean;
           camera_streaming?: boolean;
           ball_detected?: boolean;
+          player_name?: string;
         }
       ) => {
         console.log('Session state received:', data);
@@ -91,6 +107,9 @@ class SocketService {
         }
         if (data.debug_mode !== undefined) {
           systemStore.setDebugMode(data.debug_mode);
+        }
+        if (data.player_name !== undefined) {
+          systemStore.setServerPlayerName(data.player_name);
         }
 
         // Update camera status from session state
@@ -148,6 +167,10 @@ class SocketService {
     this.socket.on('trigger_status', (data: TriggerStatus) => {
       useDebugStore.getState().setTriggerStatus(data);
     });
+
+    this.socket.on('cloud_upload_status', (data: { state: 'idle' | 'running' | 'complete' | 'error'; message: string }) => {
+      useSystemStore.getState().setCloudUploadStatus(data.state, data.message);
+    });
   }
 
   // Emitters
@@ -155,12 +178,29 @@ class SocketService {
     this.socket?.emit('clear_session');
   }
 
+  uploadCloud() {
+    useSystemStore.getState().setCloudUploadStatus('running', 'Uploading...');
+    this.socket?.emit('upload_cloud');
+  }
+
   setClub(club: string) {
     this.socket?.emit('set_club', { club });
   }
 
+  setTrainingImplement(implement: string) {
+    this.socket?.emit('set_training_implement', { implement });
+  }
+
+  setPlayer(playerName: string) {
+    this.socket?.emit('set_player', { player_name: playerName });
+  }
+
   simulateShot() {
     this.socket?.emit('simulate_shot');
+  }
+
+  deleteShot(timestamp: string) {
+    this.socket?.emit('delete_shot', { timestamp });
   }
 
   toggleDebug() {

--- a/ui/src/stores/usePlayerStore.ts
+++ b/ui/src/stores/usePlayerStore.ts
@@ -1,0 +1,95 @@
+import { create } from 'zustand';
+
+const PLAYERS_STORAGE_KEY = 'openflight-players';
+const SELECTED_PLAYER_STORAGE_KEY = 'openflight-selected-player';
+const DEFAULT_PLAYER = 'Player 1';
+
+function cleanPlayerName(name: string): string {
+  return name.trim().slice(0, 40);
+}
+
+function loadPlayers(): string[] {
+  if (typeof window === 'undefined') return [DEFAULT_PLAYER];
+
+  try {
+    const raw = window.localStorage.getItem(PLAYERS_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    if (Array.isArray(parsed)) {
+      const players = parsed
+        .map((name) => cleanPlayerName(String(name)))
+        .filter(Boolean);
+      return Array.from(new Set(players)).slice(0, 12);
+    }
+  } catch {
+    // Ignore broken localStorage data and fall back to the default.
+  }
+  return [DEFAULT_PLAYER];
+}
+
+function savePlayers(players: string[]) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(PLAYERS_STORAGE_KEY, JSON.stringify(players));
+  } catch {
+    // Ignore storage failures; the picker still works for the current session.
+  }
+}
+
+function saveSelectedPlayer(playerName: string) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(SELECTED_PLAYER_STORAGE_KEY, playerName);
+  } catch {
+    // Ignore storage failures; the picker still works for the current session.
+  }
+}
+
+function loadSelectedPlayer(): string {
+  if (typeof window === 'undefined') return '';
+  try {
+    return cleanPlayerName(window.localStorage.getItem(SELECTED_PLAYER_STORAGE_KEY) ?? '');
+  } catch {
+    return '';
+  }
+}
+
+interface PlayerState {
+  players: string[];
+  selectedPlayer: string;
+  addPlayer: (name: string) => string;
+  removePlayer: (name: string) => void;
+  selectPlayer: (name: string) => void;
+}
+
+const initialPlayers = loadPlayers();
+const savedSelected = loadSelectedPlayer();
+const initialSelected = initialPlayers.includes(savedSelected) ? savedSelected : initialPlayers[0] ?? DEFAULT_PLAYER;
+
+export const usePlayerStore = create<PlayerState>((set, get) => ({
+  players: initialPlayers.length ? initialPlayers : [DEFAULT_PLAYER],
+  selectedPlayer: initialSelected,
+  addPlayer: (name) => {
+    const playerName = cleanPlayerName(name) || DEFAULT_PLAYER;
+    const nextPlayers = Array.from(new Set([...get().players, playerName])).slice(0, 12);
+    savePlayers(nextPlayers);
+    saveSelectedPlayer(playerName);
+    set({ players: nextPlayers, selectedPlayer: playerName });
+    return playerName;
+  },
+  removePlayer: (name) => {
+    const current = get();
+    const remaining = current.players.filter((player) => player !== name);
+    const nextPlayers = remaining.length ? remaining : [DEFAULT_PLAYER];
+    const selectedPlayer = current.selectedPlayer === name ? nextPlayers[0] : current.selectedPlayer;
+    savePlayers(nextPlayers);
+    saveSelectedPlayer(selectedPlayer);
+    set({ players: nextPlayers, selectedPlayer });
+  },
+  selectPlayer: (name) => {
+    const playerName = cleanPlayerName(name) || DEFAULT_PLAYER;
+    const nextPlayers = get().players.includes(playerName) ? get().players : [...get().players, playerName].slice(0, 12);
+    savePlayers(nextPlayers);
+    saveSelectedPlayer(playerName);
+    set({ players: nextPlayers, selectedPlayer: playerName });
+  },
+}));

--- a/ui/src/stores/useSystemStore.ts
+++ b/ui/src/stores/useSystemStore.ts
@@ -5,27 +5,37 @@ interface SystemState {
   connected: boolean;
   mockMode: boolean;
   debugMode: boolean;
+  cloudUploadState: 'idle' | 'running' | 'complete' | 'error';
+  cloudUploadMessage: string;
   simStatuses: Record<string, SimStatus>;
   latestSimShots: Record<string, SimShotInfo>;
   serverClub: string | null;
+  serverPlayerName: string | null;
   setConnected: (connected: boolean) => void;
   setMockMode: (mockMode: boolean) => void;
   setDebugMode: (debugMode: boolean) => void;
+  setCloudUploadStatus: (state: SystemState['cloudUploadState'], message: string) => void;
   setSimStatus: (status: SimStatus) => void;
   setLatestSimShot: (shot: SimShotInfo) => void;
   setServerClub: (club: string | null) => void;
+  setServerPlayerName: (playerName: string | null) => void;
 }
 
 export const useSystemStore = create<SystemState>((set) => ({
   connected: false,
   mockMode: false,
   debugMode: false,
+  cloudUploadState: 'idle',
+  cloudUploadMessage: '',
   simStatuses: {},
   latestSimShots: {},
   serverClub: null,
+  serverPlayerName: null,
   setConnected: (connected) => set({ connected }),
   setMockMode: (mockMode) => set({ mockMode }),
   setDebugMode: (debugMode) => set({ debugMode }),
+  setCloudUploadStatus: (cloudUploadState, cloudUploadMessage) =>
+    set({ cloudUploadState, cloudUploadMessage }),
   setSimStatus: (status) =>
     set((state) => ({
       simStatuses: { ...state.simStatuses, [status.target]: status },
@@ -35,4 +45,5 @@ export const useSystemStore = create<SystemState>((set) => ({
       latestSimShots: { ...state.latestSimShots, [shot.target]: shot },
     })),
   setServerClub: (serverClub) => set({ serverClub }),
+  setServerPlayerName: (serverPlayerName) => set({ serverPlayerName }),
 }));

--- a/ui/src/stores/useValidationStore.ts
+++ b/ui/src/stores/useValidationStore.ts
@@ -1,0 +1,69 @@
+import { create } from 'zustand';
+
+export interface ValidationEntry {
+  comparatorDevice: string;
+  comparatorSpeed: string;
+  notes: string;
+}
+
+interface ValidationState {
+  entries: Record<string, ValidationEntry>;
+  updateEntry: (timestamp: string, patch: Partial<ValidationEntry>) => void;
+  removeEntry: (timestamp: string) => void;
+  clearEntries: () => void;
+}
+
+const STORAGE_KEY = 'openflight-validation-entries';
+
+const emptyEntry: ValidationEntry = {
+  comparatorDevice: '',
+  comparatorSpeed: '',
+  notes: '',
+};
+
+function loadEntries(): Record<string, ValidationEntry> {
+  if (typeof window === 'undefined') return {};
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveEntries(entries: Record<string, ValidationEntry>) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+}
+
+export function getEmptyValidationEntry(): ValidationEntry {
+  return { ...emptyEntry };
+}
+
+export const useValidationStore = create<ValidationState>((set) => ({
+  entries: loadEntries(),
+  updateEntry: (timestamp, patch) =>
+    set((state) => {
+      const updated = {
+        ...state.entries,
+        [timestamp]: {
+          ...(state.entries[timestamp] ?? emptyEntry),
+          ...patch,
+        },
+      };
+      saveEntries(updated);
+      return { entries: updated };
+    }),
+  removeEntry: (timestamp) =>
+    set((state) => {
+      const updated = { ...state.entries };
+      delete updated[timestamp];
+      saveEntries(updated);
+      return { entries: updated };
+    }),
+  clearEntries: () => {
+    saveEntries({});
+    set({ entries: {} });
+  },
+}));

--- a/ui/src/types/shot.ts
+++ b/ui/src/types/shot.ts
@@ -1,12 +1,14 @@
 export type SpinQuality = 'high' | 'medium' | 'low' | 'experimental';
 
 export interface Shot {
+  mode?: 'rolling-buffer' | 'mock' | 'swing-speed';
   ball_speed_mph: number;
   club_speed_mph: number | null;
   smash_factor: number | null;
   estimated_carry_yards: number;
   carry_range: [number, number];
   club: string;
+  player_name?: string;
   timestamp: string;
   peak_magnitude: number | null;
   // Launch angle data (from K-LD7 radar (deprecated), camera, or estimation)
@@ -25,6 +27,11 @@ export interface Shot {
   spin_method?: string | null;
   spin_multipath_fade_hz?: number | null;
   carry_spin_adjusted: number | null;
+  swing_speed_duration_ms?: number;
+  swing_speed_reading_count?: number;
+  swing_speed_trigger_mph?: number;
+  training_implement?: string;
+  training_implement_label?: string;
 }
 
 export interface SessionStats {
@@ -71,13 +78,98 @@ export interface TriggerDiagnostic {
 }
 
 export interface TriggerStatus {
-  mode: 'rolling-buffer' | 'mock';
+  mode: 'rolling-buffer' | 'mock' | 'swing-speed';
   trigger_type: string | null;
   radar_connected: boolean;
   radar_port: string | null;
   triggers_total: number;
   triggers_accepted: number;
   triggers_rejected: number;
+}
+
+export interface SwingSpeedStats {
+  count: number;
+  last_speed_mph: number;
+  best_speed_mph: number;
+  avg_speed_mph: number;
+}
+
+export interface SwingSpeedStatsFilter {
+  playerName?: string | null;
+  trainingImplement?: string | null;
+  club?: string | null;
+}
+
+export function isSwingSpeedShot(shot: Shot | null): boolean {
+  return shot?.mode === 'swing-speed' || shot?.club === 'Swing Speed';
+}
+
+export function getSwingSpeedMph(shot: Shot): number {
+  return shot.club_speed_mph ?? shot.ball_speed_mph;
+}
+
+function normalizePlayerName(playerName: string | null | undefined): string {
+  return (playerName?.trim() || 'Player 1').toLowerCase();
+}
+
+function normalizeToken(value: string | null | undefined): string {
+  return (value?.trim() || '').toLowerCase();
+}
+
+export function filterSwingSpeedShots(shots: Shot[], filter: SwingSpeedStatsFilter = {}): Shot[] {
+  const playerName = normalizePlayerName(filter.playerName);
+  const trainingImplement = normalizeToken(filter.trainingImplement);
+  const club = normalizeToken(filter.club);
+
+  return shots.filter((shot) => {
+    if (!isSwingSpeedShot(shot)) {
+      return false;
+    }
+
+    if (filter.playerName && normalizePlayerName(shot.player_name) !== playerName) {
+      return false;
+    }
+
+    if (trainingImplement) {
+      const shotImplement = normalizeToken(shot.training_implement);
+      const shotImplementLabel = normalizeToken(shot.training_implement_label);
+      const shotClub = normalizeToken(shot.club);
+
+      return (
+        shotImplement === trainingImplement ||
+        shotImplementLabel === trainingImplement ||
+        shotClub === trainingImplement
+      );
+    }
+
+    if (club && normalizeToken(shot.club) !== club) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+export function computeSwingSpeedStats(shots: Shot[], filter: SwingSpeedStatsFilter = {}): SwingSpeedStats {
+  const swingSpeeds = filterSwingSpeedShots(shots, filter).map(getSwingSpeedMph);
+
+  if (swingSpeeds.length === 0) {
+    return {
+      count: 0,
+      last_speed_mph: 0,
+      best_speed_mph: 0,
+      avg_speed_mph: 0,
+    };
+  }
+
+  const total = swingSpeeds.reduce((sum, speed) => sum + speed, 0);
+
+  return {
+    count: swingSpeeds.length,
+    last_speed_mph: swingSpeeds[swingSpeeds.length - 1],
+    best_speed_mph: Math.max(...swingSpeeds),
+    avg_speed_mph: total / swingSpeeds.length,
+  };
 }
 
 /**

--- a/ui/src/types/socket.ts
+++ b/ui/src/types/socket.ts
@@ -25,6 +25,18 @@ export interface SimShotInfo {
   provenance: Record<string, 'measured' | 'estimated'>;
 }
 
+export interface SwingSpeedEvent {
+  peak_speed_mph: number;
+  timestamp: string;
+  duration_ms: number;
+  reading_count: number;
+  trigger_speed_mph: number;
+  peak_magnitude: number | null;
+  player_name?: string;
+  unit: string;
+  mode: 'swing-speed';
+}
+
 export interface RadarConfig {
   min_speed: number;
   max_speed: number;

--- a/ui/src/utils/audioCue.ts
+++ b/ui/src/utils/audioCue.ts
@@ -1,0 +1,52 @@
+let audioContext: AudioContext | null = null;
+
+declare global {
+  interface Window {
+    webkitAudioContext?: typeof AudioContext;
+  }
+}
+
+function getAudioContext(): AudioContext | null {
+  if (typeof window === 'undefined') return null;
+
+  const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+  if (!AudioContextClass) return null;
+
+  if (!audioContext) {
+    audioContext = new AudioContextClass();
+  }
+  return audioContext;
+}
+
+export function unlockAudioCue() {
+  const context = getAudioContext();
+  if (context?.state === 'suspended') {
+    void context.resume();
+  }
+}
+
+export function playSwingCapturedCue() {
+  const context = getAudioContext();
+  if (!context) return;
+
+  if (context.state === 'suspended') {
+    void context.resume();
+  }
+
+  const oscillator = context.createOscillator();
+  const gain = context.createGain();
+  const now = context.currentTime;
+
+  oscillator.type = 'sine';
+  oscillator.frequency.setValueAtTime(880, now);
+  oscillator.frequency.setValueAtTime(1175, now + 0.07);
+
+  gain.gain.setValueAtTime(0.0001, now);
+  gain.gain.exponentialRampToValueAtTime(0.85, now + 0.015);
+  gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.18);
+
+  oscillator.connect(gain);
+  gain.connect(context.destination);
+  oscillator.start(now);
+  oscillator.stop(now + 0.2);
+}


### PR DESCRIPTION
## Summary

Adds an experimental swing speed training mode for OPS243-based OpenFlight setups.

This mode is intended for club-only / air-swing training where there is no ball impact sound, such as driver air swings, SuperSpeed, The Stack System, Rypstick, and similar overspeed training aids.

## What changed?

- Added `--swing-speed` mode using OPS243 live speed reporting
- Added `--mock-swing-speed` mode for testing without radar hardware
- Emits swing speed reps into the existing UI shot/session flow
- Adds swing speed live display, stats, shot list support, delete support, CSV export/validation fields
- Adds training implement picker for Driver, SuperSpeed, The Stack, Rypstick, and Custom
- Adds player selection so multiple users can compare sessions
- Scopes live best/average/count by current player and selected training implement
- Adds radar tuning sliders for swing speed lower/upper gates
- Adds max speed guard for implausible high outliers
- Adds audio cue when a swing is captured
- Avoids saving `A!` during runtime radar mode restore

## Why was this required?

OpenFlight currently relies on rolling buffer mode plus a sound/impact trigger. That works for ball striking, but not for swing speed training where there is no impact sound.

This adds a dedicated training mode so OpenFlight can be used for overspeed work and air swings while keeping normal launch monitor mode as the default.

## Automated tests

Focused tests passing locally:

```text
19 passed, 1 warning