### PR TITLE
fix(tests): make the sim backoff test deterministic across platforms

### DIFF
--- a/tests/test_sim_transport.py
+++ b/tests/test_sim_transport.py
@@ -5,17 +5,19 @@ sim server, plus framing unit tests for the brace-balanced JSON framer.
 """
 import json
 import time
-from typing import List, Optional
+from typing import Optional
 
 import pytest
 
 from openflight.gspro.codec import GSProCodec
-from openflight.sim.transport import find_json_end, TcpSimClient
-from openflight.sim.types import (
-    ConnectionState, PlayerUpdate, ResolvedShot, ShotAck,
-)
 from openflight.launch_monitor import ClubType
-
+from openflight.sim.transport import TcpSimClient, find_json_end
+from openflight.sim.types import (
+    ConnectionState,
+    PlayerUpdate,
+    ResolvedShot,
+    ShotAck,
+)
 
 # --- framing unit tests ------------------------------------------------------
 
@@ -250,14 +252,44 @@ def test_reconnect_after_server_drop(mock_sim):
         client.stop()
 
 
-def test_backoff_progression_capped():
+def test_backoff_progression_capped(monkeypatch):
+    # Refuse instantly instead of dialing a real closed port: how fast the OS
+    # rejects a connect to 127.0.0.1:1 is platform-dependent (slow enough on
+    # Windows that a fixed sleep captured fewer than two retries), and the
+    # backoff schedule under test doesn't need a real socket at all.
+    from openflight.sim import transport as transport_mod
+
+    class _InstantRefusalSocket:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def settimeout(self, _timeout):
+            pass
+
+        def connect(self, _addr):
+            raise ConnectionRefusedError("refused (test)")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(transport_mod.socket, "socket", _InstantRefusalSocket)
+
     client = TcpSimClient("127.0.0.1", 1, GSProCodec(), heartbeat_interval_s=60,
                           backoff_seconds=(0.05, 0.1, 0.1))
     statuses = []
     client.on_status = statuses.append
     client.start()
-    time.sleep(0.5)
-    client.stop()
+    try:
+        # Poll for the retries instead of sleeping a fixed interval.
+        deadline = time.time() + 3.0
+        while time.time() < deadline:
+            backoffs = [s.next_retry_in_s for s in statuses
+                        if s.state == ConnectionState.CONNECTING and s.next_retry_in_s > 0]
+            if len(backoffs) >= 3:
+                break
+            time.sleep(0.02)
+    finally:
+        client.stop()
     # Before the first successful connection the client reports CONNECTING during
     # the retry backoff (RECONNECT_BACKOFF is reserved for a connection that was
     # established and then dropped). The backoff schedule is still carried on


### PR DESCRIPTION
## What does this PR do?

Makes `test_backoff_progression_capped` deterministic: the socket in `openflight.sim.transport` is monkeypatched to refuse connections instantly, and the test polls for the retries it asserts on instead of sleeping a fixed 0.5 s. Also applies ruff's mechanical import-block fix to this file (pre-existing `I001`/`F401` that the pre-commit hook enforces on any touch).

## Why was this required?

The test dialed a real socket at `127.0.0.1:1` and slept 0.5 s, then asserted at least two retries had happened. How fast the OS refuses that connect is platform-dependent — on Windows it's slow enough that fewer than two retries land inside the window, so the test fails on every stock Windows checkout (and is timing-sensitive everywhere). The subject under test is the client's backoff schedule, not the platform's TCP stack; the fake socket exercises the same `_try_connect` failure path (`settimeout` → `connect` raises `OSError` subclass → `close`) without the platform dependence.

## Automated tests

Test-only change: `tests/test_sim_transport.py` 22/22 on Windows (previously 21/1). The poll loop bounds the wait at 3 s but typically completes in well under half a second.

## Manual (human) testing

- Reproduced the flake on Windows 11 (fixed sleep captured < 2 retries) before the change.
- After: ran the single test repeatedly and the full module — green each time; verified the fake implements exactly the socket surface `_try_connect` uses so the production failure path (log + `close` + backoff) still executes.

## Checklist

- [x] **Single feature/fix** — this PR is scoped to one thing with a clear story above
- [x] **Automated tests included** — test-only change; the module is the coverage
- [x] **Manual testing described** — I documented what I verified by hand above
- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [ ] UI builds (`cd ui && npm run build`) — not applicable, no UI changes
- [ ] UI lint passes (`cd ui && npm run lint`) — not applicable, no UI changes
- [x] Updated docs or CHANGELOG if needed — test-only, no changelog entry
- [x] No unrelated changes mixed in
