### PR TITLE
feat(ops243): improve club-speed selection through impact transition

### DIFF
--- a/src/openflight/rolling_buffer/monitor.py
+++ b/src/openflight/rolling_buffer/monitor.py
@@ -436,6 +436,7 @@ class RollingBufferMonitor:
                             self._current_club,
                         )
                     ),
+                    club_type=self._current_club,
                 )
                 process_ms = (time.time() - process_start) * 1000
                 logger.info("[MONITOR] process_capture: %.1fms", process_ms)

--- a/src/openflight/rolling_buffer/processor.py
+++ b/src/openflight/rolling_buffer/processor.py
@@ -12,7 +12,7 @@ from typing import Callable, List, Optional, Tuple
 import numpy as np
 from scipy.signal import butter, find_peaks, sosfiltfilt
 
-from ..launch_monitor import SPIN_CONFIDENCE_HIGH
+from ..launch_monitor import SPIN_CONFIDENCE_HIGH, ClubType
 from .multitaper import estimate_multitaper_spin, repair_clipped_iq
 from .types import (
     ImpactEstimate,
@@ -73,6 +73,23 @@ class RollingBufferProcessor:
     # Matches the streaming processor's dc_mask and the trigger's
     # 15 mph acceptance threshold — no useful signal lives below 15 mph.
     DC_MASK_BINS = 150
+
+    # Club-speed extraction. Each overlapping FFT spans 4.27 ms, so the
+    # windows immediately before the first ball reading contain mixed club and
+    # ball energy. Track the fastest pre-impact Doppler branch, then summarize
+    # its plateau before that mixed region instead of selecting the strongest
+    # reflector (which is frequently the shaft or an earlier swing return).
+    CLUB_BRANCH_HISTORY_MS = 30.0
+    CLUB_BALL_ONSET_SEARCH_MS = 10.0
+    CLUB_BALL_MATCH_MIN_MPH = 4.0
+    CLUB_BALL_MATCH_FRACTION = 0.06
+    CLUB_PLATEAU_LOOKBACK_MS = 18.0
+    CLUB_PLATEAU_GUARD_MS = 4.0
+    CLUB_PLATEAU_QUANTILE = 0.70
+    CLUB_BALL_CONTAMINATION_RATIO = 0.95
+    CLUB_TERMINAL_START_MS = -2.5
+    CLUB_TERMINAL_END_MS = 1.0
+    CLUB_MAX_PLAUSIBLE_SPEED_MPH = 150.0
 
     # Spin detection via amplitude envelope demodulation.
     # The ball seam modulates the radar return at 1x spin rate.
@@ -1415,25 +1432,130 @@ class RollingBufferProcessor:
         ball_speed_mph: float,
         ball_timestamp_ms: float,
         max_window_ms: float = 100,
+        club_type: ClubType = ClubType.UNKNOWN,
     ) -> Tuple[Optional[float], Optional[float]]:
         """
-        Find club head speed from readings before ball impact.
+        Find club-head speed from the upper Doppler branch before impact.
 
-        Club speed should be:
-        - Before ball (temporally)
-        - 67-85% of ball speed (smash factor 1.18-1.50)
-        - Outbound direction
+        The club head normally forms the fastest accelerating branch before
+        the stable ball-speed branch appears. Its return can be weaker than the
+        shaft, so magnitude alone is not a reliable identity selector. The
+        final FFT windows also mix club and ball energy; a robust percentile of
+        the preceding plateau avoids that contamination.
+
+        Sand-wedge club and ball speeds can overlap, producing a smooth merge
+        rather than a distinct transition. For that measured case, use the
+        terminal upper branch instead of imposing an iron/driver smash-factor
+        bracket.
 
         Args:
             timeline: Speed timeline
             ball_speed_mph: Detected ball speed
             ball_timestamp_ms: When ball was detected
             max_window_ms: Maximum time before ball to search
+            club_type: Selected club, used for smooth wedge transitions
 
         Returns:
             Tuple of (club_speed_mph, club_timestamp_ms) or (None, None)
         """
-        # Expected club speed range
+        legacy_speed, legacy_timestamp = self._find_club_speed_by_magnitude(
+            timeline,
+            ball_speed_mph,
+            ball_timestamp_ms,
+            max_window_ms,
+        )
+
+        history_ms = min(max_window_ms, self.CLUB_BRANCH_HISTORY_MS)
+        upper_by_timestamp: dict[float, SpeedReading] = {}
+        for reading in timeline.readings:
+            relative_ms = reading.timestamp_ms - ball_timestamp_ms
+            if not reading.is_outbound:
+                continue
+            if not -history_ms <= relative_ms <= self.CLUB_TERMINAL_END_MS:
+                continue
+            if not 0 < reading.speed_mph <= self.CLUB_MAX_PLAUSIBLE_SPEED_MPH:
+                continue
+            current = upper_by_timestamp.get(reading.timestamp_ms)
+            if current is None or reading.speed_mph > current.speed_mph:
+                upper_by_timestamp[reading.timestamp_ms] = reading
+
+        upper_branch = sorted(
+            upper_by_timestamp.values(),
+            key=lambda reading: reading.timestamp_ms,
+        )
+        if len(upper_branch) < 3:
+            return legacy_speed, legacy_timestamp
+
+        if club_type == ClubType.SW:
+            terminal = [
+                reading
+                for reading in upper_branch
+                if self.CLUB_TERMINAL_START_MS
+                <= reading.timestamp_ms - ball_timestamp_ms
+                <= self.CLUB_TERMINAL_END_MS
+            ]
+            terminal_pick = self._quantile_reading(terminal, 0.50)
+            if terminal_pick is not None:
+                return terminal_pick.speed_mph, terminal_pick.timestamp_ms
+
+        ball_tolerance_mph = max(
+            self.CLUB_BALL_MATCH_MIN_MPH,
+            ball_speed_mph * self.CLUB_BALL_MATCH_FRACTION,
+        )
+        onset_timestamp_ms: Optional[float] = None
+        for first, second in zip(upper_branch, upper_branch[1:]):
+            first_relative_ms = first.timestamp_ms - ball_timestamp_ms
+            if first_relative_ms < -self.CLUB_BALL_ONSET_SEARCH_MS:
+                continue
+            if (
+                abs(first.speed_mph - ball_speed_mph) <= ball_tolerance_mph
+                and abs(second.speed_mph - ball_speed_mph) <= ball_tolerance_mph
+            ):
+                onset_timestamp_ms = first.timestamp_ms
+                break
+
+        if onset_timestamp_ms is None:
+            # One overlapping FFT step before the mixed club/ball guard.
+            onset_timestamp_ms = ball_timestamp_ms - 3.2
+
+        plateau_start_ms = onset_timestamp_ms - self.CLUB_PLATEAU_LOOKBACK_MS
+        plateau_end_ms = onset_timestamp_ms - self.CLUB_PLATEAU_GUARD_MS
+        plateau = [
+            reading
+            for reading in upper_branch
+            if plateau_start_ms <= reading.timestamp_ms <= plateau_end_ms
+        ]
+        plateau_pick = self._quantile_reading(plateau, self.CLUB_PLATEAU_QUANTILE)
+        if plateau_pick is None:
+            return legacy_speed, legacy_timestamp
+
+        if plateau_pick.speed_mph > ball_speed_mph * self.CLUB_BALL_CONTAMINATION_RATIO:
+            return legacy_speed, legacy_timestamp
+
+        return plateau_pick.speed_mph, plateau_pick.timestamp_ms
+
+    @staticmethod
+    def _quantile_reading(readings: list[SpeedReading], quantile: float) -> Optional[SpeedReading]:
+        """Return the observed reading nearest a speed quantile."""
+        if not readings:
+            return None
+        target_speed = float(np.quantile([reading.speed_mph for reading in readings], quantile))
+        return min(
+            readings,
+            key=lambda reading: (
+                abs(reading.speed_mph - target_speed),
+                -reading.timestamp_ms,
+            ),
+        )
+
+    @staticmethod
+    def _find_club_speed_by_magnitude(
+        timeline: SpeedTimeline,
+        ball_speed_mph: float,
+        ball_timestamp_ms: float,
+        max_window_ms: float,
+    ) -> Tuple[Optional[float], Optional[float]]:
+        """Provide a conservative fallback when no usable branch exists."""
         min_club = ball_speed_mph * 0.67
         max_club = ball_speed_mph * 0.85
 
@@ -1454,7 +1576,6 @@ class RollingBufferProcessor:
         if not candidates:
             return None, None
 
-        # Select highest magnitude (club head has larger radar cross-section)
         club_reading = max(candidates, key=lambda r: r.magnitude)
 
         return club_reading.speed_mph, club_reading.timestamp_ms
@@ -1639,6 +1760,7 @@ class RollingBufferProcessor:
         capture: IQCapture,
         expected_spin_rpm: Optional[float] = None,
         expected_spin_for_ball_speed: Optional[Callable[[float], float]] = None,
+        club_type: ClubType = ClubType.UNKNOWN,
     ) -> Optional[ProcessedCapture]:
         """
         Full processing pipeline: I/Q -> speeds -> spin -> shot data.
@@ -1649,6 +1771,7 @@ class RollingBufferProcessor:
                 only to choose among visible envelope peaks.
             expected_spin_for_ball_speed: Optional callback for deriving a
                 spin prior after ball speed has been detected.
+            club_type: Selected club for club-speed transition interpretation.
 
         Returns:
             ProcessedCapture with all extracted data, or None if processing fails
@@ -1701,7 +1824,10 @@ class RollingBufferProcessor:
 
         # Find club speed
         club_speed_mph, club_timestamp_ms = self.find_club_speed(
-            timeline, ball_speed_mph, ball_timestamp_ms
+            timeline,
+            ball_speed_mph,
+            ball_timestamp_ms,
+            club_type=club_type,
         )
         if club_speed_mph is not None:
             logger.info(

--- a/src/openflight/rolling_buffer/processor.py
+++ b/src/openflight/rolling_buffer/processor.py
@@ -90,6 +90,7 @@ class RollingBufferProcessor:
     CLUB_TERMINAL_START_MS = -2.5
     CLUB_TERMINAL_END_MS = 1.0
     CLUB_MAX_PLAUSIBLE_SPEED_MPH = 150.0
+    CLUB_SMOOTH_MERGE_TYPES = frozenset({ClubType.SW, ClubType.LW})
 
     # Spin detection via amplitude envelope demodulation.
     # The ball seam modulates the radar return at 1x spin rate.
@@ -1443,10 +1444,9 @@ class RollingBufferProcessor:
         final FFT windows also mix club and ball energy; a robust percentile of
         the preceding plateau avoids that contamination.
 
-        Sand-wedge club and ball speeds can overlap, producing a smooth merge
-        rather than a distinct transition. For that measured case, use the
-        terminal upper branch instead of imposing an iron/driver smash-factor
-        bracket.
+        High-loft wedge club and ball speeds can overlap, producing a smooth
+        merge rather than a distinct transition. For that case, use the terminal
+        upper branch instead of imposing an iron/driver smash-factor bracket.
 
         Args:
             timeline: Speed timeline
@@ -1486,7 +1486,7 @@ class RollingBufferProcessor:
         if len(upper_branch) < 3:
             return legacy_speed, legacy_timestamp
 
-        if club_type == ClubType.SW:
+        if club_type in self.CLUB_SMOOTH_MERGE_TYPES:
             terminal = [
                 reading
                 for reading in upper_branch

--- a/tests/test_rolling_buffer.py
+++ b/tests/test_rolling_buffer.py
@@ -1876,8 +1876,9 @@ class TestFindClubSpeedOverlap:
         assert club_speed == pytest.approx(82.0)
         assert club_ts == 18.0
 
-    def test_sand_wedge_uses_smooth_terminal_trace(self, processor):
-        """A wedge club trace can merge into the similarly fast ball trace."""
+    @pytest.mark.parametrize("club_type", [ClubType.SW, ClubType.LW])
+    def test_high_loft_wedge_uses_smooth_terminal_trace(self, processor, club_type):
+        """A high-loft wedge trace can merge into the similarly fast ball trace."""
         ball_timestamp_ms = 30.0
         readings = [
             SpeedReading(speed, 30.0, ball_timestamp_ms + relative_ms, "outbound")
@@ -1898,7 +1899,7 @@ class TestFindClubSpeedOverlap:
             timeline,
             ball_speed_mph=70.0,
             ball_timestamp_ms=ball_timestamp_ms,
-            club_type=ClubType.SW,
+            club_type=club_type,
         )
 
         assert club_speed == pytest.approx(69.0)

--- a/tests/test_rolling_buffer.py
+++ b/tests/test_rolling_buffer.py
@@ -1830,6 +1830,106 @@ class TestFindClubSpeedOverlap:
 
         assert club_speed == 75.0  # Higher magnitude
 
+    def test_accelerating_head_branch_beats_stronger_shaft_return(self, processor):
+        """Follow the upper pre-impact branch instead of the strongest reflector."""
+        ball_timestamp_ms = 30.0
+        readings = []
+        head_speeds = [60.0, 68.0, 75.0, 80.0, 82.0, 83.0, 83.0, 78.0]
+        for relative_ms, speed_mph in zip(
+            [-20.0, -18.0, -16.0, -14.0, -12.0, -10.0, -8.0, -6.0],
+            head_speeds,
+        ):
+            readings.append(
+                SpeedReading(
+                    speed_mph=speed_mph,
+                    magnitude=25.0,
+                    timestamp_ms=ball_timestamp_ms + relative_ms,
+                    direction="outbound",
+                )
+            )
+
+        # This slower shaft/body return is stronger than the club head and is
+        # what the former maximum-magnitude selector chose.
+        readings.append(
+            SpeedReading(
+                speed_mph=70.0,
+                magnitude=1000.0,
+                timestamp_ms=18.0,
+                direction="outbound",
+            )
+        )
+        readings.extend(
+            [
+                SpeedReading(98.0, 200.0, 26.0, "outbound"),
+                SpeedReading(99.0, 250.0, 27.0, "outbound"),
+                SpeedReading(100.0, 300.0, 30.0, "outbound"),
+            ]
+        )
+        timeline = SpeedTimeline(readings=readings, sample_rate_hz=937.5)
+
+        club_speed, club_ts = processor.find_club_speed(
+            timeline,
+            ball_speed_mph=100.0,
+            ball_timestamp_ms=ball_timestamp_ms,
+        )
+
+        assert club_speed == pytest.approx(82.0)
+        assert club_ts == 18.0
+
+    def test_sand_wedge_uses_smooth_terminal_trace(self, processor):
+        """A wedge club trace can merge into the similarly fast ball trace."""
+        ball_timestamp_ms = 30.0
+        readings = [
+            SpeedReading(speed, 30.0, ball_timestamp_ms + relative_ms, "outbound")
+            for relative_ms, speed in [
+                (-12.0, 47.0),
+                (-10.0, 52.0),
+                (-8.0, 57.0),
+                (-6.0, 62.0),
+                (-4.0, 66.0),
+                (-2.0, 68.0),
+                (-1.0, 69.0),
+                (0.0, 70.0),
+            ]
+        ]
+        timeline = SpeedTimeline(readings=readings, sample_rate_hz=937.5)
+
+        club_speed, club_ts = processor.find_club_speed(
+            timeline,
+            ball_speed_mph=70.0,
+            ball_timestamp_ms=ball_timestamp_ms,
+            club_type=ClubType.SW,
+        )
+
+        assert club_speed == pytest.approx(69.0)
+        assert club_ts == 29.0
+
+    def test_ball_contaminated_plateau_falls_back_to_credible_candidate(self, processor):
+        """A non-wedge plateau above 95% of ball speed is likely the ball."""
+        ball_timestamp_ms = 30.0
+        readings = [
+            SpeedReading(75.0, 500.0, 10.0, "outbound"),
+            SpeedReading(96.0, 20.0, 12.0, "outbound"),
+            SpeedReading(97.0, 20.0, 14.0, "outbound"),
+            SpeedReading(98.0, 20.0, 16.0, "outbound"),
+            SpeedReading(98.0, 20.0, 18.0, "outbound"),
+            SpeedReading(98.0, 20.0, 20.0, "outbound"),
+            SpeedReading(99.0, 100.0, 26.0, "outbound"),
+            SpeedReading(100.0, 200.0, 27.0, "outbound"),
+            SpeedReading(100.0, 300.0, 30.0, "outbound"),
+        ]
+        timeline = SpeedTimeline(readings=readings, sample_rate_hz=937.5)
+
+        club_speed, club_ts = processor.find_club_speed(
+            timeline,
+            ball_speed_mph=100.0,
+            ball_timestamp_ms=ball_timestamp_ms,
+            club_type=ClubType.IRON_9,
+        )
+
+        assert club_speed == 75.0
+        assert club_ts == 10.0
+
 
 class TestImpactEstimate:
     """Tests for OPS club-to-ball impact timing."""


### PR DESCRIPTION
## What does this PR do?

This PR improves OPS243 club-speed extraction by following the fastest outbound Doppler branch through the impact transition instead of assuming the strongest pre-impact reflector is the club head.

The selector now:

- builds an upper pre-impact speed branch from the rolling-buffer timeline
- excludes the final mixed club/ball FFT region and selects an observed reading near the 70th percentile of the preceding speed plateau
- detects the stable ball-speed transition and rejects likely ball-contaminated club candidates
- uses a terminal median for sand wedge and lob wedge, where club and ball speeds can merge smoothly
- retains the existing magnitude-based selector as a conservative fallback for sparse or ambiguous captures
- receives the currently selected club from `RollingBufferMonitor`

## Why was this required?

The previous selector constrained club speed to 67-85% of ball speed and chose the highest-magnitude return. In real captures, the shaft or body can be a stronger reflector than the club head, while high-loft wedges can fall outside the assumed smash-factor shape. That produced a persistent low club-speed bias and avoidable missing readings.

Tracking the upper Doppler branch better matches the physics of the accelerating club head and substantially improves agreement with TrackMan without adding per-player calibration or changing the OPS firmware.

## Automated tests

Added regression coverage for:

- selecting an accelerating club-head branch over a stronger shaft return
- handling smooth sand-wedge and lob-wedge transitions
- falling back safely when the candidate plateau is contaminated by ball energy

Validation run:

- `uv run pytest tests/ -q`: **1171 passed, 8 skipped**
- `uv run ruff check src/openflight/ tests/test_rolling_buffer.py`: passed
- `uv run ruff format --check ...`: passed
- `uv run pylint src/openflight/ --fail-under=9`: passed at **9.70/10**
- `cd ui && npm run build`: passed
- `cd ui && npm run lint`: passed

## Manual (human) testing

Replayed real OPS243 rolling-buffer I/Q captures from three TrackMan sessions (July 14, July 17, and July 22) against 196 valid TrackMan club-speed measurements.

| Metric | Existing selector | Transition selector |
|---|---:|---:|
| Coverage | 190/196 (96.9%) | 195/196 (99.5%) |
| MAE | 6.50 mph | 3.06 mph |
| Bias | -6.18 mph | -1.46 mph |
| P50 absolute error | 3.71 mph | 2.03 mph |
| P75 absolute error | 8.95 mph | 3.34 mph |
| P90 absolute error | 16.65 mph | 4.96 mph |

On the 190 shots detected by both selectors, MAE improved from 6.50 mph to 2.77 mph. Bootstrap resampling estimated a **3.74 mph mean MAE improvement** with a 95% confidence interval of **2.84-4.69 mph**.

The replay included 17 sand-wedge shots. Lob wedge uses the same physically similar smooth-transition path, but the available TrackMan sessions contained no lob-wedge source-of-truth shots, so that case remains explicitly covered by regression tests rather than TrackMan validation.

## Checklist

- [x] **Single feature/fix** — this PR is scoped to OPS243 club-speed selection
- [x] **Automated tests included** — transition, wedge, contamination, and fallback behavior are covered
- [x] **Manual testing described** — three real-hardware TrackMan sessions were replayed above
- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [x] UI builds (`cd ui && npm run build`)
- [x] UI lint passes (`cd ui && npm run lint`)
- [x] Updated docs or CHANGELOG if needed — no user-facing configuration or API changed
- [x] No unrelated changes mixed in
