### PR TITLE
docs: add shared Mouser project to the parts list

### DIFF
--- a/docs/PARTS.md
+++ b/docs/PARTS.md
@@ -2,6 +2,8 @@
 
 Hardware components for building the OpenFlight golf launch monitor.
 
+> **Ordering shortcut:** A shared **[OpenFlight Mouser project](https://www.mouser.com/en/Tools/Project/Share?AccessID=4c97a00bbc)** is available for the parts Mouser stocks — open it, save it to your own Mouser account, and add the whole list to your cart in one step instead of searching for each item. Check it against the tables below before you order: anything Mouser does not carry has a direct vendor link here.
+
 > **Next step after gathering parts:** See the [Raspberry Pi Setup Guide](raspberry-pi-setup.md) for assembly and software installation.
 
 ## Core Components


### PR DESCRIPTION
## What does this PR do?

Adds a shared Mouser project link to the top of `docs/PARTS.md`, so builders can
load the Mouser-stocked parts into a cart in one step instead of searching for
each item individually.

**Link:** https://www.mouser.com/en/Tools/Project/Share?AccessID=4c97a00bbc

One doc, one callout, +2 lines. No code, tests, or CI paths touched.

## Why was this required?

Sourcing is the most tedious step between "I want to build this" and "I have a
box of parts on my desk." The parts list currently sends the reader to a
different vendor per row, which means a dozen separate searches and carts before
a build can even start — friction that lands entirely on new builders, i.e. the
people least likely to push through it.

A pre-filled Mouser project collapses the Mouser-stocked portion of that into a
single copy-to-cart. Without it, every builder repeats the same lookup work by
hand, and small passives like the R17 resistor are easy to forget until the
sound trigger misbehaves.

The callout deliberately tells readers to check the project against the tables
below before ordering: not every part on this page is a Mouser SKU, and the
per-vendor links stay authoritative for what the build actually needs.

## Automated tests

**None added — and I don't think any are warranted here.** The change is two
lines of prose in `docs/PARTS.md`. Nothing under `src/openflight/` or `ui/src/`
is touched (the `Tests included` check confirms this and passes), and the repo
has no docs/markdown or link-checking suite for a test to hook into. Adding one
solely for this PR would be scope creep.

What I did verify mechanically, in place of a test: I rendered the changed
section through GitHub's GFM markdown API and confirmed the callout produces a
well-formed `<blockquote>` and that the link `href` survives intact with its full
`?AccessID=4c97a00bbc` query string (an easy thing to mangle in markdown).

<details>
<summary>If you'd like a real guard against doc-link rot, here's the option</summary>

A markdown link checker (e.g. `lycheeverse/lychee-action`) in CI would catch
dead vendor links across all of `docs/` — a recurring problem for a parts list
whose links point at third-party storefronts that reorganize URLs.

Note it would **not** cover this particular link: Mouser blocks non-browser
clients (see the manual-testing section), so a checker would either fail on it
or need it allowlisted. Happy to open that as a separate PR if you want it; I've
kept it out of this one to keep the change scoped to a single thing.

</details>

## Manual (human) testing

Being straight with you about who verified what, since this PR was prepared by
an agent (Claude) working in @HuggeK's checkout:

**Verified programmatically:**
- Rendered the modified section of `docs/PARTS.md` through GitHub's markdown API
  — the new callout renders as a blockquote alongside the existing "Next step"
  one, and the Mouser URL renders as a link with the query string intact.
- Reviewed the resulting diff in the PR's Files view: 2 added lines, no
  reflow or collateral change to the surrounding tables.

**NOT verified, and needs one human click before merge:**
- **That the share link actually resolves to the intended project.** Mouser
  serves an "Access to this page has been denied" captcha page to every
  non-browser client, so the URL could not be opened programmatically — `curl`
  returns HTTP 200 with a block page rather than the project. The URL came from
  @HuggeK, who created the project, but a maintainer should open it in a real
  browser and confirm it loads, is still shared (these links can be revoked),
  and holds the parts you'd expect.

This is also why the callout's wording doesn't enumerate the project's contents:
they couldn't be read, and a hand-guessed line-item list in the doc would drift
out of sync with the project anyway. If you'd prefer the doc to name which parts
the project covers, tell me what's in it and I'll add them.

## Checklist

- [x] **Single feature/fix** — one doc callout, scoped to one thing
- [ ] **Automated tests included** — N/A, docs-only; rationale above
- [x] **Manual testing described** — including what was *not* verified
- [ ] Python tests pass — not run; no Python touched
- [ ] Pylint passes — not run; no Python touched
- [ ] Ruff passes — not run; no Python touched
- [ ] UI builds — not run; no UI touched
- [ ] UI lint passes — not run; no UI touched
- [x] Updated docs or CHANGELOG if needed — this PR *is* the doc update
- [x] No unrelated changes mixed in
