### PR TITLE
docs: add Discord community link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 </p>
 
 <p align="center">
+  <a href="https://discord.gg/w8hhG4WVMN">
+    <img src="https://img.shields.io/badge/Discord-join%20the%20community-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join the OpenFlight Discord" />
+  </a>
   <a href="https://buymeacoffee.com/colemangolfs">
     <img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-yellow?style=for-the-badge&logo=buy-me-a-coffee&logoColor=white" alt="Buy Me a Coffee" />
   </a>
@@ -277,6 +280,11 @@ openflight/
 ├── docs/                      # Documentation
 └── pyproject.toml
 ```
+
+## Community
+
+Join the **[OpenFlight Discord](https://discord.gg/w8hhG4WVMN)** to ask build
+questions, share results, and follow development.
 
 ## Contributing
 


### PR DESCRIPTION
## What does this PR do?

Adds the OpenFlight Discord invite (https://discord.gg/w8hhG4WVMN) to the README in two places:

- A **Discord badge** in the header badge row, immediately before the existing Buy Me a Coffee badge.
- A short **Community** section just above Contributing, linking the invite with a line of context.

Docs only — 8 added lines, 0 removed, no source, tests, or behavior touched.

<details>
<summary>Why both a badge and a section</summary>

The badge is what people scan for at the top of a repo, but badges are easy to miss on mobile and get lost as more are added. The Community section gives the link a stable, linkable home in the document body plus a sentence saying what the server is for. The overlap is 8 lines total, which seemed a fair trade for the link being findable both ways.

</details>

<details>
<summary>Badge implementation detail</summary>

A shields.io **static** badge in Discord brand blue (`5865F2`), with `style=for-the-badge` so it matches the existing Buy Me a Coffee badge exactly.

Static rather than the dynamic `discord/{server_id}` badge on purpose: the dynamic variant requires the server to keep its widget enabled, and it renders a live member count that fluctuates — a low number on a young server reads worse than no number at all.

</details>

## Why was this required?

The Discord server exists, but nothing in the repo pointed at it, so the only ways to find it were word of mouth or an external link. Anyone landing on the GitHub page had no route to the community.

That matters more than usual for this project specifically: OpenFlight is a hardware build, so the questions people get stuck on — wiring the SEN-14262, R17 resistor values, radar aiming and geometry, flashing the IWR6843 — are interactive, environment-specific, and often need a photo. Those are a poor fit for issues (which stay open for days and accumulate as noise) and a good fit for chat. Without a visible link, that traffic either becomes low-quality issues or the person quietly gives up on the build.

The cost of not doing it is diffuse but real: a support channel that exists and is doing nothing, and a slower first-build experience for newcomers.

## Automated tests

**No automated tests added — none are applicable to this change.**

The diff adds eight lines of prose and markup to `README.md`. There is no code path, no function, and no behavior to assert against; the repo has no README link-checking or docs-linting suite that a new case could plug into.

The two things that *could* silently break here are external and outside the reach of a unit test: the Discord invite expiring, and the shields.io badge URL failing to serve. Both were verified by hand instead — see below.

The existing suites all ran on this PR and pass (`pytest` on 3.10/3.11/3.12, Pylint, UI build/lint/e2e), confirming the change is inert with respect to the codebase.

## Manual (human) testing

Verification was performed against the live URLs and GitHub's own renderer, not just by eyeballing the diff:

**1. Discord invite is valid and permanent.** Queried the invite through the Discord API (`GET https://discord.com/api/v10/invites/w8hhG4WVMN`):

- Resolves to guild **"OpenFlight"** — the correct server, not a stale or unrelated invite.
- `"expires_at": null` → **permanent invite.** This was the specific thing worth checking: Discord's default share invite expires after 7 days, and a README link that silently dies a week after merge is worse than no link. This one does not expire.
- `"type": 0` (standard guild invite).
- `https://discord.gg/w8hhG4WVMN` returns `301` and follows through normally in a browser.

**2. Badge image actually serves.** `curl` on the shields.io URL returns `200`, `content-type: image/svg+xml`, 2566 bytes — a real SVG, not an error placeholder.

**3. Rendered through GitHub's markdown pipeline.** Ran the modified header through GitHub's own GFM renderer (`gh api markdown`) rather than trusting a local preview, since the header is raw HTML inside markdown and GitHub proxies images through camo. Confirmed:

- Both badges emerge as proper `<a><img></a>` pairs with camo-proxied `src` values.
- The Discord badge sits **before** Buy Me a Coffee in the same `<p align="center">` row, so the header stays a single centered row rather than wrapping to two.
- The `alt` text ("Join the OpenFlight Discord") survives, so the badge is not a bare unlabeled image for screen readers.

**4. Read the rendered result for placement.** The Community section lands between Project Structure and Contributing — adjacent to Contributing, which is where someone who has just decided to get involved is already looking.

**Edge cases exercised by hand:** invite expiry (the main failure mode, ruled out above); badge URL returning an error rather than an image; header row wrapping from the extra badge; missing alt text.

**Not verified:** how the badge row looks on a narrow mobile viewport at a real device width — I checked the rendered HTML structure, not a screenshot at 375px.

## Checklist

- [x] **Single feature/fix** — one thing: add the Discord link to the README
- [ ] **Automated tests included** — deliberately not; docs-only change with nothing assertable, rationale under Automated tests above
- [x] **Manual testing described** — invite validity/permanence, badge availability, and GitHub-rendered output, all documented above
- [x] Python tests pass (`uv run pytest tests/ -v`) — verified green by CI on this PR (3.10 / 3.11 / 3.12)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`) — verified green by CI on this PR
- [x] Ruff passes (`uv run ruff check src/openflight/`) — no Python files touched
- [x] UI builds (`cd ui && npm run build`) — verified green by CI on this PR
- [x] UI lint passes (`cd ui && npm run lint`) — verified green by CI on this PR
- [x] Updated docs or CHANGELOG if needed — this PR *is* the docs change; no CHANGELOG entry, as it alters no shipped behavior
- [x] No unrelated changes mixed in — `README.md` only, +8 / −0
