### PR TITLE
fix(analysis): write the session shot report as UTF-8

### DIFF
--- a/scripts/analysis/session_shot_report.py
+++ b/scripts/analysis/session_shot_report.py
@@ -116,7 +116,7 @@ def load_session(path: Path) -> Session:
     """Parse a session JSONL into a :class:`Session`."""
     sess = Session()
     offsets: Counter = Counter()
-    with path.open() as fh:
+    with path.open(encoding="utf-8") as fh:
         for line in fh:
             line = line.strip()
             if not line:
@@ -480,7 +480,9 @@ def main(argv: list[str] | None = None) -> int:
     rows = collect_rows(sess, geom, sess.tuning)
     out_html = render_html(rows, args.session.stem, geom)
     out_path = args.output or args.session.with_suffix(".report.html")
-    out_path.write_text(out_html)
+    # Explicit encoding: the report contains non-ASCII glyphs (″, °), which
+    # crash on Windows' default cp1252 codec.
+    out_path.write_text(out_html, encoding="utf-8")
 
     t1 = sum(1 for r in rows if r["tier"] == 1)
     t2 = sum(1 for r in rows if r["tier"] == 2)


### PR DESCRIPTION
## What does this PR do?

Adds explicit `encoding="utf-8"` to the session-shot-report script's file I/O: the HTML output write and the session-JSONL read (`scripts/analysis/session_shot_report.py`, two lines).

## Why was this required?

The generated report contains non-ASCII glyphs (`″` for inches, `°` for degrees). Without an explicit encoding, `Path.write_text` uses the platform default codec — cp1252 on Windows — and report generation crashes with `UnicodeEncodeError: 'charmap' codec can't encode character '″'`. Anyone on Windows running the offline report tool against a session log hits this. The JSONL read gets the same treatment for symmetry (session logs are written as UTF-8).

## Automated tests

The previously failing `tests/test_session_shot_report.py::TestMain::test_main_writes_report` (which exercises `main()` end-to-end, including the report write) is the regression test — it fails on Windows before this change and passes after. Full module: 14/14 on Windows.

## Manual (human) testing

- Reproduced the crash on Windows 11: running the report path produced the `UnicodeEncodeError` in `cp1252.py` before the fix; after the fix the report generates cleanly.
- Verified the read-side change against a session JSONL fixture (module tests cover blank/malformed lines).
- Ruff clean on the touched file.

## Checklist

- [x] **Single feature/fix** — this PR is scoped to one thing with a clear story above
- [x] **Automated tests included** — the existing end-to-end test covers this fix (fails before, passes after on Windows)
- [x] **Manual testing described** — I documented what I verified by hand above
- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [ ] UI builds (`cd ui && npm run build`) — not applicable, no UI changes
- [ ] UI lint passes (`cd ui && npm run lint`) — not applicable, no UI changes
- [x] Updated docs or CHANGELOG if needed — analysis-script fix, no changelog entry
- [x] No unrelated changes mixed in
