### PR TITLE
feat: add experimental multitaper spin estimator

### DIFF
--- a/docs/rolling_buffer_spin_detection.md
+++ b/docs/rolling_buffer_spin_detection.md
@@ -10,6 +10,28 @@ The OPS243-A radar can detect golf ball spin by analyzing micro-variations in th
 2. **Overlapping FFT Windows** - Increases temporal resolution to see spin "waviness"
 3. **Secondary FFT** - Extracts spin frequency from speed oscillations
 
+## Experimental Live Estimator
+
+The live rolling-buffer pipeline automatically runs the ungated multitaper
+estimator for every valid capture. No estimator flag or additional setup is
+required beyond the normal persistent rolling-buffer configuration.
+
+- The UI displays the candidate below Spin Rate with an **EXPERIMENTAL** label.
+- The result is logged with `spin_method: "multitaper_ungated"` and the detected
+  multipath fade frequency for later TrackMan comparison.
+- The estimator intentionally reports its best 1,500-11,000 RPM candidate
+  without a confidence, rail, or club-selection gate so evaluation sessions do
+  not silently discard difficult shots.
+- Experimental spin does not currently drive spin-adjusted carry. A candidate
+  can be useful for model evaluation without being reliable enough for flight
+  calculations.
+
+TrackMan-blind validation remains above the production target: July 14 had
+2,499 RPM MAE (1,682 RPM median absolute error), and the held-out July 17
+session had 3,073 RPM MAE (2,968 RPM median). Treat individual readings as
+evaluation data rather than ground truth until geometry and multipath rejection
+improve.
+
 ## Current vs Rolling Buffer Approach
 
 | Aspect | Current (Streaming) | Rolling Buffer |

--- a/src/openflight/launch_monitor.py
+++ b/src/openflight/launch_monitor.py
@@ -223,7 +223,9 @@ class Shot:
         launch_angle_horizontal_source: Source for horizontal launch angle
         spin_rpm: Spin rate in RPM (from rolling buffer mode)
         spin_confidence: Confidence in spin measurement (0-1)
+        spin_method: Estimator that produced the spin candidate
         spin_result_quality: Processor quality label for the spin detection
+        spin_multipath_fade_hz: Fitted two-ray fade frequency, when available
         spin_snr: Signal-to-noise ratio of the spin envelope peak
         spin_modulation_depth: Envelope std/mean inside the spin window
         spin_peak_freq_hz: Frequency of the detected spin candidate
@@ -266,7 +268,9 @@ class Shot:
     # spin_rpm with the kinematic estimate (for offline scoring)
     spin_rpm_measured: Optional[float] = None
     spin_source: Optional[str] = None  # "measured", "calculated", or None
+    spin_method: Optional[str] = None
     spin_result_quality: Optional[str] = None
+    spin_multipath_fade_hz: Optional[float] = None
     spin_snr: Optional[float] = None
     spin_modulation_depth: Optional[float] = None
     spin_peak_freq_hz: Optional[float] = None

--- a/src/openflight/rolling_buffer/monitor.py
+++ b/src/openflight/rolling_buffer/monitor.py
@@ -564,7 +564,11 @@ class RollingBufferMonitor:
                             smash_factor=processed.smash_factor,
                             spin_rpm=processed.spin.spin_rpm if processed.spin else None,
                             spin_confidence=processed.spin.confidence if processed.spin else None,
+                            spin_method=processed.spin.method if processed.spin else None,
                             spin_quality=processed.spin.quality if processed.spin else None,
+                            spin_multipath_fade_hz=(
+                                processed.spin.multipath_fade_hz if processed.spin else None
+                            ),
                             spin_snr=processed.spin.snr if processed.spin else None,
                             spin_modulation_depth=(
                                 processed.spin.modulation_depth if processed.spin else None
@@ -752,7 +756,10 @@ class RollingBufferMonitor:
 
         spin = processed.spin
         spin_rejection_reason = spin.rejection_reason if spin else None
-        club_spin_rejection_reason = self._club_spin_rejection_reason(processed)
+        is_ungated_multitaper = bool(spin is not None and spin.method == "multitaper_ungated")
+        club_spin_rejection_reason = (
+            None if is_ungated_multitaper else self._club_spin_rejection_reason(processed)
+        )
         if club_spin_rejection_reason:
             spin_rejection_reason = club_spin_rejection_reason
             logger.warning(
@@ -776,14 +783,20 @@ class RollingBufferMonitor:
         has_reportable_spin = bool(
             spin is not None
             and spin.spin_rpm > 0
-            and club_spin_rejection_reason is None
-            and not spin.at_lower_rail
-            and not spin.at_upper_rail
+            and (
+                is_ungated_multitaper
+                or (
+                    club_spin_rejection_reason is None
+                    and not spin.at_lower_rail
+                    and not spin.at_upper_rail
+                )
+            )
         )
         if (
             spin is not None
             and spin.spin_rpm > 0
             and club_spin_rejection_reason is None
+            and not is_ungated_multitaper
             and not has_reportable_spin
         ):
             if spin.at_lower_rail:
@@ -835,7 +848,9 @@ class RollingBufferMonitor:
             club=self._current_club,
             spin_rpm=spin_rpm,
             spin_confidence=spin_confidence,
+            spin_method=spin.method if spin else None,
             spin_result_quality=spin_result_quality,
+            spin_multipath_fade_hz=spin.multipath_fade_hz if spin else None,
             spin_snr=spin.snr if spin else None,
             spin_modulation_depth=spin.modulation_depth if spin else None,
             spin_peak_freq_hz=spin.peak_freq_hz if spin else None,

--- a/src/openflight/rolling_buffer/multitaper.py
+++ b/src/openflight/rolling_buffer/multitaper.py
@@ -1,0 +1,169 @@
+"""Multipath-aware multitaper spin estimation for OPS rolling captures."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.signal.windows import dpss
+
+
+@dataclass(frozen=True)
+class MultitaperEstimate:
+    """Ungated spectral candidate and supporting evidence."""
+
+    spin_hz: float
+    spin_rpm: float
+    peak_to_floor: float
+    fade_hz: float
+
+
+def repair_clipped_iq(
+    i_samples: np.ndarray,
+    q_samples: np.ndarray,
+    *,
+    margin: int = 10,
+) -> tuple[np.ndarray, float]:
+    """Interpolate near-rail samples using the evaluated offline treatment."""
+    i_values = np.asarray(i_samples, dtype=np.float64)
+    q_values = np.asarray(q_samples, dtype=np.float64)
+    clipped = (
+        (i_values <= margin)
+        | (i_values >= 4095 - margin)
+        | (q_values <= margin)
+        | (q_values >= 4095 - margin)
+    )
+    repaired_i = i_values.copy()
+    repaired_q = q_values.copy()
+    valid = np.flatnonzero(~clipped)
+    if valid.size >= 2 and clipped.any():
+        bad = np.flatnonzero(clipped)
+        repaired_i[bad] = np.interp(bad, valid, repaired_i[valid])
+        repaired_q[bad] = np.interp(bad, valid, repaired_q[valid])
+    repaired = (repaired_i - repaired_i.mean()) + 1j * (repaired_q - repaired_q.mean())
+    return repaired, float(np.mean(clipped))
+
+
+def _polynomial_design(length: int, order: int = 3) -> np.ndarray:
+    coordinate = np.linspace(-1.0, 1.0, length)
+    return np.column_stack([coordinate**degree for degree in range(order + 1)])
+
+
+def _sine_columns(length: int, sample_rate_hz: float, frequency_hz: float) -> np.ndarray:
+    time_s = np.arange(length, dtype=np.float64) / sample_rate_hz
+    phase = 2.0 * np.pi * frequency_hz * time_s
+    return np.column_stack((np.sin(phase), np.cos(phase)))
+
+
+def _dominant_frequency(
+    signal: np.ndarray,
+    sample_rate_hz: float,
+    band_hz: tuple[float, float],
+) -> float:
+    polynomial = _polynomial_design(len(signal))
+    residual = signal - polynomial @ np.linalg.lstsq(polynomial, signal, rcond=None)[0]
+    fft_size = max(8192, 1 << math.ceil(math.log2(len(signal) * 8)))
+    spectrum = np.abs(np.fft.rfft(residual * np.hanning(len(residual)), fft_size))
+    frequencies = np.fft.rfftfreq(fft_size, d=1.0 / sample_rate_hz)
+    valid_indices = np.flatnonzero((frequencies >= band_hz[0]) & (frequencies <= band_hz[1]))
+    if not valid_indices.size:
+        raise ValueError("fade band does not intersect the spectrum")
+    return float(frequencies[valid_indices[np.argmax(spectrum[valid_indices])]])
+
+
+def _remove_multipath_fade(
+    envelope: np.ndarray,
+    sample_rate_hz: float,
+    *,
+    fade_band_hz: tuple[float, float],
+    search_width_hz: float = 8.0,
+    grid_step_hz: float = 0.25,
+) -> tuple[np.ndarray, float]:
+    """Regress the dominant two-ray fade and its second harmonic."""
+    polynomial = _polynomial_design(len(envelope))
+    fade_hint_hz = _dominant_frequency(envelope, sample_rate_hz, fade_band_hz)
+    fade_low = max(fade_band_hz[0], fade_hint_hz - search_width_hz)
+    fade_high = min(fade_band_hz[1], fade_hint_hz + search_width_hz)
+
+    best_frequency = fade_hint_hz
+    best_residual: np.ndarray | None = None
+    best_sse = math.inf
+    for fade_hz in np.arange(fade_low, fade_high + grid_step_hz / 2.0, grid_step_hz):
+        design = np.column_stack(
+            (
+                polynomial,
+                _sine_columns(len(envelope), sample_rate_hz, fade_hz),
+                _sine_columns(len(envelope), sample_rate_hz, 2.0 * fade_hz),
+            )
+        )
+        coefficients = np.linalg.lstsq(design, envelope, rcond=None)[0]
+        residual = envelope - design @ coefficients
+        sse = float(residual @ residual)
+        if sse < best_sse:
+            best_frequency = float(fade_hz)
+            best_residual = residual
+            best_sse = sse
+
+    if best_residual is None:
+        raise ValueError("fade search produced no candidates")
+    return best_residual, best_frequency
+
+
+def estimate_multitaper_spin(
+    envelope: np.ndarray,
+    sample_rate_hz: float,
+    *,
+    spin_rpm_band: tuple[float, float] = (1500.0, 11_000.0),
+    fade_band_hz: tuple[float, float] = (25.0, 90.0),
+    time_bandwidth: float = 2.5,
+    taper_count: int = 4,
+) -> MultitaperEstimate:
+    """Return the strongest bounded candidate after two-ray fade removal."""
+    values = np.asarray(envelope, dtype=np.float64)
+    if values.ndim != 1 or len(values) < 128:
+        raise ValueError("envelope must contain at least 128 samples")
+
+    values, fade_hz = _remove_multipath_fade(
+        values,
+        sample_rate_hz,
+        fade_band_hz=fade_band_hz,
+    )
+    polynomial = _polynomial_design(len(values))
+    values = values - polynomial @ np.linalg.lstsq(polynomial, values, rcond=None)[0]
+
+    tapers = dpss(len(values), time_bandwidth, Kmax=taper_count, sym=False)
+    fft_size = max(8192, 1 << math.ceil(math.log2(len(values) * 8)))
+    power = np.zeros(fft_size // 2 + 1, dtype=np.float64)
+    for taper in tapers:
+        spectrum = np.fft.rfft(values * taper, fft_size)
+        power += np.abs(spectrum) ** 2
+    power /= len(tapers)
+
+    frequencies = np.fft.rfftfreq(fft_size, d=1.0 / sample_rate_hz)
+    low_hz, high_hz = (bound / 60.0 for bound in spin_rpm_band)
+    valid = (frequencies >= low_hz) & (frequencies <= high_hz)
+    valid_indices = np.flatnonzero(valid)
+    if not valid_indices.size:
+        raise ValueError("spin band does not intersect the spectrum")
+
+    coherent_power = np.abs(np.fft.rfft(values * np.hanning(len(values)), fft_size)) ** 2
+    peak_index = int(valid_indices[np.argmax(coherent_power[valid])])
+    natural_resolution_hz = sample_rate_hz / len(values)
+    exclusion = np.abs(frequencies - frequencies[peak_index]) <= 1.5 * natural_resolution_hz
+    evidence_band = (frequencies >= max(20.0, low_hz - 4.0 * natural_resolution_hz)) & (
+        frequencies <= high_hz + 4.0 * natural_resolution_hz
+    )
+    floor_values = power[evidence_band & ~exclusion]
+    if not floor_values.size:
+        floor_values = power[valid]
+    floor = float(np.median(floor_values))
+    peak_region = valid & (np.abs(frequencies - frequencies[peak_index]) <= natural_resolution_hz)
+    ratio = float(np.max(power[peak_region]) / max(floor, np.finfo(float).tiny))
+    spin_hz = float(frequencies[peak_index])
+    return MultitaperEstimate(
+        spin_hz=spin_hz,
+        spin_rpm=spin_hz * 60.0,
+        peak_to_floor=ratio,
+        fade_hz=fade_hz,
+    )

--- a/src/openflight/rolling_buffer/processor.py
+++ b/src/openflight/rolling_buffer/processor.py
@@ -13,6 +13,7 @@ import numpy as np
 from scipy.signal import butter, find_peaks, sosfiltfilt
 
 from ..launch_monitor import SPIN_CONFIDENCE_HIGH
+from .multitaper import estimate_multitaper_spin, repair_clipped_iq
 from .types import (
     ImpactEstimate,
     IQCapture,
@@ -74,18 +75,18 @@ class RollingBufferProcessor:
     DC_MASK_BINS = 150
 
     # Spin detection via amplitude envelope demodulation.
-    # The ball seam modulates the radar return at 2x spin rate.
-    SPIN_BANDPASS_BW_HZ = 700       # ±700 Hz around ball Doppler (must cover max seam freq)
-    SPIN_BANDPASS_ORDER = 4          # Butterworth filter order
-    SPIN_ENVELOPE_FFT_SIZE = 8192   # Zero-padded FFT for envelope
-    SPIN_MIN_SEAM_HZ = 33.0         # ~2000 RPM min (seam = 1x spin)
-    SPIN_MAX_SEAM_HZ = 200.0        # 12000 RPM max
-    SPIN_MIN_SAMPLES = 600           # ~20ms minimum ball signal
-    SPIN_SNR_HIGH = 8.0              # High confidence threshold
-    SPIN_SNR_MEDIUM = 5.0            # Medium confidence threshold
-    SPIN_SNR_MIN = 2.5               # Minimum to report
-    SPIN_AUTOCORR_MIN = 0.3          # Minimum normalized correlation
-    SPIN_MIN_CYCLES = 2              # Minimum seam cycles to report
+    # The ball seam modulates the radar return at 1x spin rate.
+    SPIN_BANDPASS_BW_HZ = 700  # ±700 Hz around ball Doppler (must cover max seam freq)
+    SPIN_BANDPASS_ORDER = 4  # Butterworth filter order
+    SPIN_ENVELOPE_FFT_SIZE = 8192  # Zero-padded FFT for envelope
+    SPIN_MIN_SEAM_HZ = 33.0  # ~2000 RPM min (seam = 1x spin)
+    SPIN_MAX_SEAM_HZ = 200.0  # 12000 RPM max
+    SPIN_MIN_SAMPLES = 600  # ~20ms minimum ball signal
+    SPIN_SNR_HIGH = 8.0  # High confidence threshold
+    SPIN_SNR_MEDIUM = 5.0  # Medium confidence threshold
+    SPIN_SNR_MIN = 2.5  # Minimum to report
+    SPIN_AUTOCORR_MIN = 0.3  # Minimum normalized correlation
+    SPIN_MIN_CYCLES = 2  # Minimum seam cycles to report
     # Rail-rejection guards. The envelope FFT has two pathological
     # regions where the peak picker hunts for noise rather than a real
     # seam tone:
@@ -99,7 +100,7 @@ class RollingBufferProcessor:
     #     prefilter. Even a moderate noise spike there reads as
     #     ~12000 RPM. Reject the pick when the peak lands there
     #     and SNR isn't strong enough to override.
-    SPIN_DC_LEAKAGE_BINS = 1         # Zero this many low bins of valid range
+    SPIN_DC_LEAKAGE_BINS = 1  # Zero this many low bins of valid range
     # Picks at or below this RPM are reported but capped to low quality:
     # red envelope noise produces sustained narrowband mimics in this
     # band that a single ~136 ms capture cannot distinguish from a real
@@ -116,11 +117,11 @@ class RollingBufferProcessor:
     # FFT. Signal is "lost" when the smoothed envelope stays below
     # SPIN_SIGNAL_LOSS_THRESHOLD x (early-window median) for
     # SPIN_SIGNAL_LOSS_HOLD_SAMPLES.
-    SPIN_SIGNAL_LOSS_SMOOTH_SAMPLES = 90   # ~3 ms moving average
-    SPIN_SIGNAL_LOSS_REF_SAMPLES = 450     # first ~15 ms sets reference level
-    SPIN_SIGNAL_LOSS_THRESHOLD = 0.15      # fraction of reference level
-    SPIN_SIGNAL_LOSS_HOLD_SAMPLES = 150    # ~5 ms sustained loss
-    SPIN_UPPER_RAIL_BINS = 2         # Top N bins of valid range = "upper rail"
+    SPIN_SIGNAL_LOSS_SMOOTH_SAMPLES = 90  # ~3 ms moving average
+    SPIN_SIGNAL_LOSS_REF_SAMPLES = 450  # first ~15 ms sets reference level
+    SPIN_SIGNAL_LOSS_THRESHOLD = 0.15  # fraction of reference level
+    SPIN_SIGNAL_LOSS_HOLD_SAMPLES = 150  # ~5 ms sustained loss
+    SPIN_UPPER_RAIL_BINS = 2  # Top N bins of valid range = "upper rail"
     SPIN_PRIOR_MIN_RELATIVE_MAG = 0.40  # Candidate must be this strong to displace argmax
     SPIN_PRIOR_MAX_RELATIVE_ERROR = 0.55  # Candidate must be within this fraction of expected
     SPIN_PRIOR_STRONGEST_FAR_ERROR = 0.45  # Strongest peak is "far" above this error
@@ -128,10 +129,13 @@ class RollingBufferProcessor:
     SPIN_IMPLAUSIBLE_LOWER_RAIL_FRACTION = 0.60  # Rail below this fraction is artifact-like
     SPIN_LOWER_RAIL_RECOVERY_MIN_RELATIVE_MAG = 0.20
     SPIN_LOWER_RAIL_RECOVERY_MAX_RELATIVE_ERROR = 0.35
-    SPIN_CANDIDATE_COUNT = 5       # Ranked diagnostic peaks to persist in logs
-    SPIN_PHASE_ENV_SNR_MIN = 1.75   # Envelope floor for phase-confirmed recovery
-    SPIN_PHASE_SNR_MIN = 2.5        # Phase witness floor
+    SPIN_CANDIDATE_COUNT = 5  # Ranked diagnostic peaks to persist in logs
+    SPIN_PHASE_ENV_SNR_MIN = 1.75  # Envelope floor for phase-confirmed recovery
+    SPIN_PHASE_SNR_MIN = 2.5  # Phase witness floor
     SPIN_PHASE_AGREEMENT_PCT = 10.0  # Max envelope/phase candidate difference
+    MULTITAPER_SPIN_RPM_BAND = (1500.0, 11_000.0)
+    MULTITAPER_RAIL_MARGIN_RPM = 250.0
+    MULTITAPER_MIN_SAMPLES = 128
 
     BALL_SPEED_MATCH_TOLERANCE_MPH = 3.0
     IMPACT_TRANSITION_MIN_DELTA_MPH = 15.0
@@ -473,9 +477,7 @@ class RollingBufferProcessor:
                 side_floors.append(float(np.median(live)))
         return max(side_floors) if side_floors else 0.0
 
-    def _spin_peak_is_persistent(
-        self, ball_envelope: np.ndarray, peak_freq_hz: float
-    ) -> bool:
+    def _spin_peak_is_persistent(self, ball_envelope: np.ndarray, peak_freq_hz: float) -> bool:
         """Whether the picked seam tone is present in both halves of the window.
 
         A real seam tone persists for the whole ball flight; an envelope-noise
@@ -545,6 +547,119 @@ class RollingBufferProcessor:
             len(envelope) / self.SAMPLE_RATE * 1000,
         )
         return start_sample + loss_offset
+
+    def detect_spin_multitaper(
+        self,
+        capture: IQCapture,
+        ball_speed_mph: float,
+        ball_timestamp_ms: float,
+        expected_spin_rpm: Optional[float] = None,
+    ) -> SpinResult:
+        """Return an ungated multipath-aware multitaper spin candidate.
+
+        This is the live version of the best-performing TrackMan-scored
+        offline track. Evidence is logged as confidence, but never used to
+        suppress a bounded candidate. The result remains ``experimental`` so
+        it cannot drive spin-adjusted carry.
+        """
+        del expected_spin_rpm  # The evaluated estimator intentionally has no spin prior.
+        iq, clipped_fraction = repair_clipped_iq(
+            np.asarray(capture.i_samples),
+            np.asarray(capture.q_samples),
+        )
+        if clipped_fraction > 0:
+            logger.info(
+                "[PROCESSOR] Multitaper repaired %.2f%% clipped I/Q samples",
+                clipped_fraction * 100.0,
+            )
+
+        ball_speed_mps = ball_speed_mph / self.MPS_TO_MPH
+        ball_doppler_hz = 2 * ball_speed_mps / self.WAVELENGTH_M
+        nyquist = self.SAMPLE_RATE / 2
+        low = max((ball_doppler_hz - self.SPIN_BANDPASS_BW_HZ) / nyquist, 0.001)
+        high = min((ball_doppler_hz + self.SPIN_BANDPASS_BW_HZ) / nyquist, 0.999)
+        if low >= high:
+            return SpinResult.no_spin_detected(
+                "Ball Doppler outside filter range",
+                method="multitaper_ungated",
+            )
+
+        try:
+            sos = butter(self.SPIN_BANDPASS_ORDER, [low, high], btype="band", output="sos")
+            envelope = np.abs(sosfiltfilt(sos, iq))
+        except Exception as exc:
+            return SpinResult.no_spin_detected(
+                f"Bandpass filter failed: {exc}",
+                method="multitaper_ungated",
+            )
+
+        start_sample = max(0, int(ball_timestamp_ms * self.SAMPLE_RATE / 1000))
+        end_sample = self._ball_signal_end_sample(envelope, start_sample)
+        ball_envelope = envelope[start_sample:end_sample]
+        transient_samples = int(self.SAMPLE_RATE / self.SPIN_BANDPASS_BW_HZ)
+        if len(ball_envelope) > 2 * transient_samples + self.SPIN_MIN_SAMPLES:
+            ball_envelope = ball_envelope[transient_samples:-transient_samples]
+        if len(ball_envelope) < self.MULTITAPER_MIN_SAMPLES:
+            return SpinResult.no_spin_detected(
+                f"Ball signal too short ({len(ball_envelope)} samples, "
+                f"need {self.MULTITAPER_MIN_SAMPLES})",
+                method="multitaper_ungated",
+            )
+
+        envelope_mean = float(np.mean(ball_envelope))
+        modulation_depth = (
+            float(np.std(ball_envelope) / envelope_mean) if envelope_mean > 0 else None
+        )
+        try:
+            estimate = estimate_multitaper_spin(
+                ball_envelope,
+                self.SAMPLE_RATE,
+                spin_rpm_band=self.MULTITAPER_SPIN_RPM_BAND,
+            )
+        except (ValueError, np.linalg.LinAlgError) as exc:
+            return SpinResult.no_spin_detected(
+                f"Multitaper estimation failed: {exc}",
+                modulation_depth=modulation_depth,
+                method="multitaper_ungated",
+            )
+
+        min_rpm, max_rpm = self.MULTITAPER_SPIN_RPM_BAND
+        at_lower_rail = estimate.spin_rpm <= min_rpm + self.MULTITAPER_RAIL_MARGIN_RPM
+        at_upper_rail = estimate.spin_rpm >= max_rpm - self.MULTITAPER_RAIL_MARGIN_RPM
+        window_seconds = len(ball_envelope) / self.SAMPLE_RATE
+        confidence = min(0.59, estimate.peak_to_floor / (estimate.peak_to_floor + 5.0))
+        candidate = SpinCandidate(
+            rank=1,
+            rpm=estimate.spin_rpm,
+            freq_hz=estimate.spin_hz,
+            relative_magnitude=1.0,
+            snr=estimate.peak_to_floor,
+            at_lower_rail=at_lower_rail,
+            at_upper_rail=at_upper_rail,
+            selected=True,
+        )
+        logger.info(
+            "[PROCESSOR] Ungated multitaper spin: %.0f RPM, evidence=%.2f, "
+            "fade=%.2f Hz, window=%.1fms",
+            estimate.spin_rpm,
+            estimate.peak_to_floor,
+            estimate.fade_hz,
+            window_seconds * 1000.0,
+        )
+        return SpinResult(
+            spin_rpm=estimate.spin_rpm,
+            confidence=confidence,
+            snr=estimate.peak_to_floor,
+            quality="experimental",
+            method="multitaper_ungated",
+            multipath_fade_hz=estimate.fade_hz,
+            modulation_depth=modulation_depth,
+            peak_freq_hz=estimate.spin_hz,
+            seam_cycles=estimate.spin_hz * window_seconds,
+            at_lower_rail=at_lower_rail,
+            at_upper_rail=at_upper_rail,
+            candidates=[candidate],
+        )
 
     def detect_spin(
         self,
@@ -616,7 +731,8 @@ class RollingBufferProcessor:
 
         if len(ball_envelope) < self.SPIN_MIN_SAMPLES:
             return SpinResult.no_spin_detected(
-                f"Ball signal too short ({len(ball_envelope)} samples, need {self.SPIN_MIN_SAMPLES})"
+                f"Ball signal too short ({len(ball_envelope)} samples, "
+                f"need {self.SPIN_MIN_SAMPLES})"
             )
 
         # Check modulation depth before proceeding. Real seam modulation
@@ -744,10 +860,15 @@ class RollingBufferProcessor:
             "[PROCESSOR] Spin envelope: peak=%.1f Hz (%.0f RPM), SNR=%.1f, "
             "cycles=%.1f, mod=%.4f, window=%.0fms, samples=%d, "
             "rail_lo=%s, rail_hi=%s",
-            peak_freq, spin_rpm, fft_snr, seam_cycles,
+            peak_freq,
+            spin_rpm,
+            fft_snr,
+            seam_cycles,
             modulation_depth if modulation_depth is not None else float("nan"),
-            window_seconds * 1000, len(ball_envelope),
-            at_lower_rail, at_upper_rail,
+            window_seconds * 1000,
+            len(ball_envelope),
+            at_lower_rail,
+            at_upper_rail,
         )
 
         # Reject upper-rail picks unless SNR is genuinely high. A peak
@@ -759,7 +880,9 @@ class RollingBufferProcessor:
             logger.warning(
                 "[PROCESSOR] Spin rejected: upper-rail peak at %.0f RPM "
                 "(SNR %.1f < %.1f, bandpass-shoulder noise)",
-                spin_rpm, fft_snr, self.SPIN_SNR_HIGH,
+                spin_rpm,
+                fft_snr,
+                self.SPIN_SNR_HIGH,
             )
             return SpinResult.no_spin_detected(
                 f"Upper-rail peak at {spin_rpm:.0f} RPM "
@@ -778,9 +901,7 @@ class RollingBufferProcessor:
         # SNR (a real low-spin driver tone is strong; noise picks in
         # this zone hover just above the report floor).
         if at_lower_rail and (
-            modulation_depth is None
-            or modulation_depth < 0.012
-            or fft_snr < self.SPIN_SNR_MEDIUM
+            modulation_depth is None or modulation_depth < 0.012 or fft_snr < self.SPIN_SNR_MEDIUM
         ):
             logger.warning(
                 "[PROCESSOR] Spin rejected: lower-rail peak at %.0f RPM "
@@ -805,7 +926,7 @@ class RollingBufferProcessor:
         autocorr_confirmed = False
         if fft_snr < self.SPIN_SNR_MEDIUM and fft_snr >= self.SPIN_SNR_MIN:
             norm = np.correlate(windowed, windowed, mode="full")
-            norm = norm[len(norm) // 2:]  # positive lags only
+            norm = norm[len(norm) // 2 :]  # positive lags only
             if norm[0] > 0:
                 norm = norm / norm[0]
 
@@ -816,8 +937,7 @@ class RollingBufferProcessor:
             # upper rail.
             leakage_floor_hz = (
                 self.SPIN_MIN_SEAM_HZ
-                + self.SPIN_DC_LEAKAGE_BINS * self.SAMPLE_RATE
-                / self.SPIN_ENVELOPE_FFT_SIZE
+                + self.SPIN_DC_LEAKAGE_BINS * self.SAMPLE_RATE / self.SPIN_ENVELOPE_FFT_SIZE
             )
             min_lag = int(self.SAMPLE_RATE / self.SPIN_MAX_SEAM_HZ)
             max_lag = int(self.SAMPLE_RATE / leakage_floor_hz)
@@ -838,7 +958,8 @@ class RollingBufferProcessor:
                             autocorr_confirmed = True
                             logger.info(
                                 "[PROCESSOR] Spin autocorrelation confirms: %.0f RPM (corr=%.2f)",
-                                acorr_rpm, acorr_peak_val,
+                                acorr_rpm,
+                                acorr_peak_val,
                             )
                         else:
                             # Autocorr peak disagrees with FFT peak. The
@@ -851,7 +972,9 @@ class RollingBufferProcessor:
                                 "[PROCESSOR] Spin autocorrelation disagrees: "
                                 "FFT=%.0f RPM, autocorr=%.0f RPM (corr=%.2f); "
                                 "keeping FFT pick",
-                                spin_rpm, acorr_rpm, acorr_peak_val,
+                                spin_rpm,
+                                acorr_rpm,
+                                acorr_peak_val,
                             )
 
         # --- Quality assessment ---
@@ -869,11 +992,7 @@ class RollingBufferProcessor:
 
         if fft_snr < self.SPIN_SNR_MIN and not autocorr_confirmed:
             phase_confirmation = None
-            if (
-                fft_snr >= self.SPIN_PHASE_ENV_SNR_MIN
-                and not at_lower_rail
-                and not at_upper_rail
-            ):
+            if fft_snr >= self.SPIN_PHASE_ENV_SNR_MIN and not at_lower_rail and not at_upper_rail:
                 phase_confirmation = self._phase_spin_confirmation(
                     filtered[spin_window_start_sample:spin_window_end_sample],
                     envelope_spin_rpm=spin_rpm,
@@ -905,17 +1024,19 @@ class RollingBufferProcessor:
                         phase_method=phase_confirmation["method"],
                         phase_rpm=round(phase_confirmation["rpm"]),
                         phase_snr=round(phase_confirmation["snr"], 2),
-                        phase_agreement_pct=round(
-                            phase_confirmation["agreement_pct"], 1
-                        ),
+                        phase_agreement_pct=round(phase_confirmation["agreement_pct"], 1),
                         phase_confirmed=True,
                     )
 
             logger.info(
                 "[PROCESSOR] Spin rejected: SNR %.2f below %.1f "
                 "(peak=%.0f RPM, cycles=%.1f, rail_lo=%s, rail_hi=%s)",
-                fft_snr, self.SPIN_SNR_MIN, spin_rpm, seam_cycles,
-                at_lower_rail, at_upper_rail,
+                fft_snr,
+                self.SPIN_SNR_MIN,
+                spin_rpm,
+                seam_cycles,
+                at_lower_rail,
+                at_upper_rail,
             )
             return SpinResult.no_spin_detected(
                 f"SNR too low ({fft_snr:.2f}, need {self.SPIN_SNR_MIN:.1f})",
@@ -926,21 +1047,17 @@ class RollingBufferProcessor:
                 at_lower_rail=at_lower_rail,
                 at_upper_rail=at_upper_rail,
                 candidates=spin_candidates,
-                phase_method=(
-                    phase_confirmation["method"] if phase_confirmation else None
-                ),
+                phase_method=(phase_confirmation["method"] if phase_confirmation else None),
                 phase_rpm=(
                     round(phase_confirmation["rpm"])
-                    if phase_confirmation and phase_confirmation["rpm"] else None
+                    if phase_confirmation and phase_confirmation["rpm"]
+                    else None
                 ),
-                phase_snr=(
-                    round(phase_confirmation["snr"], 2)
-                    if phase_confirmation else None
-                ),
+                phase_snr=(round(phase_confirmation["snr"], 2) if phase_confirmation else None),
                 phase_agreement_pct=(
                     round(phase_confirmation["agreement_pct"], 1)
-                    if phase_confirmation
-                    and phase_confirmation["agreement_pct"] is not None else None
+                    if phase_confirmation and phase_confirmation["agreement_pct"] is not None
+                    else None
                 ),
                 phase_confirmed=False,
             )
@@ -969,8 +1086,7 @@ class RollingBufferProcessor:
         # fluctuation, however sharp its spectral peak looks.
         if not self._spin_peak_is_persistent(ball_envelope, peak_freq):
             logger.info(
-                "[PROCESSOR] Spin demoted: %.0f RPM peak not persistent "
-                "across both window halves",
+                "[PROCESSOR] Spin demoted: %.0f RPM peak not persistent across both window halves",
                 spin_rpm,
             )
             confidence = min(confidence, 0.3)
@@ -1041,7 +1157,7 @@ class RollingBufferProcessor:
 
         # Keep the top-N by magnitude, but always include the selected
         # candidate so rejected shots explain what the algorithm actually chose.
-        kept = sorted_indices[:self.SPIN_CANDIDATE_COUNT]
+        kept = sorted_indices[: self.SPIN_CANDIDATE_COUNT]
         if selected_idx is not None and selected_idx not in kept:
             kept.append(int(selected_idx))
 
@@ -1112,11 +1228,13 @@ class RollingBufferProcessor:
         if not valid:
             return None
 
-        valid.sort(key=lambda witness: (
-            not witness["confirmed"],
-            witness["agreement_pct"],
-            -witness["snr"],
-        ))
+        valid.sort(
+            key=lambda witness: (
+                not witness["confirmed"],
+                witness["agreement_pct"],
+                -witness["snr"],
+            )
+        )
         return valid[0]
 
     def _phase_spin_candidate(
@@ -1224,8 +1342,7 @@ class RollingBufferProcessor:
         strongest_is_implausible_lower_rail = (
             strongest_is_lower_rail
             and expected_spin_rpm >= self.SPIN_HIGH_PRIOR_MIN_RPM
-            and strongest_rpm
-            < expected_spin_rpm * self.SPIN_IMPLAUSIBLE_LOWER_RAIL_FRACTION
+            and strongest_rpm < expected_spin_rpm * self.SPIN_IMPLAUSIBLE_LOWER_RAIL_FRACTION
         )
 
         candidates = []
@@ -1356,32 +1473,21 @@ class RollingBufferProcessor:
             transition_gap_ms: Optional[float] = None,
         ) -> ImpactEstimate:
             first_ball_center_ms = (
-                self._reading_center_ms(first_ball)
-                if first_ball is not None else None
+                self._reading_center_ms(first_ball) if first_ball is not None else None
             )
             last_club_center_ms = (
-                self._reading_center_ms(last_club)
-                if last_club is not None else None
+                self._reading_center_ms(last_club) if last_club is not None else None
             )
             return ImpactEstimate(
                 timestamp_ms=sound_trigger_ms,
-                source=(
-                    "sound_trigger"
-                    if sound_trigger_ms is not None else "unavailable"
-                ),
+                source=("sound_trigger" if sound_trigger_ms is not None else "unavailable"),
                 reason=reason,
                 speed_delta_mph=speed_delta_mph,
                 transition_gap_ms=transition_gap_ms,
-                last_club_speed_mph=(
-                    last_club.speed_mph if last_club is not None else None
-                ),
-                last_club_timestamp_ms=(
-                    last_club.timestamp_ms if last_club is not None else None
-                ),
+                last_club_speed_mph=(last_club.speed_mph if last_club is not None else None),
+                last_club_timestamp_ms=(last_club.timestamp_ms if last_club is not None else None),
                 last_club_center_ms=last_club_center_ms,
-                first_ball_speed_mph=(
-                    first_ball.speed_mph if first_ball is not None else None
-                ),
+                first_ball_speed_mph=(first_ball.speed_mph if first_ball is not None else None),
                 first_ball_timestamp_ms=(
                     first_ball.timestamp_ms if first_ball is not None else None
                 ),
@@ -1394,7 +1500,8 @@ class RollingBufferProcessor:
             key=lambda r: (r.timestamp_ms, -r.magnitude),
         )
         ball_candidates = [
-            r for r in outbound
+            r
+            for r in outbound
             if abs(r.speed_mph - ball_speed_mph) <= self.BALL_SPEED_MATCH_TOLERANCE_MPH
         ]
         if not ball_candidates:
@@ -1423,8 +1530,7 @@ class RollingBufferProcessor:
 
         if club_speed_mph is not None:
             club_nearby = [
-                r for r in transition_candidates
-                if abs(r.speed_mph - club_speed_mph) <= 5.0
+                r for r in transition_candidates if abs(r.speed_mph - club_speed_mph) <= 5.0
             ]
             if club_nearby:
                 transition_candidates = club_nearby
@@ -1481,6 +1587,7 @@ class RollingBufferProcessor:
 
         # Bin to 1-mph buckets, find the mode
         from collections import Counter
+
         binned = Counter(round(s) for s in speeds)
 
         # The ball is the highest-speed cluster with significant repetition.
@@ -1499,7 +1606,12 @@ class RollingBufferProcessor:
         # Log if max speed differs significantly from mode (outlier rejected)
         max_speed = max(speeds)
         if max_speed > ball_bin + 10:
-            logger.info("[PROCESSOR] Ball speed outlier rejected: max=%.1f, mode=%.1f mph (%d occurrences)", max_speed, float(ball_bin), frequent[0][1])
+            logger.info(
+                "[PROCESSOR] Ball speed outlier rejected: max=%.1f, mode=%.1f mph (%d occurrences)",
+                max_speed,
+                float(ball_bin),
+                frequent[0][1],
+            )
 
         # Return the actual max speed within ±2 mph of the mode bin
         # for sub-mph precision
@@ -1537,7 +1649,11 @@ class RollingBufferProcessor:
             return None
 
         ball_speed_mph = self._find_consistent_ball_speed(std_outbound)
-        logger.info("[PROCESSOR] Ball speed: %.1f mph (mode-based, %d outbound readings)", ball_speed_mph, len(std_outbound))
+        logger.info(
+            "[PROCESSOR] Ball speed: %.1f mph (mode-based, %d outbound readings)",
+            ball_speed_mph,
+            len(std_outbound),
+        )
 
         # Process with overlapping FFT for high-resolution timeline (needed for spin)
         timeline = self.process_overlapping(capture)
@@ -1550,7 +1666,8 @@ class RollingBufferProcessor:
         # (within tolerance) to get the precise timestamp for spin analysis
         outbound = [r for r in timeline.readings if r.is_outbound]
         ball_candidates = [
-            r for r in outbound
+            r
+            for r in outbound
             if abs(r.speed_mph - ball_speed_mph) <= self.BALL_SPEED_MATCH_TOLERANCE_MPH
         ]
         if ball_candidates:
@@ -1571,7 +1688,11 @@ class RollingBufferProcessor:
             timeline, ball_speed_mph, ball_timestamp_ms
         )
         if club_speed_mph is not None:
-            logger.info("[PROCESSOR] Club speed: %.1f mph at %.1fms before ball", club_speed_mph, ball_timestamp_ms - club_timestamp_ms)
+            logger.info(
+                "[PROCESSOR] Club speed: %.1f mph at %.1fms before ball",
+                club_speed_mph,
+                ball_timestamp_ms - club_timestamp_ms,
+            )
         else:
             logger.debug("[PROCESSOR] No club speed found (ball=%.1f mph)", ball_speed_mph)
 
@@ -1605,7 +1726,7 @@ class RollingBufferProcessor:
             expected_spin_rpm = expected_spin_for_ball_speed(ball_speed_mph)
 
         # Spin detection via amplitude envelope demodulation on raw I/Q
-        spin = self.detect_spin(
+        spin = self.detect_spin_multitaper(
             capture,
             ball_speed_mph,
             ball_timestamp_ms,
@@ -1614,7 +1735,9 @@ class RollingBufferProcessor:
 
         logger.info(
             "[PROCESSOR] Spin result: %.0f RPM, SNR=%.2f, quality=%s",
-            spin.spin_rpm, spin.snr, spin.quality,
+            spin.spin_rpm,
+            spin.snr,
+            spin.quality,
         )
 
         return ProcessedCapture(

--- a/src/openflight/rolling_buffer/types.py
+++ b/src/openflight/rolling_buffer/types.py
@@ -263,7 +263,7 @@ class SpinResult:
     spin_rpm: float
     confidence: float
     snr: float
-    quality: str  # "high", "medium", "low", or reason for rejection
+    quality: str  # "high", "medium", "low", "experimental", or rejection reason
     method: str = "envelope_fft"
     multipath_fade_hz: Optional[float] = None
     modulation_depth: Optional[float] = None

--- a/src/openflight/rolling_buffer/types.py
+++ b/src/openflight/rolling_buffer/types.py
@@ -234,6 +234,9 @@ class SpinResult:
         confidence: Quality score from 0-1 (high SNR, valid range = high confidence)
         snr: Signal-to-noise ratio of the spin peak
         quality: Human-readable quality assessment
+        method: Estimator that produced the result.
+        multipath_fade_hz: Fitted two-ray fade frequency removed before
+            estimating spin, when applicable.
         modulation_depth: Envelope std/mean inside the ball window. <0.005
             usually means quantization noise; <0.01 means the FFT peak
             may not be a real seam tone.
@@ -261,6 +264,8 @@ class SpinResult:
     confidence: float
     snr: float
     quality: str  # "high", "medium", "low", or reason for rejection
+    method: str = "envelope_fft"
+    multipath_fade_hz: Optional[float] = None
     modulation_depth: Optional[float] = None
     peak_freq_hz: Optional[float] = None
     seam_cycles: Optional[float] = None
@@ -295,6 +300,8 @@ class SpinResult:
         phase_snr: Optional[float] = None,
         phase_agreement_pct: Optional[float] = None,
         phase_confirmed: bool = False,
+        method: str = "envelope_fft",
+        multipath_fade_hz: Optional[float] = None,
     ) -> "SpinResult":
         """Factory for when spin detection fails. Diagnostic fields are
         carried through so we can see *why* it failed in the JSONL.
@@ -304,6 +311,8 @@ class SpinResult:
             confidence=0,
             snr=round(snr, 2),
             quality=reason,
+            method=method,
+            multipath_fade_hz=multipath_fade_hz,
             modulation_depth=modulation_depth,
             peak_freq_hz=peak_freq_hz,
             seam_cycles=seam_cycles,

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -852,8 +852,14 @@ def shot_to_dict(shot: Shot) -> dict:
             round(shot.spin_rpm_measured) if shot.spin_rpm_measured else None
         ),
         "spin_source": shot.spin_source,
+        "spin_method": shot.spin_method,
         "spin_confidence": round(shot.spin_confidence, 2) if shot.spin_confidence else None,
         "spin_quality": shot.spin_quality,
+        "spin_multipath_fade_hz": (
+            round(shot.spin_multipath_fade_hz, 2)
+            if shot.spin_multipath_fade_hz is not None
+            else None
+        ),
         "spin_snr": round(shot.spin_snr, 2) if shot.spin_snr is not None else None,
         "spin_modulation_depth": (
             round(shot.spin_modulation_depth, 4) if shot.spin_modulation_depth is not None else None
@@ -2125,7 +2131,9 @@ def on_shot_detected(shot: Shot):
                 readings=shot.readings_data,
                 spin_rpm=shot.spin_rpm,
                 spin_confidence=shot.spin_confidence,
+                spin_method=shot.spin_method,
                 spin_quality=shot.spin_quality,
+                spin_multipath_fade_hz=shot.spin_multipath_fade_hz,
                 spin_snr=shot.spin_snr,
                 spin_modulation_depth=shot.spin_modulation_depth,
                 spin_peak_freq_hz=shot.spin_peak_freq_hz,

--- a/src/openflight/session_logger.py
+++ b/src/openflight/session_logger.py
@@ -359,7 +359,7 @@ class SessionLogger:
             spin_rpm: Spin rate in RPM (rolling buffer mode only)
             spin_confidence: Confidence of spin detection (rolling buffer mode only)
             spin_method: Estimator that produced the spin candidate
-            spin_quality: Quality assessment ("high", "medium", "low")
+            spin_quality: Quality assessment ("high", "medium", "low", "experimental")
             spin_multipath_fade_hz: Fitted two-ray fade frequency
             spin_snr: Signal-to-noise ratio of spin detection
             spin_modulation_depth: Envelope std/mean ratio
@@ -864,7 +864,7 @@ class SessionLogger:
             spin_rpm: Detected spin rate in RPM
             spin_confidence: Confidence of spin detection (0-1)
             spin_method: Estimator that produced the spin candidate
-            spin_quality: Quality assessment ("high", "medium", "low")
+            spin_quality: Quality assessment ("high", "medium", "low", "experimental")
             spin_multipath_fade_hz: Fitted two-ray fade frequency
             spin_snr: Signal-to-noise ratio of spin detection
             spin_modulation_depth: Envelope std/mean ratio (1-5% real seam,

--- a/src/openflight/session_logger.py
+++ b/src/openflight/session_logger.py
@@ -312,7 +312,9 @@ class SessionLogger:
         readings: Optional[List[Dict]] = None,
         spin_rpm: Optional[float] = None,
         spin_confidence: Optional[float] = None,
+        spin_method: Optional[str] = None,
         spin_quality: Optional[str] = None,
+        spin_multipath_fade_hz: Optional[float] = None,
         spin_snr: Optional[float] = None,
         spin_modulation_depth: Optional[float] = None,
         spin_peak_freq_hz: Optional[float] = None,
@@ -356,7 +358,9 @@ class SessionLogger:
             readings: Optional list of individual readings that comprised the shot
             spin_rpm: Spin rate in RPM (rolling buffer mode only)
             spin_confidence: Confidence of spin detection (rolling buffer mode only)
+            spin_method: Estimator that produced the spin candidate
             spin_quality: Quality assessment ("high", "medium", "low")
+            spin_multipath_fade_hz: Fitted two-ray fade frequency
             spin_snr: Signal-to-noise ratio of spin detection
             spin_modulation_depth: Envelope std/mean ratio
             spin_peak_freq_hz: Frequency of the picked envelope-FFT peak
@@ -391,7 +395,9 @@ class SessionLogger:
             "readings": readings,
             "spin_rpm": spin_rpm,
             "spin_confidence": spin_confidence,
+            "spin_method": spin_method,
             "spin_quality": spin_quality,
+            "spin_multipath_fade_hz": spin_multipath_fade_hz,
             "spin_snr": spin_snr,
             "spin_modulation_depth": spin_modulation_depth,
             "spin_peak_freq_hz": spin_peak_freq_hz,
@@ -806,7 +812,9 @@ class SessionLogger:
         smash_factor: Optional[float] = None,
         spin_rpm: Optional[float] = None,
         spin_confidence: Optional[float] = None,
+        spin_method: Optional[str] = None,
         spin_quality: Optional[str] = None,
+        spin_multipath_fade_hz: Optional[float] = None,
         spin_snr: Optional[float] = None,
         spin_modulation_depth: Optional[float] = None,
         spin_peak_freq_hz: Optional[float] = None,
@@ -855,7 +863,9 @@ class SessionLogger:
             smash_factor: Ball speed / club speed ratio
             spin_rpm: Detected spin rate in RPM
             spin_confidence: Confidence of spin detection (0-1)
+            spin_method: Estimator that produced the spin candidate
             spin_quality: Quality assessment ("high", "medium", "low")
+            spin_multipath_fade_hz: Fitted two-ray fade frequency
             spin_snr: Signal-to-noise ratio of spin detection
             spin_modulation_depth: Envelope std/mean ratio (1-5% real seam,
                 <0.5% noise floor, 0.5-1% suspicious)
@@ -937,7 +947,9 @@ class SessionLogger:
                 "smash_factor": smash_factor,
                 "spin_rpm": spin_rpm,
                 "spin_confidence": spin_confidence,
+                "spin_method": spin_method,
                 "spin_quality": spin_quality,
+                "spin_multipath_fade_hz": spin_multipath_fade_hz,
                 "spin_snr": spin_snr,
                 "spin_modulation_depth": spin_modulation_depth,
                 "spin_peak_freq_hz": spin_peak_freq_hz,

--- a/tests/test_multitaper_spin.py
+++ b/tests/test_multitaper_spin.py
@@ -1,0 +1,149 @@
+"""Live-pipeline tests for the ungated multitaper spin estimator."""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from openflight.launch_monitor import ClubType
+from openflight.rolling_buffer import (
+    IQCapture,
+    ProcessedCapture,
+    RollingBufferProcessor,
+    SpeedTimeline,
+    SpinResult,
+)
+from openflight.rolling_buffer.multitaper import repair_clipped_iq
+
+
+def _modulated_capture(
+    *,
+    ball_speed_mph: float = 100.0,
+    spin_rpm: float = 9000.0,
+    fade_hz: float = 48.0,
+    spin_depth: float = 0.015,
+    fade_depth: float = 0.15,
+    sample_count: int = 4096,
+) -> IQCapture:
+    """Build an OPS capture with strong multipath fade and weaker seam tone."""
+    sample_rate_hz = 30_000
+    time_s = np.arange(sample_count, dtype=np.float64) / sample_rate_hz
+    speed_mps = ball_speed_mph / RollingBufferProcessor.MPS_TO_MPH
+    doppler_hz = 2.0 * speed_mps / RollingBufferProcessor.WAVELENGTH_M
+    spin_hz = spin_rpm / 60.0
+    amplitude = 500.0 * (
+        1.0
+        + fade_depth * np.sin(2.0 * np.pi * fade_hz * time_s)
+        + spin_depth * np.sin(2.0 * np.pi * spin_hz * time_s)
+    )
+    phase = 2.0 * np.pi * doppler_hz * time_s
+    i_samples = np.clip(amplitude * np.cos(phase) + 2048.0, 0, 4095).astype(int)
+    q_samples = np.clip(amplitude * np.sin(phase) + 2048.0, 0, 4095).astype(int)
+    return IQCapture(
+        sample_time=0.0,
+        trigger_time=0.068,
+        i_samples=i_samples.tolist(),
+        q_samples=q_samples.tolist(),
+    )
+
+
+def test_multitaper_recovers_weak_spin_below_strong_fade():
+    """Fade regression should expose a seam tone much weaker than multipath."""
+    processor = RollingBufferProcessor()
+
+    result = processor.detect_spin_multitaper(
+        _modulated_capture(),
+        ball_speed_mph=100.0,
+        ball_timestamp_ms=5.0,
+    )
+
+    assert result.method == "multitaper_ungated"
+    assert result.spin_rpm == pytest.approx(9000.0, abs=500.0)
+    assert result.quality == "experimental"
+    assert result.rejection_reason is None
+
+
+def test_clipped_iq_is_interpolated_before_multitaper_processing():
+    """Near-rail samples must receive the same repair used in offline scoring."""
+    i_samples = np.array([1000.0, 1100.0, 4095.0, 1300.0, 1400.0])
+    q_samples = np.array([2000.0, 2100.0, 2200.0, 2300.0, 2400.0])
+
+    repaired, clipped_fraction = repair_clipped_iq(i_samples, q_samples)
+
+    assert clipped_fraction == pytest.approx(0.2)
+    assert repaired.real[2] == pytest.approx(0.0)
+    assert repaired.imag[2] == pytest.approx(0.0)
+
+
+def test_process_capture_uses_multitaper_estimator(monkeypatch):
+    """The production capture path must call multitaper, not the legacy gate."""
+    processor = RollingBufferProcessor()
+
+    def legacy_detector_must_not_run(*args, **kwargs):
+        raise AssertionError("legacy spin detector called")
+
+    monkeypatch.setattr(processor, "detect_spin", legacy_detector_must_not_run)
+    processed = processor.process_capture(_modulated_capture())
+
+    assert processed is not None
+    assert processed.spin is not None
+    assert processed.spin.method == "multitaper_ungated"
+    assert processed.spin.spin_rpm > 0
+
+
+def test_multitaper_accepts_short_record_used_by_offline_scoring():
+    """The live wrapper must not reintroduce the legacy 600-sample gate."""
+    processor = RollingBufferProcessor()
+
+    result = processor.detect_spin_multitaper(
+        _modulated_capture(sample_count=512),
+        ball_speed_mph=100.0,
+        ball_timestamp_ms=0.0,
+    )
+
+    assert result.method == "multitaper_ungated"
+    assert result.spin_rpm > 0
+    assert result.rejection_reason is None
+
+
+def test_multitaper_candidate_is_reported_without_confidence_or_rail_gate():
+    """Experimental candidates stay visible but remain excluded from carry."""
+    from openflight.rolling_buffer import RollingBufferMonitor
+
+    capture = _modulated_capture()
+    processed = ProcessedCapture(
+        timeline=SpeedTimeline(readings=[], sample_rate_hz=937.5),
+        ball_speed_mph=100.0,
+        ball_timestamp_ms=60.0,
+        club_speed_mph=75.0,
+        spin=SpinResult(
+            spin_rpm=10_950.0,
+            confidence=0.1,
+            snr=1.2,
+            quality="experimental",
+            method="multitaper_ungated",
+            peak_freq_hz=182.5,
+            at_upper_rail=True,
+        ),
+        capture=capture,
+    )
+    monitor = RollingBufferMonitor(port=None, trigger_type="manual")
+    monitor.set_club(ClubType.PW)
+
+    shot = monitor._create_shot(processed)
+
+    assert shot is not None
+    assert shot.spin_rpm == pytest.approx(10_950.0)
+    assert shot.spin_method == "multitaper_ungated"
+    assert shot.spin_confidence == pytest.approx(0.1)
+    assert shot.spin_rejection_reason is None
+    assert shot.carry_spin_adjusted is None
+
+
+def test_shot_method_defaults_to_none():
+    """Non-rolling and legacy shots remain backward compatible."""
+    from openflight.launch_monitor import Shot
+
+    shot = Shot(ball_speed_mph=100.0, timestamp=datetime.now())
+
+    assert shot.spin_method is None

--- a/tests/test_multitaper_spin.py
+++ b/tests/test_multitaper_spin.py
@@ -122,6 +122,7 @@ def test_multitaper_candidate_is_reported_without_confidence_or_rail_gate():
             snr=1.2,
             quality="experimental",
             method="multitaper_ungated",
+            multipath_fade_hz=48.2,
             peak_freq_hz=182.5,
             at_upper_rail=True,
         ),
@@ -136,8 +137,17 @@ def test_multitaper_candidate_is_reported_without_confidence_or_rail_gate():
     assert shot.spin_rpm == pytest.approx(10_950.0)
     assert shot.spin_method == "multitaper_ungated"
     assert shot.spin_confidence == pytest.approx(0.1)
+    assert shot.spin_quality == "experimental"
     assert shot.spin_rejection_reason is None
     assert shot.carry_spin_adjusted is None
+
+    from openflight.server import shot_to_dict
+
+    payload = shot_to_dict(shot)
+    assert payload["spin_rpm"] == 10_950
+    assert payload["spin_method"] == "multitaper_ungated"
+    assert payload["spin_quality"] == "experimental"
+    assert payload["spin_multipath_fade_hz"] == pytest.approx(48.2)
 
 
 def test_shot_method_defaults_to_none():

--- a/ui/src/components/ShotDisplay.css
+++ b/ui/src/components/ShotDisplay.css
@@ -289,6 +289,18 @@
   color: var(--text-muted);
 }
 
+.metric-card__confidence--experimental {
+  width: fit-content;
+  padding: 2px 7px;
+  border: 1px solid rgba(244, 207, 71, 0.35);
+  border-radius: 999px;
+  background: rgba(244, 207, 71, 0.08);
+}
+
+.metric-card__confidence--experimental .metric-card__confidence-label {
+  color: var(--color-gold);
+}
+
 /* Empty State - Waiting */
 .shot-display--empty {
   display: flex;

--- a/ui/src/components/ShotDisplay.test.tsx
+++ b/ui/src/components/ShotDisplay.test.tsx
@@ -1,6 +1,5 @@
 import { renderToString } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
-import { UnitPreferenceProvider } from '../state/UnitPreferenceProvider';
 import type { Shot } from '../types/shot';
 import { ShotDisplay } from './ShotDisplay';
 
@@ -23,6 +22,7 @@ const experimentalShot: Shot = {
   spin_rpm: 8750,
   spin_confidence: 0.36,
   spin_quality: 'experimental',
+  spin_source: 'measured',
   spin_method: 'multitaper_ungated',
   spin_multipath_fade_hz: 48.2,
   carry_spin_adjusted: null,
@@ -30,11 +30,7 @@ const experimentalShot: Shot = {
 
 describe('ShotDisplay', () => {
   it('labels ungated spin as experimental without confidence dots', () => {
-    const html = renderToString(
-      <UnitPreferenceProvider>
-        <ShotDisplay shot={experimentalShot} />
-      </UnitPreferenceProvider>
-    );
+    const html = renderToString(<ShotDisplay shot={experimentalShot} />);
 
     expect(html).toContain('8,750');
     expect(html).toContain('metric-card__confidence--experimental');

--- a/ui/src/components/ShotDisplay.test.tsx
+++ b/ui/src/components/ShotDisplay.test.tsx
@@ -1,0 +1,44 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { UnitPreferenceProvider } from '../state/UnitPreferenceProvider';
+import type { Shot } from '../types/shot';
+import { ShotDisplay } from './ShotDisplay';
+
+const experimentalShot: Shot = {
+  ball_speed_mph: 105.2,
+  club_speed_mph: 79.4,
+  smash_factor: 1.32,
+  estimated_carry_yards: 132,
+  carry_range: [125, 139],
+  club: 'pitching_wedge',
+  timestamp: '2026-07-17T12:00:00Z',
+  peak_magnitude: 42,
+  launch_angle_vertical: null,
+  launch_angle_horizontal: null,
+  launch_angle_confidence: null,
+  angle_source: null,
+  club_angle_deg: -3.2,
+  club_path_deg: 0.8,
+  spin_axis_deg: -1.1,
+  spin_rpm: 8750,
+  spin_confidence: 0.36,
+  spin_quality: 'experimental',
+  spin_method: 'multitaper_ungated',
+  spin_multipath_fade_hz: 48.2,
+  carry_spin_adjusted: null,
+};
+
+describe('ShotDisplay', () => {
+  it('labels ungated spin as experimental without confidence dots', () => {
+    const html = renderToString(
+      <UnitPreferenceProvider>
+        <ShotDisplay shot={experimentalShot} />
+      </UnitPreferenceProvider>
+    );
+
+    expect(html).toContain('8,750');
+    expect(html).toContain('metric-card__confidence--experimental');
+    expect(html).toContain('experimental');
+    expect(html).not.toContain('metric-card__confidence-dots');
+  });
+});

--- a/ui/src/components/ShotDisplay.tsx
+++ b/ui/src/components/ShotDisplay.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { Shot } from '../types/shot';
+import type { Shot, SpinQuality } from '../types/shot';
 import { useUnitPreference } from '../state/useUnitPreference';
 import { formatCarryRange, formatDistance, formatSpeed, getDistanceUnit, getSpeedUnit } from '../utils/units';
 import './ShotDisplay.css';
@@ -91,7 +91,7 @@ function MetricCard({
   label: string;
   subtext?: string;
   variant?: 'default' | 'primary' | 'secondary' | 'spin';
-  confidence?: 'high' | 'medium' | 'low' | null;
+  confidence?: SpinQuality | null;
 }) {
   return (
     <div className={`metric-card metric-card--${variant}`}>
@@ -103,11 +103,13 @@ function MetricCard({
       {subtext && <span className="metric-card__subtext">{subtext}</span>}
       {confidence && (
         <div className={`metric-card__confidence metric-card__confidence--${confidence}`}>
-          <span className="metric-card__confidence-dots">
-            <span className="dot filled" />
-            <span className={`dot ${confidence === 'medium' || confidence === 'high' ? 'filled' : ''}`} />
-            <span className={`dot ${confidence === 'high' ? 'filled' : ''}`} />
-          </span>
+          {confidence !== 'experimental' && (
+            <span className="metric-card__confidence-dots">
+              <span className="dot filled" />
+              <span className={`dot ${confidence === 'medium' || confidence === 'high' ? 'filled' : ''}`} />
+              <span className={`dot ${confidence === 'high' ? 'filled' : ''}`} />
+            </span>
+          )}
           <span className="metric-card__confidence-label">{confidence}</span>
         </div>
       )}

--- a/ui/src/types/shot.ts
+++ b/ui/src/types/shot.ts
@@ -1,3 +1,5 @@
+export type SpinQuality = 'high' | 'medium' | 'low' | 'experimental';
+
 export interface Shot {
   ball_speed_mph: number;
   club_speed_mph: number | null;
@@ -18,8 +20,10 @@ export interface Shot {
   // Rolling buffer mode spin data
   spin_rpm: number | null;
   spin_confidence: number | null;
-  spin_quality: 'high' | 'medium' | 'low' | null;
+  spin_quality: SpinQuality | null;
   spin_source: 'measured' | 'calculated' | null;
+  spin_method?: string | null;
+  spin_multipath_fade_hz?: number | null;
   carry_spin_adjusted: number | null;
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds the best-performing offline OPS243-A spin track to the live rolling-buffer
pipeline as an explicitly experimental estimator.

The estimator runs automatically for every valid rolling-buffer capture. It
reports its best bounded spin candidate without confidence, club, or rail gates
so Coleman and other testers can collect complete evaluation datasets instead
of losing difficult shots to silent rejection.

Reported shots now include:

- `spin_rpm`
- `spin_method: "multitaper_ungated"`
- `spin_quality: "experimental"`
- peak-to-floor evidence through the existing spin confidence/SNR fields
- the fitted `spin_multipath_fade_hz`

The normal and full-screen UIs display **EXPERIMENTAL** below Spin Rate. These
readings intentionally do not drive spin-adjusted carry.

### How the estimator works

1. Repairs clipped 12-bit I/Q samples by interpolating across samples near the
   ADC rails, then removes the I/Q DC offsets.
2. Bandpasses the complex signal around the measured ball Doppler frequency and
   extracts its amplitude envelope. The window starts at ball detection,
   removes filter transients, and ends at sustained ball-signal loss when the
   net impact truncates the return.
3. Estimates the dominant 25-90 Hz two-ray ground-fade component. A least-squares
   model removes polynomial drift, that fade frequency, and its second harmonic.
4. Applies four DPSS (Slepian) tapers with time-bandwidth 2.5 to the residual
   envelope. It computes a spectrum for each taper and averages their power.
5. Selects the strongest coherent peak in the 1,500-11,000 RPM band. The
   multitaper peak-to-median-floor ratio is retained as evidence, but is not
   currently a reporting gate.

This branch is based on current upstream `main` and has no dependency on the
IWR6843 work.

## Why was this required?

OmniPreSense recommended overlapping 128-sample speed windows to expose the
small ripple associated with ball rotation. Our TrackMan-paired analysis found
that the strongest ripple was usually not spin: it tracked ball speed and radar
placement, consistent with two-ray ground-bounce fading. The 1x seam tone was
present, but could be 10-30x weaker than that placement-dependent fade.

A single-window periodogram is sensitive to the exact endpoints of this short,
non-stationary capture. Spectral leakage and high variance can move the selected
peak between neighboring or unrelated components. DPSS tapers are designed to
concentrate energy inside a controlled bandwidth. Averaging several tapered
spectra reduces variance and endpoint leakage without requiring a longer radar
capture.

Multitaper was selected because it performed best among the offline tracks we
evaluated against TrackMan, not because it has reached production accuracy.
Blind evaluation remains above the product target:

| Session | MAE | Median absolute error |
| --- | ---: | ---: |
| July 14 | 2,499 RPM | 1,682 RPM |
| July 17 held-out | 3,073 RPM | 2,968 RPM |

This PR is intended to broaden hardware evaluation and collect enough paired
data to improve the multipath model. A reported candidate is not a claim that
the reading is correct. The estimator can still choose residual fade energy,
harmonics, or an RPM search rail. Captures with invalid processing or
insufficient post-impact ball signal can still return no spin.

### Reviewer focus

- Is the fitted fade plus second-harmonic model appropriate across expected
  indoor geometries?
- Is the 25-90 Hz fade search band broad enough without removing real low-spin
  energy?
- Is automatic, ungated reporting appropriate for an evaluation release?
- Does Raspberry Pi processing latency remain acceptable during live use?
- Are the `experimental` UI and carry-isolation semantics clear enough to avoid
  treating candidates as production measurements?

## Automated tests

- `uv run pytest tests/ -q`: 919 passed, 6 skipped
- `uv run pytest tests/test_multitaper_spin.py -q`: 6 passed
- `uv run pylint src/openflight/ --fail-under=9`: 9.70/10
- `uv run ruff check src/openflight/ tests/test_multitaper_spin.py`
- `cd ui && npm run test`: 20 passed
- `cd ui && npm run build`
- `cd ui && npm run lint`
- `cd ui && npm run format:check`

The automated tests cover clipped-I/Q repair, synthetic seam recovery beneath a
stronger fade tone, automatic processor selection, ungated reporting, carry
isolation, API serialization, and the UI's experimental label.

## Manual (human) testing

The stored TrackMan-paired captures were replayed through the offline-selected
multitaper implementation. The live implementation reproduced all 193 stored
offline predictions exactly, including the July 14 and held-out July 17 sets
reported above.

Live Raspberry Pi/OPS hardware latency has not yet been benchmarked on this
branch. That is an explicit goal of this evaluation PR rather than a completed
manual test.

Suggested evaluation for Coleman and other testers:

1. Update to this PR and start OpenFlight normally with
   `scripts/start-kiosk.sh`; there is no estimator flag to enable.
2. Confirm the OPS persistent rolling-buffer setup is already complete.
3. Record radar height, ball distance, tilt, net distance, club, and ball model
   for each session. Geometry matters because the dominant fade shifts with
   placement.
4. Collect TrackMan-paired shots and retain the OpenFlight JSONL session logs.
5. Compare every candidate, including low-evidence and search-rail results,
   rather than evaluating only successful-looking shots.

## Checklist

- [x] **Single feature/fix** - this PR is scoped to one experimental estimator
- [x] **Automated tests included** - backend and UI behavior are covered
- [x] **Manual testing described** - offline replay and hardware gap documented
- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [x] UI builds (`cd ui && npm run build`)
- [x] UI lint passes (`cd ui && npm run lint`)
- [x] Updated docs or CHANGELOG if needed
- [x] No unrelated changes mixed in
