### PR TITLE
docs(readme): note the Pi hostname works in place of the IP for TV display

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,17 @@ for details.
 OpenFlight also serves a fullscreen-friendly browser display for tablets, TV browsers, or a Chrome tab cast to Chromecast.
 
 1. Start OpenFlight as usual with `scripts/start-kiosk.sh`.
-2. Find the OpenFlight host IP address on your LAN.
-3. Open `http://<openflight-host-ip>:8080/display` from another laptop, tablet, or TV browser.
+2. Find the OpenFlight host on your LAN — its hostname (see below) or its IP address.
+3. Open `http://<openflight-host>:8080/display` from another laptop, tablet, or TV browser.
 4. For Chromecast, open the display page in Chrome and use Chrome's built-in **Cast** feature to cast the tab.
+
+> **Prefer the hostname over the IP.** Raspberry Pi OS broadcasts its hostname over
+> mDNS (Avahi), so `http://openflight.local:8080/display` keeps working even when the
+> Pi's DHCP lease expires and it comes back on a different address — a bookmarked IP
+> breaks unless you reserved it on your router. Set the name in Raspberry Pi Imager's
+> **Hostname** field when you flash the card; the default is `raspberrypi`, i.e.
+> `raspberrypi.local`. The viewing device has to support mDNS — macOS, iOS, Windows 10+
+> and most Linux desktops do, but some smart-TV browsers don't, so use the IP there.
 
 This is browser/tab casting only. OpenFlight does not include native Cast SDK support yet.
 


### PR DESCRIPTION
## What does this PR do?

Notes in **TV Display Mode** that the Pi's hostname works in place of its IP — e.g. `http://openflight.local:8080/display`.

## Why was this required?

A bookmarked IP silently stops working when the Pi's DHCP lease expires and it comes back on a different address. Reserving the IP on the router avoids that, but it's an easy step to miss. Raspberry Pi OS already broadcasts its hostname over mDNS, so the hostname is the stabler address to hand out.

## Automated tests

None — docs-only change to `README.md`; no code paths touched.

## Manual (human) testing

Docs-only, so this was verified against primary sources and the repo itself rather than by re-running the app. **Not verified on a live Pi + TV** — flagging that honestly.

<details>
<summary>What was checked, and against what</summary>

| Claim | Verified against |
|---|---|
| Imager sets a hostname; the Pi broadcasts it via mDNS as `<hostname>.local` | [Raspberry Pi getting-started docs](https://www.raspberrypi.com/documentation/computers/getting-started.html) — *"Your Raspberry Pi broadcasts this hostname to the network using mDNS … other devices … can communicate with your Raspberry Pi using `<hostname>.local`"* |
| Raspberry Pi OS resolves `.local` via Avahi; default hostname is `raspberrypi` | [Raspberry Pi remote-access docs](https://www.raspberrypi.com/documentation/computers/remote-access.html) — *"Raspberry Pi OS supports multicast DNS as part of the Avahi service."* |
| The display page actually answers on a LAN hostname | `src/openflight/server.py` binds `--host` default `0.0.0.0`, `--web-port` default `8080` |
| This repo already depends on mDNS | `scripts/setup/sync-to-pi.sh` defaults to `PI_HOST=pi@raspberrypi.local` |
| Client-side mDNS is the real caveat | Same Raspberry Pi doc hedges *"If your device supports mDNS"* — so the note keeps the IP as the fallback and calls out smart-TV browsers |

The install path this assumes is the one the repo already documents: `docs/raspberry-pi-setup.md:24` says to use Raspberry Pi Imager.

</details>

## Checklist

- [x] **Single feature/fix** — one README section
- [ ] **Automated tests included** — N/A, docs-only (explained above)
- [x] **Manual testing described** — sources and limits stated above
- [ ] Python tests pass — N/A, no Python touched
- [ ] Pylint passes — N/A, no Python touched
- [ ] Ruff passes — N/A, no Python touched
- [ ] UI builds — N/A, no UI touched
- [ ] UI lint passes — N/A, no UI touched
- [x] Updated docs or CHANGELOG if needed
- [x] No unrelated changes mixed in
