### PR TITLE
fix(tests): write CRLF CSV fixtures byte-exact on Windows

### DIFF
--- a/tests/test_compare_trackman.py
+++ b/tests/test_compare_trackman.py
@@ -154,7 +154,9 @@ class TestLoadTrackman:
             "5/6/2026 6:58:02 PM,7 Iron,118.5,17.2,-1.5\r\n"
             "5/6/2026 6:59:00 PM,Driver,165.0,11.0,0.5\r\n"
         )
-        path.write_text(content, encoding="utf-8")
+        # newline="" keeps the CRLF content byte-exact; the default translates
+        # "\n" to os.linesep, turning "\r\n" into "\r\r\n" on Windows.
+        path.write_text(content, encoding="utf-8", newline="")
         shots = ct.load_trackman(path)
         assert len(shots) == 2
         assert shots[0].club == "7-iron"
@@ -173,7 +175,7 @@ class TestLoadTrackman:
             ",[mph]\r\n"
             "7 Iron,120.0\r\n"
         )
-        path.write_text(content, encoding="utf-8")
+        path.write_text(content, encoding="utf-8", newline="")
         shots = ct.load_trackman(path)
         assert len(shots) == 1
         assert shots[0].ball_speed_mph == pytest.approx(120.0)


### PR DESCRIPTION
## What does this PR do?

Adds `newline=""` to the two CRLF CSV fixture writes in `tests/test_compare_trackman.py` so the fixture bytes reach disk exactly as written on every platform.

## Why was this required?

`Path.write_text` applies default newline translation (`"\n"` → `os.linesep`), which turns the fixtures' embedded `\r\n` into `\r\r\n` on Windows. The BOM/`sep=` preamble test (`test_handles_excel_sep_preamble_and_bom`) then parses 0 shots instead of 2 and fails on every Windows checkout. These fixtures exist to reproduce what TrackMan actually exports, so they must be byte-exact; `newline=""` disables translation and is a no-op on POSIX.

## Automated tests

Test-only change — the module is the coverage: `tests/test_compare_trackman.py` goes from 34 passed / 1 failed to **35/35 on Windows**; unchanged on Linux/macOS.

## Manual (human) testing

- Reproduced the failure on Windows 11 before the change (`assert 0 == 2` — zero shots parsed from the CRLF fixture).
- After: full module passes on Windows; confirmed via the sibling `_write_trackman_csv` helper (which already used `open(..., newline="")`) that this matches the file's existing convention.

## Checklist

- [x] **Single feature/fix** — this PR is scoped to one thing with a clear story above
- [x] **Automated tests included** — test-only change; the module is the coverage
- [x] **Manual testing described** — I documented what I verified by hand above
- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [ ] UI builds (`cd ui && npm run build`) — not applicable, no UI changes
- [ ] UI lint passes (`cd ui && npm run lint`) — not applicable, no UI changes
- [x] Updated docs or CHANGELOG if needed — test-only, no changelog entry
- [x] No unrelated changes mixed in
