### PR TITLE
test: skip POSIX-only assertions on Windows with explicit reasons

### DIFF
--- a/tests/test_cloud_config.py
+++ b/tests/test_cloud_config.py
@@ -1,6 +1,7 @@
 """Tests for the openflight-cloud config module."""
 
 import json
+import os
 import stat
 
 import pytest
@@ -39,6 +40,9 @@ class TestLoadConfig:
 
 
 class TestSaveConfig:
+    @pytest.mark.skipif(
+        os.name == "nt", reason="POSIX permission bits are not representable on Windows"
+    )
     def test_writes_file_with_0600_permissions(self, tmp_path):
         path = tmp_path / "nested" / "cloud.json"
         config = cfg.CloudConfig(device_token="tok", device_id="id")

--- a/tests/test_serial_latency.py
+++ b/tests/test_serial_latency.py
@@ -1,10 +1,16 @@
 """Tests for USB serial latency timer diagnostics."""
 
+import os
 from pathlib import Path
+
+import pytest
 
 from openflight.serial_latency import read_usb_serial_latency_timer
 
 
+@pytest.mark.skipif(
+    os.name == "nt", reason="symlink creation requires elevation on Windows"
+)
 def test_read_usb_serial_latency_timer_resolves_udev_alias(tmp_path: Path):
     dev_root = tmp_path / "dev"
     sysfs_root = tmp_path / "sys" / "bus" / "usb-serial" / "devices"


### PR DESCRIPTION
## What does this PR do?

Adds `skipif(os.name == "nt", ...)` with explicit reasons to two tests that assert POSIX platform capabilities: the cloud-config 0600-permission check (`tests/test_cloud_config.py`) and the udev-alias resolution test (`tests/test_serial_latency.py`).

## Why was this required?

Both tests fail on a Windows checkout for environmental reasons, not product bugs: POSIX permission bits aren't representable through `st_mode` on Windows, and the udev test's `symlink_to` needs elevation there. Together with the recently merged #171 and #172, this is part of getting a stock Windows checkout to zero unexplained failures — today contributors see red tests and learn to ignore them, which erodes the "tests must pass" signal. Skips with stated reasons make the environment limit explicit and keep the tests fully active on Linux/macOS (including the Pi, where the 0600 check actually matters).

## Automated tests

Test-only change: the two modules report 12 passed / 2 skipped on Windows (previously 2 failed); on POSIX the skip conditions are false and nothing changes.

## Manual (human) testing

- Ran both modules on Windows 11 before (2 environment failures) and after (2 skips, reasons visible under `-rs`).
- Verified the skip conditions target exactly the capability each test needs (mode-bit representability; unprivileged symlink creation) rather than blanket-skipping the modules — the other 12 tests still run on Windows.

## Checklist

- [x] **Single feature/fix** — this PR is scoped to one thing with a clear story above
- [x] **Automated tests included** — test-only change; the modules are the coverage
- [x] **Manual testing described** — I documented what I verified by hand above
- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [ ] UI builds (`cd ui && npm run build`) — not applicable, no UI changes
- [ ] UI lint passes (`cd ui && npm run lint`) — not applicable, no UI changes
- [x] Updated docs or CHANGELOG if needed — test-only, no changelog entry
- [x] No unrelated changes mixed in
