### PR TITLE
fix(tests): compute repo root portably in start-kiosk contract tests

### DIFF
--- a/tests/test_start_kiosk.py
+++ b/tests/test_start_kiosk.py
@@ -1,10 +1,24 @@
 """Tests for the kiosk entry script flag wiring."""
 
+import shutil
 import subprocess
+from pathlib import Path
+
+import pytest
+
+# The contract under test is the bash script's flag forwarding; without a
+# POSIX shell there is nothing to exercise. With one present (e.g. Git Bash
+# on Windows) --dry-run works everywhere.
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="start-kiosk.sh contract tests need bash"
+)
 
 
 def _dry_run(*args: str, check: bool = True):
-    repo_root = __file__.rsplit("/tests/", 1)[0]
+    # pathlib, not string-splitting on "/tests/": __file__ uses backslashes
+    # on Windows, which made repo_root the test file itself (cwd=<file> ->
+    # NotADirectoryError in CreateProcess).
+    repo_root = Path(__file__).resolve().parents[1]
     return subprocess.run(
         ["bash", "scripts/start-kiosk.sh", *args, "--dry-run"],
         cwd=repo_root,


### PR DESCRIPTION
## What does this PR do?

Fixes the repo-root computation in `tests/test_start_kiosk.py` so the start-kiosk contract tests run on Windows: `Path(__file__).resolve().parents[1]` instead of `__file__.rsplit("/tests/", 1)`, plus a `skipif` for environments with no `bash` at all.

## Why was this required?

All 17 tests in this module fail on a Windows checkout — but not for the reason it appears. `__file__` uses backslashes on Windows, so `rsplit("/tests/", 1)` never matches and `repo_root` ends up being the test file itself; `subprocess.run(..., cwd=<file>)` then dies in `CreateProcess` with `NotADirectoryError` before `bash` is even consulted. With the cwd computed portably, the whole module **runs and passes on Windows** under Git Bash — these are real contract tests being lost to a path bug, not POSIX-only tests. A module-level `skipif(shutil.which("bash") is None)` covers machines that genuinely lack a POSIX shell.

Windows contributors currently see 22 red tests on a stock checkout (17 of them from this module) and learn to ignore failures — corrosive to a repo whose culture is "tests are non-negotiable."

## Automated tests

This PR is itself test-only: the 18 tests in `tests/test_start_kiosk.py` are the coverage. Before: 17 fail on Windows with `NotADirectoryError`. After: **18/18 pass on Windows** (Git Bash) and behavior on Linux/macOS is unchanged (`Path.resolve().parents[1]` yields the same directory the old expression yielded there).

## Manual (human) testing

- Reproduced the failure mode on Windows 11 before the fix (`NotADirectoryError: [WinError 267]` from `CreateProcess`).
- Verified the underlying script works under Git Bash by hand: `bash scripts/start-kiosk.sh --iwr6843 --dry-run` from the repo root prints `openflight-server --web-port 8080 --no-camera --trigger sound --iwr6843` (rc=0).
- Ran the module on Windows: 18 passed in 5.4 s. Ruff clean.

## Checklist

- [x] **Single feature/fix** — this PR is scoped to one thing with a clear story above
- [x] **Automated tests included** — test-only change; the module is the coverage
- [x] **Manual testing described** — I documented what I verified by hand above
- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [ ] UI builds (`cd ui && npm run build`) — not applicable, no UI changes
- [ ] UI lint passes (`cd ui && npm run lint`) — not applicable, no UI changes
- [x] Updated docs or CHANGELOG if needed — test-only, no changelog entry
- [x] No unrelated changes mixed in
