### PR TITLE
Add session golf ball picker

### DIFF
--- a/src/openflight/launch_monitor.py
+++ b/src/openflight/launch_monitor.py
@@ -286,6 +286,7 @@ class Shot:
     spin_rejection_reason: Optional[str] = None
     carry_spin_adjusted: Optional[float] = None
     mode: str = "rolling-buffer"
+    ball_name: str = "Unknown Ball"
     readings_data: Optional[list] = None
     angle_source: Optional[str] = None  # "radar", "camera", "estimated", or None
     club_angle_deg: Optional[float] = None  # Club angle of attack from K-LD7 (vertical)

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -82,6 +82,7 @@ mock_mode: bool = False
 debug_mode: bool = False
 debug_log_file = None
 debug_log_path: Optional[Path] = None
+current_ball_name: str = "Unknown Ball"
 
 # K-LD7 angle radars (vertical = launch angle, horizontal = club path)
 kld7_vertical = None
@@ -804,6 +805,7 @@ def _kld7_radc_tuning_kwargs(args) -> dict:
 def _session_start_config() -> dict:
     """Return session-start config including experimental K-LD7 provenance."""
     config = radar_config.copy()
+    config["ball_name"] = current_ball_name
     config["kld7_experiments"] = {
         "trackman_calibration_enabled": False,
         "trackman_calibration_model": None,
@@ -837,6 +839,7 @@ def shot_to_dict(shot: Shot) -> dict:
             round(shot.estimated_carry_range[1]),
         ],
         "club": shot.club.value,
+        "ball_name": shot.ball_name,
         "timestamp": shot.timestamp.isoformat(),
         "peak_magnitude": shot.peak_magnitude,
         # Launch angle data
@@ -1502,6 +1505,7 @@ def handle_connect():
                 "camera_enabled": camera_enabled,
                 "camera_streaming": camera_streaming,
                 "ball_detected": ball_detected,
+                "ball_name": current_ball_name,
             },
         )
         socketio.emit("trigger_status", _get_trigger_status())
@@ -1532,6 +1536,17 @@ def handle_set_club(data):
         pass
 
 
+@socketio.on("set_ball")
+def handle_set_ball(data):
+    """Handle active golf ball selection changes."""
+    global current_ball_name  # pylint: disable=global-statement
+
+    raw_name = data.get("ball_name", "Unknown Ball") if isinstance(data, dict) else "Unknown Ball"
+    ball_name = str(raw_name).strip()[:64] or "Unknown Ball"
+    current_ball_name = ball_name
+    socketio.emit("ball_changed", {"ball_name": current_ball_name})
+
+
 @socketio.on("clear_session")
 def handle_clear_session():
     """Clear all recorded shots."""
@@ -1546,7 +1561,10 @@ def handle_get_session():
     if monitor:
         stats = monitor.get_session_stats()
         shots = [shot_to_dict(s) for s in monitor.get_shots()]
-        socketio.emit("session_state", {"stats": stats, "shots": shots})
+        socketio.emit(
+            "session_state",
+            {"stats": stats, "shots": shots, "ball_name": current_ball_name},
+        )
 
 
 @socketio.on("simulate_shot")
@@ -2025,6 +2043,7 @@ def on_shot_detected(shot: Shot):
     """Callback when a shot is detected - emit to all clients."""
     global ball_detected, ball_detection_confidence  # pylint: disable=global-statement
 
+    shot.ball_name = current_ball_name
     logger.info("[SERVER] Shot callback: %.1f mph", shot.ball_speed_mph)
 
     iwr6843_ms = _process_iwr6843_angle(shot)
@@ -2452,6 +2471,7 @@ def on_shot_detected(shot: Shot):
                 club_path_deg=shot.club_path_deg,
                 spin_axis_deg=shot.spin_axis_deg,
                 impact_timestamp=shot.impact_timestamp,
+                ball_name=shot.ball_name,
                 pipeline_ms={
                     "iwr6843": (round(iwr6843_ms, 1) if iwr6843_ms is not None else None),
                     "kld7": round(kld7_ms, 1) if kld7_ms is not None else None,

--- a/src/openflight/session_logger.py
+++ b/src/openflight/session_logger.py
@@ -343,6 +343,7 @@ class SessionLogger:
         spin_axis_deg: Optional[float] = None,
         pipeline_ms: Optional[Dict] = None,
         impact_timestamp: Optional[float] = None,
+        ball_name: Optional[str] = None,
     ):
         """
         Log a detected shot with all metrics.
@@ -390,6 +391,7 @@ class SessionLogger:
             "smash_factor": smash_factor,
             "estimated_carry_yards": estimated_carry_yards,
             "club": club,
+            "ball_name": ball_name,
             "peak_magnitude": peak_magnitude,
             "readings_count": readings_count,
             "readings": readings,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -705,6 +705,7 @@ class TestShotToDict:
         assert result["ball_speed_mph"] == 150.5
         assert result["club_speed_mph"] == 103.2
         assert result["club"] == "driver"
+        assert result["ball_name"] == "Unknown Ball"
         assert result["timestamp"] == "2024-01-15T10:30:00"
         assert "estimated_carry_yards" in result
         assert "carry_range" in result
@@ -793,6 +794,25 @@ class TestShotToDict:
         assert result["spin_phase_agreement_pct"] == 2.1
         assert result["spin_phase_confirmed"] is True
         assert result["spin_rejection_reason"] == "SNR too low (2.96, need 3.0)"
+
+    def test_set_ball_updates_future_shot_payloads(self, monkeypatch):
+        """Selected UI ball should be stamped on subsequent shot payloads."""
+        emitted = []
+        monkeypatch.setattr(server_module, "current_ball_name", "Unknown Ball")
+        monkeypatch.setattr(server_module.socketio, "emit", lambda *args, **kwargs: emitted.append(args))
+        monkeypatch.setattr(server_module, "monitor", SimpleNamespace(get_session_stats=lambda: {}))
+
+        server_module.handle_set_ball({"ball_name": "Titleist Pro V1"})
+        shot = Shot(
+            ball_speed_mph=150.0,
+            timestamp=datetime(2024, 1, 15, 10, 30, 0),
+            club=ClubType.DRIVER,
+        )
+        server_module.on_shot_detected(shot)
+
+        assert server_module.current_ball_name == "Titleist Pro V1"
+        shot_payload = next(payload for name, payload in emitted if name == "shot")
+        assert shot_payload["shot"]["ball_name"] == "Titleist Pro V1"
 
 
 class TestEstimateLaunchAngle:

--- a/tests/test_session_logger.py
+++ b/tests/test_session_logger.py
@@ -243,12 +243,14 @@ class TestLogShot:
             launch_angle_vertical_source="radar",
             launch_angle_horizontal_source="estimated",
             impact_timestamp=1234567890.25,
+            ball_name="Titleist Pro V1",
         )
 
         lines = logger.session_path.read_text().strip().split("\n")
         entry = json.loads(lines[-1])
 
         assert entry["type"] == "shot_detected"
+        assert entry["ball_name"] == "Titleist Pro V1"
         assert entry["spin_rpm"] is None
         assert entry["spin_snr"] == 2.96
         assert entry["spin_candidate_rpm"] == 5713

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -16,6 +16,7 @@ import { SimStatus } from './components/SimStatus';
 import { SimShotBadges } from './components/SimShotBadges';
 import { ClubPicker } from './components/ClubPicker';
 import { ClubSelectScreen } from './components/ClubSelectScreen';
+import { BallPicker } from './components/BallPicker';
 import { BallDetectionIndicator } from './components/BallDetectionIndicator';
 import { DisplayMode } from './components/DisplayMode';
 import {
@@ -188,6 +189,7 @@ function AppContent() {
               KMH/M
             </button>
           </div>
+          <BallPicker />
           <ClubPicker selectedClub={selectedClub} onClubChange={handleClubChange} />
           <BallDetectionIndicator
             available={cameraStatus.available}

--- a/ui/src/components/BallPicker.tsx
+++ b/ui/src/components/BallPicker.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+import { DEFAULT_BALLS, useBallStore } from '../stores/useBallStore';
+import { useSystemStore } from '../stores/useSystemStore';
+import { socketService } from '../services/socketService';
+import './ClubPicker.css';
+
+export function BallPicker() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [newBall, setNewBall] = useState('');
+  const { balls, customBalls, selectedBall, addBall, removeBall, selectBall } = useBallStore();
+  const connected = useSystemStore((state) => state.connected);
+  const serverBallName = useSystemStore((state) => state.serverBallName);
+
+  useEffect(() => {
+    if (connected) {
+      socketService.setBall(selectedBall);
+    }
+  }, [connected, selectedBall]);
+
+  useEffect(() => {
+    if (serverBallName && serverBallName !== selectedBall) {
+      selectBall(serverBallName);
+    }
+  }, [serverBallName, selectedBall, selectBall]);
+
+  const handleSelect = (ballName: string) => {
+    selectBall(ballName);
+    socketService.setBall(ballName);
+    setIsOpen(false);
+  };
+
+  const handleAdd = () => {
+    const ballName = addBall(newBall);
+    socketService.setBall(ballName);
+    setNewBall('');
+    setIsOpen(false);
+  };
+
+  const handleRemove = (ballName: string) => {
+    removeBall(ballName);
+    if (ballName === selectedBall) {
+      socketService.setBall('Unknown Ball');
+    }
+  };
+
+  return (
+    <div className="club-picker club-picker--ball">
+      <button className="club-picker__trigger" onClick={() => setIsOpen(!isOpen)} aria-expanded={isOpen}>
+        <span className="club-picker__label">Ball</span>
+        <span className="club-picker__value club-picker__value--ball">{selectedBall}</span>
+        <svg
+          className={`club-picker__arrow ${isOpen ? 'club-picker__arrow--open' : ''}`}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <>
+          <div className="club-picker__overlay" onClick={() => setIsOpen(false)} />
+          <div className="club-picker__dropdown club-picker__dropdown--ball">
+            <div className="club-picker__section">
+              <span className="club-picker__section-title">Golf Ball</span>
+              <div className="club-picker__ball-list">
+                {balls.map((ballName) => {
+                  const removable = customBalls.includes(ballName) && !DEFAULT_BALLS.includes(ballName);
+                  return (
+                    <div className="club-picker__ball-row" key={ballName}>
+                      <button
+                        className={`club-picker__option club-picker__option--ball ${
+                          selectedBall === ballName ? 'club-picker__option--selected' : ''
+                        }`}
+                        onClick={() => handleSelect(ballName)}
+                      >
+                        {ballName}
+                      </button>
+                      {removable && (
+                        <button
+                          className="club-picker__remove"
+                          type="button"
+                          aria-label={`Remove ${ballName}`}
+                          title="Remove"
+                          onClick={() => handleRemove(ballName)}
+                        >
+                          X
+                        </button>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="club-picker__add-row">
+              <input
+                className="club-picker__input"
+                type="text"
+                placeholder="Add ball"
+                value={newBall}
+                maxLength={64}
+                onChange={(event) => setNewBall(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    handleAdd();
+                  }
+                }}
+              />
+              <button className="club-picker__add" type="button" onClick={handleAdd}>
+                Add
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/BallPicker.tsx
+++ b/ui/src/components/BallPicker.tsx
@@ -9,7 +9,6 @@ export function BallPicker() {
   const [newBall, setNewBall] = useState('');
   const { balls, customBalls, selectedBall, addBall, removeBall, selectBall } = useBallStore();
   const connected = useSystemStore((state) => state.connected);
-  const serverBallName = useSystemStore((state) => state.serverBallName);
 
   useEffect(() => {
     if (connected) {
@@ -17,21 +16,13 @@ export function BallPicker() {
     }
   }, [connected, selectedBall]);
 
-  useEffect(() => {
-    if (serverBallName && serverBallName !== selectedBall) {
-      selectBall(serverBallName);
-    }
-  }, [serverBallName, selectedBall, selectBall]);
-
   const handleSelect = (ballName: string) => {
     selectBall(ballName);
-    socketService.setBall(ballName);
     setIsOpen(false);
   };
 
   const handleAdd = () => {
-    const ballName = addBall(newBall);
-    socketService.setBall(ballName);
+    addBall(newBall);
     setNewBall('');
     setIsOpen(false);
   };
@@ -39,7 +30,7 @@ export function BallPicker() {
   const handleRemove = (ballName: string) => {
     removeBall(ballName);
     if (ballName === selectedBall) {
-      socketService.setBall('Unknown Ball');
+      selectBall('Unknown Ball');
     }
   };
 

--- a/ui/src/components/ClubPicker.css
+++ b/ui/src/components/ClubPicker.css
@@ -43,6 +43,13 @@
   font-size: 1.125rem;
 }
 
+.club-picker__value--ball {
+  max-width: 8.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .club-picker__arrow {
   width: 14px;
   height: 14px;
@@ -88,6 +95,10 @@
     0 10px 40px rgba(0, 0, 0, 0.5),
     0 0 0 1px rgba(212, 175, 55, 0.1);
   animation: dropdown-enter 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.club-picker__dropdown--ball {
+  min-width: 360px;
 }
 
 @keyframes dropdown-enter {
@@ -155,6 +166,85 @@
   box-shadow: 0 0 12px rgba(212, 175, 55, 0.2);
 }
 
+.club-picker__ball-list {
+  display: grid;
+  gap: var(--space-xs);
+  max-height: min(56vh, 420px);
+  overflow-y: auto;
+  padding-right: var(--space-xs);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(212, 175, 55, 0.45) transparent;
+}
+
+.club-picker__ball-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.club-picker__ball-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.club-picker__ball-list::-webkit-scrollbar-thumb {
+  background: rgba(212, 175, 55, 0.35);
+  border-radius: var(--radius-sm);
+}
+
+.club-picker__ball-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-xs);
+}
+
+.club-picker__option--ball {
+  min-height: 40px;
+  text-align: left;
+}
+
+.club-picker__remove,
+.club-picker__add {
+  min-height: 40px;
+  padding: 0 var(--space-sm);
+  background: transparent;
+  border: 1px solid rgba(245, 240, 230, 0.12);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.club-picker__remove:hover,
+.club-picker__add:hover {
+  color: var(--color-gold);
+  border-color: rgba(212, 175, 55, 0.35);
+}
+
+.club-picker__add-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-xs);
+  margin-top: var(--space-md);
+}
+
+.club-picker__input {
+  min-height: 40px;
+  min-width: 0;
+  padding: 0 var(--space-sm);
+  background: rgba(5, 5, 8, 0.45);
+  border: 1px solid rgba(245, 240, 230, 0.12);
+  border-radius: var(--radius-sm);
+  color: var(--color-cream);
+  font-size: 0.875rem;
+}
+
+.club-picker__input:focus {
+  outline: none;
+  border-color: rgba(212, 175, 55, 0.4);
+  box-shadow: 0 0 0 2px rgba(212, 175, 55, 0.12);
+}
+
 /* Responsive for 7" screen - bottom sheet style */
 @media (max-width: 800px) {
   .club-picker__dropdown {
@@ -204,5 +294,9 @@
 
   .club-picker__value {
     font-size: 1rem;
+  }
+
+  .club-picker__value--ball {
+    max-width: 6.25rem;
   }
 }

--- a/ui/src/components/ShotList.css
+++ b/ui/src/components/ShotList.css
@@ -59,6 +59,24 @@
   text-align: center;
 }
 
+.shot-row__ball {
+  max-width: 8rem;
+  min-width: 5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-cream);
+  background: rgba(34, 197, 94, 0.1);
+  border: 1px solid rgba(34, 197, 94, 0.2);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-sm);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-align: center;
+}
+
 .shot-row__stat {
   display: flex;
   flex-direction: column;
@@ -159,6 +177,13 @@
   .shot-row__club {
     font-size: 0.6875rem;
     min-width: 3rem;
+    padding: 2px var(--space-xs);
+  }
+
+  .shot-row__ball {
+    max-width: 5.75rem;
+    min-width: 3.75rem;
+    font-size: 0.625rem;
     padding: 2px var(--space-xs);
   }
 

--- a/ui/src/components/ShotList.tsx
+++ b/ui/src/components/ShotList.tsx
@@ -23,6 +23,7 @@ const ShotRow = memo(function ShotRow({ shot, shotNumber, unitSystem, distanceUn
     <div className="shot-row">
       <span className="shot-row__number">#{shotNumber}</span>
       <span className="shot-row__club">{shot.club}</span>
+      <span className="shot-row__ball">{shot.ball_name ?? 'Unknown Ball'}</span>
       <span className="shot-row__stat">
         <span className="shot-row__value">{formatSpeed(shot.ball_speed_mph, unitSystem, 1)}</span>
         <span className="shot-row__label">ball</span>

--- a/ui/src/services/socketService.ts
+++ b/ui/src/services/socketService.ts
@@ -69,6 +69,10 @@ class SocketService {
       useSystemStore.getState().setServerClub(data.club);
     });
 
+    this.socket.on('ball_changed', (data: { ball_name: string }) => {
+      useSystemStore.getState().setServerBallName(data.ball_name);
+    });
+
     this.socket.on(
       'session_state',
       (
@@ -79,6 +83,7 @@ class SocketService {
           camera_enabled?: boolean;
           camera_streaming?: boolean;
           ball_detected?: boolean;
+          ball_name?: string;
         }
       ) => {
         console.log('Session state received:', data);
@@ -91,6 +96,9 @@ class SocketService {
         }
         if (data.debug_mode !== undefined) {
           systemStore.setDebugMode(data.debug_mode);
+        }
+        if (data.ball_name !== undefined) {
+          systemStore.setServerBallName(data.ball_name);
         }
 
         // Update camera status from session state
@@ -157,6 +165,10 @@ class SocketService {
 
   setClub(club: string) {
     this.socket?.emit('set_club', { club });
+  }
+
+  setBall(ballName: string) {
+    this.socket?.emit('set_ball', { ball_name: ballName });
   }
 
   simulateShot() {

--- a/ui/src/stores/useBallStore.ts
+++ b/ui/src/stores/useBallStore.ts
@@ -1,0 +1,143 @@
+import { create } from 'zustand';
+
+export const DEFAULT_BALLS = [
+  'Unknown Ball',
+  'Range Ball',
+  'Titleist Pro V1',
+  'Titleist Pro V1x',
+  'Titleist AVX',
+  'Titleist Tour Soft',
+  'Callaway Chrome Tour',
+  'Callaway Chrome Tour X',
+  'Callaway Chrome Soft',
+  'Callaway ERC Soft',
+  'Callaway Supersoft',
+  'TaylorMade TP5',
+  'TaylorMade TP5x',
+  'TaylorMade Tour Response',
+  'TaylorMade SpeedSoft',
+  'Srixon Z-Star',
+  'Srixon Z-Star XV',
+  'Srixon Q-Star Tour',
+  'Srixon Soft Feel',
+  'Bridgestone Tour B X',
+  'Bridgestone Tour B XS',
+  'Bridgestone Tour B RX',
+  'Bridgestone Tour B RXS',
+  'Wilson Staff Model',
+  'Wilson Duo Soft',
+  'Maxfli Tour',
+  'Maxfli Tour X',
+  'Vice Pro',
+  'Vice Pro Plus',
+  'Mizuno RB Tour',
+];
+
+const BALLS_STORAGE_KEY = 'openflight-balls';
+const SELECTED_BALL_STORAGE_KEY = 'openflight-selected-ball';
+const DEFAULT_BALL = 'Unknown Ball';
+
+function cleanBallName(name: string): string {
+  return name.trim().slice(0, 64);
+}
+
+function dedupeBalls(balls: string[]): string[] {
+  const seen = new Set<string>();
+  return balls.filter((ball) => {
+    const key = ball.toLowerCase();
+    if (!ball || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function loadCustomBalls(): string[] {
+  if (typeof window === 'undefined') return [];
+
+  try {
+    const raw = window.localStorage.getItem(BALLS_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    if (Array.isArray(parsed)) {
+      return parsed.map((name) => cleanBallName(String(name))).filter(Boolean).slice(0, 24);
+    }
+  } catch {
+    // Ignore broken localStorage data and fall back to defaults.
+  }
+  return [];
+}
+
+function saveCustomBalls(customBalls: string[]) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(BALLS_STORAGE_KEY, JSON.stringify(customBalls));
+  } catch {
+    // Ignore storage failures; the picker still works for the current session.
+  }
+}
+
+function saveSelectedBall(ballName: string) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(SELECTED_BALL_STORAGE_KEY, ballName);
+  } catch {
+    // Ignore storage failures; the picker still works for the current session.
+  }
+}
+
+function loadSelectedBall(): string {
+  if (typeof window === 'undefined') return '';
+  try {
+    return cleanBallName(window.localStorage.getItem(SELECTED_BALL_STORAGE_KEY) ?? '');
+  } catch {
+    return '';
+  }
+}
+
+interface BallState {
+  balls: string[];
+  customBalls: string[];
+  selectedBall: string;
+  addBall: (name: string) => string;
+  removeBall: (name: string) => void;
+  selectBall: (name: string) => void;
+}
+
+const initialCustomBalls = loadCustomBalls();
+const initialBalls = dedupeBalls([...DEFAULT_BALLS, ...initialCustomBalls]);
+const savedSelected = loadSelectedBall();
+const initialSelected = initialBalls.includes(savedSelected) ? savedSelected : DEFAULT_BALL;
+
+export const useBallStore = create<BallState>((set, get) => ({
+  balls: initialBalls,
+  customBalls: initialCustomBalls,
+  selectedBall: initialSelected,
+  addBall: (name) => {
+    const ballName = cleanBallName(name) || DEFAULT_BALL;
+    const nextCustomBalls = dedupeBalls([...get().customBalls, ballName]).slice(0, 24);
+    const nextBalls = dedupeBalls([...DEFAULT_BALLS, ...nextCustomBalls]);
+    saveCustomBalls(nextCustomBalls);
+    saveSelectedBall(ballName);
+    set({ balls: nextBalls, customBalls: nextCustomBalls, selectedBall: ballName });
+    return ballName;
+  },
+  removeBall: (name) => {
+    const current = get();
+    const nextCustomBalls = current.customBalls.filter((ball) => ball !== name);
+    const nextBalls = dedupeBalls([...DEFAULT_BALLS, ...nextCustomBalls]);
+    const selectedBall = current.selectedBall === name ? DEFAULT_BALL : current.selectedBall;
+    saveCustomBalls(nextCustomBalls);
+    saveSelectedBall(selectedBall);
+    set({ balls: nextBalls, customBalls: nextCustomBalls, selectedBall });
+  },
+  selectBall: (name) => {
+    const ballName = cleanBallName(name) || DEFAULT_BALL;
+    const current = get();
+    const customBalls = current.balls.some((ball) => ball.toLowerCase() === ballName.toLowerCase())
+      ? current.customBalls
+      : dedupeBalls([...current.customBalls, ballName]).slice(0, 24);
+    const balls = dedupeBalls([...DEFAULT_BALLS, ...customBalls]);
+    saveCustomBalls(customBalls);
+    saveSelectedBall(ballName);
+    set({ balls, customBalls, selectedBall: ballName });
+  },
+}));

--- a/ui/src/stores/useSystemStore.ts
+++ b/ui/src/stores/useSystemStore.ts
@@ -8,12 +8,14 @@ interface SystemState {
   simStatuses: Record<string, SimStatus>;
   latestSimShots: Record<string, SimShotInfo>;
   serverClub: string | null;
+  serverBallName: string | null;
   setConnected: (connected: boolean) => void;
   setMockMode: (mockMode: boolean) => void;
   setDebugMode: (debugMode: boolean) => void;
   setSimStatus: (status: SimStatus) => void;
   setLatestSimShot: (shot: SimShotInfo) => void;
   setServerClub: (club: string | null) => void;
+  setServerBallName: (ballName: string | null) => void;
 }
 
 export const useSystemStore = create<SystemState>((set) => ({
@@ -23,6 +25,7 @@ export const useSystemStore = create<SystemState>((set) => ({
   simStatuses: {},
   latestSimShots: {},
   serverClub: null,
+  serverBallName: null,
   setConnected: (connected) => set({ connected }),
   setMockMode: (mockMode) => set({ mockMode }),
   setDebugMode: (debugMode) => set({ debugMode }),
@@ -35,4 +38,5 @@ export const useSystemStore = create<SystemState>((set) => ({
       latestSimShots: { ...state.latestSimShots, [shot.target]: shot },
     })),
   setServerClub: (serverClub) => set({ serverClub }),
+  setServerBallName: (serverBallName) => set({ serverBallName }),
 }));

--- a/ui/src/types/shot.ts
+++ b/ui/src/types/shot.ts
@@ -7,6 +7,7 @@ export interface Shot {
   estimated_carry_yards: number;
   carry_range: [number, number];
   club: string;
+  ball_name?: string;
   timestamp: string;
   peak_magnitude: number | null;
   // Launch angle data (from K-LD7 radar (deprecated), camera, or estimation)


### PR DESCRIPTION
Adds a session-level golf ball picker so shots can be tagged with the ball used.

- Adds a Ball picker in the UI
- Includes common ball presets and custom ball creation
- Sends selected ball to the server via Socket.IO
- Tags shot payloads and session logs with `ball_name`
- Displays ball name in the shot list