### PR TITLE
Add LIS3DH inclinometer compensation

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ uv run pytest tests/ -v
 - **[Sound Trigger Wiring](docs/sound-trigger-wiring.md)** — How to wire the sound trigger
 - **[Raspberry Pi Setup](docs/raspberry-pi-setup.md)** — Full setup guide
 - **[IWR6843 Operator Guide](docs/iwr6843/README.md)** — Wire, flash, mount, aim, and calibrate the angle radar
+- **[LIS3DH Inclinometer Setup](docs/inclinometer/README.md)**: Add enclosure-level compensation to IWR6843 tilt
 - **[OPS243 USB → GPIO UART Migration](docs/ops243-uart-migration.md)** — Required before adding the IWR6843
 - **[IWR6843 Firmware Developer Guide](firmware/README.md)** — Build the firmware from source (not needed to flash the prebuilt image)
 - **[Simulator Connectors](docs/simulator/README.md)** — Stream shots to GSPro, OpenGolfSim, and others

--- a/docs/PARTS.md
+++ b/docs/PARTS.md
@@ -88,6 +88,19 @@ Full instructions: **[IWR6843 Operator Guide](iwr6843/README.md)** for wiring,
 flashing, mounting, and geometry; **[Moving the OPS243 to the Pi GPIO
 UART](ops243-uart-migration.md)** for the OPS side of Layout A.
 
+### Optional Enclosure Inclinometer
+
+An LIS3DH mounted to the enclosure base lets OpenFlight compensate the IWR6843
+tilt when the rig is placed on uneven ground.
+
+| Part | Description | Link | ~Price |
+|------|-------------|------|--------|
+| **Adafruit LIS3DH breakout** | Triple-axis accelerometer with STEMMA QT connectors | [Adafruit product 2809](https://www.adafruit.com/product/2809) | $5 |
+| **JST-SH cable kit** | Solderless STEMMA QT/Qwiic to female Dupont wiring used in the validated build | [Amazon](https://www.amazon.com/Connector-Compatible-Development-Sensors-Drivers/dp/B0GJPRX4YT) | ~$10 |
+
+See the **[LIS3DH Inclinometer Setup Guide](inclinometer/README.md)** for wiring,
+mounting, calibration, startup flags, and troubleshooting.
+
 ---
 
 ## Angle Radar (K-LD7) — DEPRECATED

--- a/docs/inclinometer/README.md
+++ b/docs/inclinometer/README.md
@@ -1,0 +1,341 @@
+# LIS3DH Inclinometer Setup
+
+OpenFlight can use an LIS3DH accelerometer mounted to the enclosure base to
+measure whether the rig is level. The measured enclosure pitch is added to the
+fixed IWR6843 antenna mounting angle for each shot.
+
+This is an optional feature. It is disabled unless `--inclinometer` is passed.
+The server flag requires `--iwr6843`; use the standalone tools when testing the
+LIS3DH without the radar.
+
+If the sensor is missing, moving, stale, or temporarily unreadable, OpenFlight
+keeps the shot and uses the configured IWR6843 tilt without an enclosure
+correction.
+
+## What To Buy
+
+The hardware used for the validated OpenFlight build is:
+
+| Part | Product |
+|------|---------|
+| LIS3DH breakout | [Adafruit LIS3DH Triple-Axis Accelerometer, product 2809](https://www.adafruit.com/product/2809) |
+| Solderless cable kit | [4-pin JST SH 1.0 mm STEMMA QT/Qwiic cable kit on Amazon](https://www.amazon.com/Connector-Compatible-Development-Sensors-Drivers/dp/B0GJPRX4YT) |
+| Mounting | Thin double-sided mounting tape or nonconductive standoffs |
+
+The Amazon cable kit is the exact cable product used in this build. It includes
+JST-SH-to-female-Dupont cables, so the breakout can connect directly to the
+Raspberry Pi GPIO header without soldering pins onto the LIS3DH.
+
+Do not buy a bare LIS3DH chip. Use a breakout board with the regulator, I2C
+pull-ups, and STEMMA QT/Qwiic connectors already installed.
+
+## How Compensation Works
+
+The LIS3DH is mounted flat on the enclosure base, not on the tilted TI radar
+board. OpenFlight keeps the three quantities separate:
+
+```text
+calibrated enclosure pitch = raw LIS3DH pitch + inclinometer zero offset
+effective IWR tilt = configured IWR tilt + calibrated enclosure pitch
+```
+
+For the prototype installation:
+
+- The IWR6843 antenna was measured at `11.5` degrees relative to the enclosure.
+- A calibration surface measured `+0.1` degrees in the radar tilt direction.
+- The resulting LIS3DH zero offset was approximately `+1.5` degrees.
+
+Treat those as examples, not universal defaults. Measure each physical build.
+
+## Power Down Before Wiring
+
+Shut down the Pi and remove power before connecting or moving GPIO wires. A
+misplaced 3.3 V lead can short the Pi, cause reboot loops or a black screen, and
+potentially damage the Pi or sensor.
+
+## Wiring
+
+The two STEMMA QT connectors on the Adafruit LIS3DH are electrically identical.
+Use whichever port gives the cable the cleanest route through the enclosure.
+
+The purchased cable kit uses these colors:
+
+| Cable color | Signal | Raspberry Pi physical pin | Pi signal |
+|-------------|--------|---------------------------|-----------|
+| Red | `VIN` / `3.3V` | **17** | 3.3 V power |
+| Black | `GND` | **20** | Ground |
+| Blue | `SDA` | **3** | GPIO2 / I2C SDA |
+| Yellow | `SCL` | **5** | GPIO3 / I2C SCL |
+
+```text
+LIS3DH STEMMA QT                         Raspberry Pi GPIO header
+
+Red     VIN / 3.3V  ------------------>  physical pin 17 (3.3V)
+Black   GND         ------------------>  physical pin 20 (GND)
+Blue    SDA         ------------------>  physical pin 3  (GPIO2/SDA)
+Yellow  SCL         ------------------>  physical pin 5  (GPIO3/SCL)
+```
+
+> [!WARNING]
+> Use physical pin numbers exactly as shown. GPIO/BCM numbers are a different
+> numbering system. Do not connect the LIS3DH to a 5 V GPIO-header pin.
+
+Cable colors are not a universal standard. If using a different cable, verify
+each conductor against the breakout labels before powering the Pi.
+
+The I2C bus can share Pi power and ground pins with other devices. It does not
+need a dedicated 3.3 V or ground pin as long as the shared connection is secure.
+
+## Mounting And Axis Direction
+
+Mount the LIS3DH firmly and flat against the bottom of the enclosure. Avoid
+thick foam tape that lets the board flex independently from the enclosure.
+
+For the Adafruit board:
+
+- X runs along the long direction between the two STEMMA QT connectors.
+- Y runs across the short direction of the board.
+- Z points perpendicular to the board.
+
+The validated installation aligns **Y with the radar tilt direction**. Positive
+Y must increase when the enclosure tilts backward. X/roll is recorded but is not
+currently applied to the launch-angle correction.
+
+Before fixing the board permanently, run the readout script and gently tilt the
+enclosure backward. Confirm that the reported pitch becomes more positive.
+
+## Enable I2C On The Pi
+
+Enable the Pi header I2C interface and reboot:
+
+```bash
+sudo raspi-config nonint do_i2c 0
+sudo reboot
+```
+
+After reconnecting over SSH, verify that bus 1 exists:
+
+```bash
+ls -l /dev/i2c-1
+```
+
+To scan the bus, install `i2c-tools` if needed and run:
+
+```bash
+sudo apt-get install -y i2c-tools
+i2cdetect -y 1
+```
+
+The default LIS3DH address is `0x18`, so the scan should contain `18`:
+
+```text
+     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+10: -- -- -- -- -- -- -- -- 18 -- -- -- -- -- -- --
+```
+
+## Install Software
+
+From the OpenFlight checkout:
+
+```bash
+uv sync
+```
+
+The Linux installation includes `smbus2`, which the LIS3DH driver uses to talk
+to `/dev/i2c-1`.
+
+## Verify Raw Readings
+
+Run the standalone hardware readout before starting the full application:
+
+```bash
+uv run python scripts/hardware-test/read_lis3dh.py
+```
+
+Example output:
+
+```text
+LIS3DH detected on I2C-1 at 0x18
+X=+0.001g  Y=-0.024g  Z=+0.974g  Raw=-1.41deg  Enclosure=-1.41deg
+```
+
+Useful options:
+
+```bash
+# Print 10 samples and exit
+uv run python scripts/hardware-test/read_lis3dh.py --count 10
+
+# Preview the calibrated enclosure and effective TI angles
+uv run python scripts/hardware-test/read_lis3dh.py \
+  --zero-offset-deg 1.5 \
+  --iwr6843-tilt-deg 11.5
+
+# Probe a non-default address while troubleshooting
+uv run python scripts/hardware-test/read_lis3dh.py --address 0x19
+```
+
+## Calibrate The Zero Offset
+
+The zero offset corrects only the LIS3DH's own mounting and sensor bias. It does
+not include the TI board's fixed mounting angle.
+
+1. Put the complete enclosure on a firm, stationary surface.
+2. Measure that surface in the radar tilt direction with a phone level app.
+3. Keep the enclosure still and run the calibration helper.
+4. Pass the phone reading to `--reference-pitch`, including its sign.
+
+For a surface measured at `+0.1` degrees:
+
+```bash
+uv run python scripts/hardware-test/calibrate_lis3dh.py --reference-pitch 0.1
+```
+
+The script averages 50 samples and prints a value such as:
+
+```text
+Raw pitch mean: -1.401deg (std dev 0.071deg)
+Reference pitch: +0.100deg
+Recommended flag: --inclinometer-zero-offset +1.501
+```
+
+Record that value in the launch command. The current implementation does not
+write a calibration file.
+
+## Measure The Fixed IWR6843 Tilt
+
+Measure the TI antenna face relative to the enclosure base, not relative to the
+floor under the rig. Pass that fixed mounting angle through
+`--iwr6843-tilt-deg`.
+
+For the prototype's measured `11.5` degree mounting angle:
+
+```bash
+--iwr6843-tilt-deg 11.5
+```
+
+Do not add the current floor slope to this number. The LIS3DH supplies that
+runtime correction.
+
+## Start OpenFlight
+
+Example production startup:
+
+```bash
+scripts/start-kiosk.sh \
+  --iwr6843 \
+  --iwr6843-tilt-deg 11.5 \
+  --inclinometer \
+  --inclinometer-zero-offset 1.5
+```
+
+At startup, OpenFlight prints the raw enclosure pitch, calibrated pitch,
+configured IWR tilt, and effective IWR tilt. It then samples the LIS3DH at 10 Hz.
+
+For each shot, OpenFlight:
+
+1. Selects the newest stable LIS3DH snapshot timestamped before impact.
+2. Rejects snapshots after motion, sensor errors, or more than two seconds old.
+3. Adds calibrated enclosure pitch to the configured IWR tilt.
+4. Uses a per-shot copy of the IWR calibration so shared calibration is never
+   mutated.
+5. Continues with the configured IWR tilt if correction cannot be applied.
+
+## Session Logging
+
+The `session_start` entry records:
+
+- Whether the inclinometer initialized.
+- I2C bus and address.
+- Sampling rate and zero offset.
+- Startup reading or initialization error.
+
+Each `shot_detected` entry records:
+
+- Raw and calibrated pitch.
+- X, Y, Z, and gravity magnitude.
+- Reading timestamp and age at impact.
+- Stability/application status.
+- Configured and effective IWR tilt.
+
+Common statuses are `stable`, `moving`, `stale`, `sensor_error`, and
+`no_stable_preimpact_reading`.
+
+## Troubleshooting
+
+### Green LED Is On, But `0x18` Is Missing
+
+The LED confirms power only. It does not prove SDA/SCL communication.
+
+1. Confirm `/dev/i2c-1` exists.
+2. Confirm I2C is enabled, then reboot.
+3. Recheck blue to physical pin 3 and yellow to physical pin 5.
+4. Confirm black is on ground and red is on 3.3 V.
+5. Reseat both ends of the JST-SH cable.
+6. Try the other identical STEMMA QT port on the LIS3DH.
+7. Run `i2cdetect -y 1` again.
+
+If the scan shows `0x19`, the board's address-selection input is pulled high.
+Restore the default `0x18` configuration or use `--address 0x19` only with the
+standalone readout while diagnosing it. The OpenFlight runtime currently expects
+`0x18`.
+
+### `WHO_AM_I expected 0x33`
+
+OpenFlight reached an I2C device at the selected address, but it did not identify
+as an LIS3DH. Check for another device using `0x18`, verify the breakout model,
+and inspect the bus with `i2cdetect -y 1`.
+
+### Permission Denied On `/dev/i2c-1`
+
+Add the OpenFlight user to the `i2c` group, then log out and back in or reboot:
+
+```bash
+sudo usermod -aG i2c "$USER"
+sudo reboot
+```
+
+### Pi Reboots, Shows A Black Screen, Or Runs The Fan At Full Speed
+
+Power down immediately and inspect the GPIO connections. This commonly points
+to a shifted connector, a power-to-ground short, or a wire on the wrong physical
+pin. Remove the LIS3DH, confirm the Pi boots normally, and reconnect one signal
+at a time with power removed.
+
+### Pitch Sign Is Backward
+
+Tilt the enclosure backward while watching the readout. Pitch should become more
+positive. If it becomes negative, rotate the LIS3DH mounting so positive Y faces
+the required direction. A zero offset corrects bias; it should not be used to
+hide a reversed axis.
+
+### Pitch Is Noisy Or Shots Report `moving`
+
+- Tighten the sensor mounting.
+- Replace flexible foam tape with thin rigid tape or standoffs.
+- Keep the cable from pulling on the breakout.
+- Wait about one second after repositioning the rig before taking a shot.
+- Check that gravity magnitude is close to `1.0g` in the readout.
+
+### Shots Report `stale`
+
+OpenFlight has not received a recent stable reading. Check the I2C connection,
+sensor mounting, and logs for sample errors. The shot is still processed using
+the configured IWR tilt.
+
+### Effective Tilt Looks Wrong
+
+Confirm the inputs have distinct meanings:
+
+- `--iwr6843-tilt-deg`: TI antenna angle relative to the enclosure.
+- `--inclinometer-zero-offset`: LIS3DH calibration bias.
+- Runtime enclosure pitch: current enclosure angle relative to level.
+
+Do not put the floor slope into `--iwr6843-tilt-deg`, and do not put the TI board
+mounting angle into `--inclinometer-zero-offset`.
+
+## Current Limitations
+
+- Pitch compensation uses the LIS3DH Y direction.
+- X/roll is logged but not yet applied to full 3D boresight compensation.
+- Sensor bus, address, and calibration are command-line/runtime settings rather
+  than a persisted rig configuration file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "kld7>=0.2.1",
     "gpiozero>=2.0.1; sys_platform == 'linux'",
     "lgpio>=0.2.2.0; sys_platform == 'linux'",
+    "smbus2>=0.5.0; sys_platform == 'linux'",
 ]
 
 [project.optional-dependencies]

--- a/scripts/hardware-test/calibrate_lis3dh.py
+++ b/scripts/hardware-test/calibrate_lis3dh.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Average a stationary LIS3DH and print its recommended zero-offset flag."""
+
+import argparse
+import statistics
+import time
+
+from openflight.inclinometer import LIS3DH
+from openflight.inclinometer.service import pitch_degrees
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bus", type=int, default=1)
+    parser.add_argument("--address", type=lambda value: int(value, 0), default=0x18)
+    parser.add_argument("--samples", type=int, default=50)
+    parser.add_argument("--interval", type=float, default=0.1)
+    parser.add_argument(
+        "--reference-pitch",
+        type=float,
+        default=0.0,
+        help="Known pitch of the supporting surface in degrees (default: level/0)",
+    )
+    args = parser.parse_args()
+    if args.samples < 2:
+        parser.error("--samples must be at least 2")
+
+    sensor = LIS3DH(bus_number=args.bus, address=args.address)
+    sensor.initialize()
+    pitches = []
+    try:
+        print(f"Keep the enclosure still while collecting {args.samples} samples...")
+        for _ in range(args.samples):
+            pitches.append(pitch_degrees(sensor.read()))
+            time.sleep(args.interval)
+    finally:
+        sensor.close()
+
+    raw_pitch = statistics.mean(pitches)
+    std_pitch = statistics.pstdev(pitches)
+    offset = args.reference_pitch - raw_pitch
+    print(f"Raw pitch mean: {raw_pitch:+.3f}deg (std dev {std_pitch:.3f}deg)")
+    print(f"Reference pitch: {args.reference_pitch:+.3f}deg")
+    print(f"Recommended flag: --inclinometer-zero-offset {offset:+.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hardware-test/read_lis3dh.py
+++ b/scripts/hardware-test/read_lis3dh.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Print LIS3DH acceleration, enclosure pitch, and optional effective TI tilt."""
+
+import argparse
+import time
+
+from openflight.inclinometer import LIS3DH
+from openflight.inclinometer.service import pitch_degrees
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bus", type=int, default=1, help="I2C bus number (default: 1)")
+    parser.add_argument("--address", type=lambda value: int(value, 0), default=0x18)
+    parser.add_argument("--interval", type=float, default=0.25)
+    parser.add_argument("--count", type=int, default=0, help="Readings to print; 0 runs forever")
+    parser.add_argument(
+        "--zero-offset-deg",
+        type=float,
+        default=0.0,
+        help="Degrees added to raw LIS3DH pitch (default: 0)",
+    )
+    parser.add_argument(
+        "--iwr6843-tilt-deg",
+        type=float,
+        default=None,
+        help="Fixed TI board-to-enclosure tilt; enables effective TI tilt output",
+    )
+    args = parser.parse_args()
+
+    sensor = LIS3DH(bus_number=args.bus, address=args.address)
+    sensor.initialize()
+    print(f"LIS3DH detected on I2C-{args.bus} at 0x{args.address:02x}")
+    try:
+        index = 0
+        while args.count == 0 or index < args.count:
+            sample = sensor.read()
+            raw_pitch = pitch_degrees(sample)
+            enclosure_pitch = raw_pitch + args.zero_offset_deg
+            output = (
+                f"X={sample.x_g:+.3f}g  Y={sample.y_g:+.3f}g  "
+                f"Z={sample.z_g:+.3f}g  Raw={raw_pitch:+.2f}deg  "
+                f"Enclosure={enclosure_pitch:+.2f}deg"
+            )
+            if args.iwr6843_tilt_deg is not None:
+                effective_tilt = args.iwr6843_tilt_deg + enclosure_pitch
+                output += f"  TI={effective_tilt:+.2f}deg"
+            print(output)
+            index += 1
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        sensor.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/start-kiosk.sh
+++ b/scripts/start-kiosk.sh
@@ -38,6 +38,8 @@ IWR6843_TX_ORDER=""
 IWR6843_CAPTURE_TIMEOUT=""
 IWR6843_OUTPUT_DIR=""
 IWR6843_AZIMUTH_OFFSET=""
+INCLINOMETER=false
+INCLINOMETER_ZERO_OFFSET=""
 KLD7=false
 KLD7_PORT=""
 KLD7_ANGLE_OFFSET=""
@@ -197,6 +199,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --iwr6843-azimuth-offset-deg)
             IWR6843_AZIMUTH_OFFSET="$2"
+            shift 2
+            ;;
+        --inclinometer)
+            INCLINOMETER=true
+            shift
+            ;;
+        --inclinometer-zero-offset)
+            INCLINOMETER_ZERO_OFFSET="$2"
             shift 2
             ;;
         --kld7)
@@ -561,6 +571,11 @@ if [ "$IWR6843" = true ]; then
     [ -n "$IWR6843_CAPTURE_TIMEOUT" ] && SERVER_CMD="$SERVER_CMD --iwr6843-capture-timeout $IWR6843_CAPTURE_TIMEOUT"
     [ -n "$IWR6843_OUTPUT_DIR" ] && SERVER_CMD="$SERVER_CMD --iwr6843-output-dir $IWR6843_OUTPUT_DIR"
     [ -n "$IWR6843_AZIMUTH_OFFSET" ] && SERVER_CMD="$SERVER_CMD --iwr6843-azimuth-offset-deg $IWR6843_AZIMUTH_OFFSET"
+fi
+
+if [ "$INCLINOMETER" = true ]; then
+    SERVER_CMD="$SERVER_CMD --inclinometer"
+    [ -n "$INCLINOMETER_ZERO_OFFSET" ] && SERVER_CMD="$SERVER_CMD --inclinometer-zero-offset $INCLINOMETER_ZERO_OFFSET"
 fi
 
 if [ "$EXPERIMENTAL_KLD7_RAW_RADC_LOGGING" = true ]; then

--- a/src/openflight/inclinometer/__init__.py
+++ b/src/openflight/inclinometer/__init__.py
@@ -1,0 +1,14 @@
+"""Enclosure orientation sensing for radar tilt compensation."""
+
+from .lis3dh import LIS3DH, LIS3DHIdentityError
+from .models import AccelerationSample, OrientationSnapshot, SnapshotSelection
+from .service import InclinometerService
+
+__all__ = [
+    "AccelerationSample",
+    "InclinometerService",
+    "LIS3DH",
+    "LIS3DHIdentityError",
+    "OrientationSnapshot",
+    "SnapshotSelection",
+]

--- a/src/openflight/inclinometer/lis3dh.py
+++ b/src/openflight/inclinometer/lis3dh.py
@@ -1,0 +1,100 @@
+"""Minimal LIS3DH I2C driver for enclosure orientation readings."""
+
+from __future__ import annotations
+
+import time
+from typing import Protocol
+
+from .models import AccelerationSample
+
+
+class SMBusLike(Protocol):  # pylint: disable=unnecessary-ellipsis
+    """Subset of smbus2 used by the driver, allowing deterministic tests."""
+
+    def read_byte_data(self, address: int, register: int) -> int:
+        """Read one register byte."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def write_byte_data(self, address: int, register: int, value: int) -> None:
+        """Write one register byte."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def read_i2c_block_data(self, address: int, register: int, length: int) -> list[int]:
+        """Read a contiguous register block."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def close(self) -> None:
+        """Close the bus."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+
+class LIS3DHIdentityError(RuntimeError):
+    """Raised when the expected LIS3DH identity register is not present."""
+
+
+class LIS3DH:
+    """Read a LIS3DH configured for +/-2g high-resolution measurements."""
+
+    DEFAULT_ADDRESS = 0x18
+    WHO_AM_I = 0x0F
+    WHO_AM_I_VALUE = 0x33
+    CTRL_REG1 = 0x20
+    CTRL_REG4 = 0x23
+    OUT_X_L = 0x28
+    AUTO_INCREMENT = 0x80
+
+    def __init__(
+        self,
+        *,
+        bus_number: int = 1,
+        address: int = DEFAULT_ADDRESS,
+        bus: SMBusLike | None = None,
+    ):
+        if bus is None:
+            from smbus2 import SMBus  # pylint: disable=import-outside-toplevel,import-error
+
+            bus = SMBus(bus_number)
+        self.bus = bus
+        self.bus_number = bus_number
+        self.address = address
+        self._closed = False
+
+    def initialize(self) -> None:
+        """Verify identity and enable 100 Hz, high-resolution XYZ sampling."""
+        identity = self.bus.read_byte_data(self.address, self.WHO_AM_I)
+        if identity != self.WHO_AM_I_VALUE:
+            raise LIS3DHIdentityError(
+                f"LIS3DH WHO_AM_I expected 0x{self.WHO_AM_I_VALUE:02x}, got 0x{identity:02x}"
+            )
+        self.bus.write_byte_data(self.address, self.CTRL_REG1, 0x57)
+        self.bus.write_byte_data(self.address, self.CTRL_REG4, 0x88)
+
+    @staticmethod
+    def _axis_g(low: int, high: int) -> float:
+        """Decode one left-aligned 12-bit high-resolution +/-2g axis."""
+        raw = (high << 8) | low
+        if raw & 0x8000:
+            raw -= 1 << 16
+        return (raw >> 4) * 0.001
+
+    def read(self, *, timestamp: float | None = None) -> AccelerationSample:
+        """Read one XYZ sample in units of gravity."""
+        data = self.bus.read_i2c_block_data(
+            self.address,
+            self.OUT_X_L | self.AUTO_INCREMENT,
+            6,
+        )
+        if len(data) != 6:
+            raise OSError(f"LIS3DH returned {len(data)} data bytes; expected 6")
+        return AccelerationSample(
+            timestamp=time.time() if timestamp is None else timestamp,
+            x_g=self._axis_g(data[0], data[1]),
+            y_g=self._axis_g(data[2], data[3]),
+            z_g=self._axis_g(data[4], data[5]),
+        )
+
+    def close(self) -> None:
+        """Close the owned I2C bus."""
+        if not self._closed:
+            self.bus.close()
+            self._closed = True

--- a/src/openflight/inclinometer/models.py
+++ b/src/openflight/inclinometer/models.py
@@ -1,0 +1,60 @@
+"""Value objects shared by inclinometer drivers and consumers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True)
+class AccelerationSample:
+    """One timestamped LIS3DH acceleration reading in units of gravity."""
+
+    timestamp: float
+    x_g: float
+    y_g: float
+    z_g: float
+
+
+@dataclass(frozen=True)
+class OrientationSnapshot:
+    """Filtered enclosure orientation produced from a stationary sample window."""
+
+    timestamp: float
+    x_g: float
+    y_g: float
+    z_g: float
+    gravity_g: float
+    raw_pitch_deg: float
+    calibrated_pitch_deg: float
+    pitch_std_deg: float
+    sample_count: int
+
+    def to_dict(self) -> dict:
+        """Return JSON-safe rounded diagnostic fields."""
+        data = asdict(self)
+        for key in ("x_g", "y_g", "z_g", "gravity_g"):
+            data[key] = round(data[key], 4)
+        for key in ("raw_pitch_deg", "calibrated_pitch_deg", "pitch_std_deg"):
+            data[key] = round(data[key], 3)
+        data["stable"] = True
+        return data
+
+
+@dataclass(frozen=True)
+class SnapshotSelection:
+    """Result of selecting a stable orientation for one impact."""
+
+    snapshot: OrientationSnapshot | None
+    status: str
+    age_s: float | None = None
+
+    def to_dict(self) -> dict:
+        """Return selection diagnostics suitable for shot/session logging."""
+        data = {
+            "applied": self.snapshot is not None,
+            "status": self.status,
+            "age_s": round(self.age_s, 3) if self.age_s is not None else None,
+        }
+        if self.snapshot is not None:
+            data.update(self.snapshot.to_dict())
+        return data

--- a/src/openflight/inclinometer/service.py
+++ b/src/openflight/inclinometer/service.py
@@ -1,0 +1,179 @@
+"""Background filtering and pre-impact snapshot selection for an inclinometer."""
+
+from __future__ import annotations
+
+import logging
+import math
+import statistics
+import threading
+import time
+from collections import deque
+from typing import Protocol
+
+from .models import AccelerationSample, OrientationSnapshot, SnapshotSelection
+
+logger = logging.getLogger(__name__)
+
+
+class Accelerometer(Protocol):  # pylint: disable=unnecessary-ellipsis
+    """Sensor contract required by the service."""
+
+    def initialize(self) -> None:
+        """Configure and verify the sensor."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def read(self, *, timestamp: float | None = None) -> AccelerationSample:
+        """Read one acceleration sample."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def close(self) -> None:
+        """Release sensor resources."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+
+def pitch_degrees(sample: AccelerationSample) -> float:
+    """Return enclosure pitch; positive Y is positive tilt-back."""
+    return math.degrees(math.atan2(sample.y_g, math.hypot(sample.x_g, sample.z_g)))
+
+
+class InclinometerService:
+    """Sample, filter, and retain stable enclosure orientations."""
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        sensor: Accelerometer,
+        *,
+        zero_offset_deg: float = 0.0,
+        sample_hz: float = 10.0,
+        window_samples: int = 8,
+        history_seconds: float = 15.0,
+        max_snapshot_age_s: float = 2.0,
+        max_pitch_std_deg: float = 0.5,
+        gravity_range_g: tuple[float, float] = (0.85, 1.15),
+    ):
+        if sample_hz <= 0 or window_samples < 2:
+            raise ValueError("sample_hz must be positive and window_samples must be at least 2")
+        self.sensor = sensor
+        self.zero_offset_deg = zero_offset_deg
+        self.sample_hz = sample_hz
+        self.window_samples = window_samples
+        self.max_snapshot_age_s = max_snapshot_age_s
+        self.max_pitch_std_deg = max_pitch_std_deg
+        self.gravity_range_g = gravity_range_g
+        self._samples: deque[AccelerationSample] = deque(maxlen=window_samples)
+        history_size = max(window_samples, math.ceil(history_seconds * sample_hz))
+        self._history: deque[OrientationSnapshot] = deque(maxlen=history_size)
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._last_error: str | None = None
+        self._last_error_timestamp: float | None = None
+        self._last_unstable_timestamp: float | None = None
+
+    def start(self) -> None:
+        """Initialize hardware and start the sampling thread."""
+        self.sensor.initialize()
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._sample_loop,
+            name="openflight-inclinometer",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop sampling and release the I2C bus."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        self.sensor.close()
+
+    def _sample_loop(self) -> None:
+        interval_s = 1.0 / self.sample_hz
+        while not self._stop_event.is_set():
+            started = time.monotonic()
+            try:
+                self.add_sample(self.sensor.read())
+                with self._lock:
+                    self._last_error = None
+                    self._last_error_timestamp = None
+            except Exception as error:  # pylint: disable=broad-exception-caught
+                with self._lock:
+                    self._last_error = str(error)
+                    self._last_error_timestamp = time.time()
+                logger.warning("LIS3DH sample failed: %s", error)
+            delay = max(0.0, interval_s - (time.monotonic() - started))
+            self._stop_event.wait(delay)
+
+    def add_sample(self, sample: AccelerationSample) -> OrientationSnapshot | None:
+        """Add one sample and return a snapshot when the window is stationary."""
+        with self._lock:
+            self._samples.append(sample)
+            if len(self._samples) < self.window_samples:
+                return None
+            samples = list(self._samples)
+            pitches = [pitch_degrees(item) for item in samples]
+            pitch_std = statistics.pstdev(pitches)
+            x_g = statistics.median(item.x_g for item in samples)
+            y_g = statistics.median(item.y_g for item in samples)
+            z_g = statistics.median(item.z_g for item in samples)
+            gravity_g = math.sqrt(x_g * x_g + y_g * y_g + z_g * z_g)
+            if not self.gravity_range_g[0] <= gravity_g <= self.gravity_range_g[1]:
+                self._last_unstable_timestamp = sample.timestamp
+                return None
+            if pitch_std > self.max_pitch_std_deg:
+                self._last_unstable_timestamp = sample.timestamp
+                return None
+            raw_pitch = statistics.median(pitches)
+            snapshot = OrientationSnapshot(
+                timestamp=sample.timestamp,
+                x_g=x_g,
+                y_g=y_g,
+                z_g=z_g,
+                gravity_g=gravity_g,
+                raw_pitch_deg=raw_pitch,
+                calibrated_pitch_deg=raw_pitch + self.zero_offset_deg,
+                pitch_std_deg=pitch_std,
+                sample_count=len(samples),
+            )
+            self._history.append(snapshot)
+            return snapshot
+
+    def snapshot_for_impact(self, impact_timestamp: float) -> SnapshotSelection:
+        """Select the newest stable snapshot at or before an impact."""
+        with self._lock:
+            candidates = [item for item in self._history if item.timestamp <= impact_timestamp]
+            last_error = self._last_error
+            error_timestamp = self._last_error_timestamp
+            unstable_timestamp = self._last_unstable_timestamp
+        if not candidates:
+            status = "sensor_error" if last_error else "no_stable_preimpact_reading"
+            return SnapshotSelection(snapshot=None, status=status)
+        snapshot = candidates[-1]
+        age_s = max(0.0, impact_timestamp - snapshot.timestamp)
+        if error_timestamp is not None and snapshot.timestamp < error_timestamp <= impact_timestamp:
+            return SnapshotSelection(snapshot=None, status="sensor_error", age_s=age_s)
+        if (
+            unstable_timestamp is not None
+            and snapshot.timestamp < unstable_timestamp <= impact_timestamp
+        ):
+            return SnapshotSelection(snapshot=None, status="moving", age_s=age_s)
+        if age_s > self.max_snapshot_age_s:
+            return SnapshotSelection(snapshot=None, status="stale", age_s=age_s)
+        return SnapshotSelection(snapshot=snapshot, status="stable", age_s=age_s)
+
+    def wait_for_stable(self, timeout_s: float = 2.0) -> SnapshotSelection:
+        """Wait briefly for a startup orientation diagnostic."""
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            selection = self.snapshot_for_impact(time.time())
+            if selection.snapshot is not None:
+                return selection
+            time.sleep(min(0.05, 1.0 / self.sample_hz))
+        return self.snapshot_for_impact(time.time())
+
+    @property
+    def last_error(self) -> str | None:
+        """Most recent sensor error, cleared after the next valid read."""
+        with self._lock:
+            return self._last_error

--- a/src/openflight/iwr6843/runtime.py
+++ b/src/openflight/iwr6843/runtime.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import math
+from dataclasses import dataclass, replace
 
 from openflight.iwr6843.calibration import Calibration
 from openflight.iwr6843.club import ClubPathResult, estimate_club_path
@@ -37,13 +38,14 @@ class IWR6843Runtime:
     azimuth_offset_deg: float = 0.0
     tdm_sign_policy: str = "positive"
 
-    def process_shot(
+    def process_shot(  # pylint: disable=too-many-arguments
         self,
         *,
         impact_timestamp: float | None,
         ball_speed_mph: float,
         club: str | None,
         club_speed_mph: float | None = None,
+        tilt_deg: float | None = None,
     ) -> IWR6843ShotResult:
         """Match one OPS shot to TI data and run LCMF-v1."""
         capture = self.capture_monitor.capture_for_shot(
@@ -52,9 +54,12 @@ class IWR6843Runtime:
         )
         if capture is None or not capture.valid or capture.raw is None:
             return IWR6843ShotResult(capture=capture, measurement=None)
+        shot_calibration = self.calibration
+        if tilt_deg is not None:
+            shot_calibration = replace(self.calibration, tilt_rad=math.radians(tilt_deg))
         measurement = estimate_lcmf_v1(
             capture.raw,
-            self.calibration,
+            shot_calibration,
             ball_speed_mph=ball_speed_mph,
             club=club,
             net_range_m=self.net_range_m,
@@ -71,7 +76,7 @@ class IWR6843Runtime:
             policy_sign = _TDM_SIGN_BY_POLICY.get(self.tdm_sign_policy, 1)
             club_path = estimate_club_path(
                 capture.raw,
-                self.calibration,
+                shot_calibration,
                 ops_club_speed_mph=club_speed_mph,
                 aim_offset_deg=self.azimuth_offset_deg,
                 tdm_sign=policy_sign if fallback else ball_sign,

--- a/src/openflight/launch_monitor.py
+++ b/src/openflight/launch_monitor.py
@@ -292,6 +292,7 @@ class Shot:
     club_angle_deg: Optional[float] = None  # Club angle of attack from K-LD7 (vertical)
     club_path_deg: Optional[float] = None  # Club path: IWR6843, or K-LD7 (deprecated, horizontal)
     spin_axis_deg: Optional[float] = None  # Spin axis tilt: 0=backspin, +right(fade), -left(draw)
+    inclinometer: Optional[dict] = None  # Stable enclosure orientation used for this shot
 
     @property
     def ball_speed_ms(self) -> float:

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -126,6 +126,10 @@ experimental_kld7_raw_radc_logging: bool = False
 iwr6843_runtime = None
 iwr6843_runtime_config: dict = {"enabled": False}
 
+# Optional LIS3DH enclosure orientation used to compensate TI mount tilt.
+inclinometer_service = None
+inclinometer_runtime_config: dict = {"enabled": False}
+
 # Ballistic model toggle. When True, shot carry comes from the physics
 # simulator whenever a vertical launch angle is available. When False
 # (default), all carry computations go through the legacy table estimator.
@@ -195,6 +199,8 @@ def _cleanup_hardware_for_shutdown() -> None:
         _run_shutdown_step("K-LD7 vertical stop", kld7_vertical.stop)
     if kld7_horizontal:
         _run_shutdown_step("K-LD7 horizontal stop", kld7_horizontal.stop)
+    if inclinometer_service:
+        _run_shutdown_step("inclinometer stop", inclinometer_service.stop)
     if iwr6843_runtime:
         _run_shutdown_step("IWR6843 stop", iwr6843_runtime.stop)
 
@@ -846,6 +852,7 @@ def _session_start_config() -> dict:
         "radc_tuning_params": dict(active_kld7_radc_tuning),
     }
     config["iwr6843"] = dict(iwr6843_runtime_config)
+    config["inclinometer"] = dict(inclinometer_runtime_config)
     return config
 
 
@@ -885,6 +892,7 @@ def shot_to_dict(shot: Shot) -> dict:
         "club_angle_deg": shot.club_angle_deg,
         "club_path_deg": shot.club_path_deg,
         "spin_axis_deg": shot.spin_axis_deg,
+        "inclinometer": shot.inclinometer,
         # Spin data from rolling buffer mode
         "spin_rpm": round(shot.spin_rpm) if shot.spin_rpm else None,
         "spin_rpm_measured": (round(shot.spin_rpm_measured) if shot.spin_rpm_measured else None),
@@ -1122,6 +1130,79 @@ def init_iwr6843(
         )
         iwr6843_runtime = None
         iwr6843_runtime_config = {"enabled": False, "error": str(error)}
+        return False
+
+
+def init_inclinometer(*, zero_offset_deg: float, bus_number: int = 1, address: int = 0x18) -> bool:
+    """Start the optional LIS3DH service without risking radar availability."""
+    global inclinometer_service  # pylint: disable=global-statement
+    global inclinometer_runtime_config  # pylint: disable=global-statement
+
+    service = None
+    try:
+        from .inclinometer import LIS3DH, InclinometerService
+
+        service = InclinometerService(
+            LIS3DH(bus_number=bus_number, address=address),
+            zero_offset_deg=zero_offset_deg,
+        )
+        service.start()
+        startup = service.wait_for_stable(timeout_s=2.0)
+        inclinometer_service = service
+        inclinometer_runtime_config = {
+            "enabled": True,
+            "sensor": "lis3dh",
+            "i2c_bus": bus_number,
+            "i2c_address": f"0x{address:02x}",
+            "sample_hz": service.sample_hz,
+            "zero_offset_deg": zero_offset_deg,
+            "startup": startup.to_dict(),
+        }
+        if startup.snapshot is None:
+            logger.warning(
+                "[SERVER] LIS3DH initialized but has no stable startup reading (%s)",
+                startup.status,
+            )
+            print(f"Inclinometer enabled, waiting for a stable reading ({startup.status})")
+            return True
+
+        snapshot = startup.snapshot
+        print(
+            "Inclinometer enabled "
+            f"(raw pitch {snapshot.raw_pitch_deg:+.2f}deg, "
+            f"calibrated {snapshot.calibrated_pitch_deg:+.2f}deg)"
+        )
+        if iwr6843_runtime is not None:
+            configured_tilt = math.degrees(iwr6843_runtime.calibration.tilt_rad)
+            effective_tilt = configured_tilt + snapshot.calibrated_pitch_deg
+            print(
+                f"IWR6843 tilt: configured {configured_tilt:.2f}deg, "
+                f"effective {effective_tilt:.2f}deg"
+            )
+        return True
+    except Exception as error:  # pylint: disable=broad-exception-caught
+        if service is not None:
+            try:
+                service.stop()
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.debug("Failed to close LIS3DH after initialization error", exc_info=True)
+        logger.warning("[SERVER] Inclinometer initialization failed: %s", error, exc_info=True)
+        log_session_error(
+            "Inclinometer initialization failed",
+            component="inclinometer",
+            context={"i2c_bus": bus_number, "i2c_address": f"0x{address:02x}"},
+            exc=error,
+        )
+        inclinometer_service = None
+        inclinometer_runtime_config = {
+            "enabled": False,
+            "requested": True,
+            "sensor": "lis3dh",
+            "i2c_bus": bus_number,
+            "i2c_address": f"0x{address:02x}",
+            "zero_offset_deg": zero_offset_deg,
+            "error": str(error),
+        }
         return False
 
 
@@ -2056,6 +2137,40 @@ def horizontal_confidence_from(coherence: float | None) -> float:
     return round(min(ANGLE_CONFIDENCE_CEILING, max(0.0, float(coherence))), 3)
 
 
+def _snapshot_inclinometer_for_shot(shot: Shot) -> None:
+    """Attach the stable pre-impact enclosure orientation used by this shot."""
+    if inclinometer_service is None or shot.mode == "mock":
+        return
+
+    impact_timestamp = shot.impact_timestamp or time.time()
+    selection = inclinometer_service.snapshot_for_impact(impact_timestamp)
+    data = selection.to_dict()
+    data["zero_offset_deg"] = inclinometer_runtime_config.get("zero_offset_deg", 0.0)
+    snapshot = selection.snapshot
+    if snapshot is not None and iwr6843_runtime is not None:
+        configured_tilt = math.degrees(iwr6843_runtime.calibration.tilt_rad)
+        effective_tilt = configured_tilt + snapshot.calibrated_pitch_deg
+        data.update(
+            {
+                "applied": True,
+                "configured_iwr_tilt_deg": round(configured_tilt, 3),
+                "effective_iwr_tilt_deg": round(effective_tilt, 3),
+            }
+        )
+        logger.info(
+            "[SERVER] Inclinometer pitch: raw %+.2fdeg, calibrated %+.2fdeg, "
+            "IWR tilt %.2fdeg (age %.0fms)",
+            snapshot.raw_pitch_deg,
+            snapshot.calibrated_pitch_deg,
+            effective_tilt,
+            (selection.age_s or 0.0) * 1000.0,
+        )
+    else:
+        data["applied"] = False
+        logger.warning("[SERVER] Inclinometer correction not applied: %s", selection.status)
+    shot.inclinometer = data
+
+
 def _process_iwr6843_angle(shot: Shot) -> float | None:
     """Apply a correlated LCMF-v1 result without risking the OPS shot."""
     if iwr6843_runtime is None or shot.mode == "mock":
@@ -2068,6 +2183,11 @@ def _process_iwr6843_angle(shot: Shot) -> float | None:
             ball_speed_mph=shot.ball_speed_mph,
             club=shot.club.value,
             club_speed_mph=shot.club_speed_mph,
+            tilt_deg=(
+                shot.inclinometer.get("effective_iwr_tilt_deg")
+                if shot.inclinometer and shot.inclinometer.get("applied")
+                else None
+            ),
         )
         capture = shot_result.capture
         measurement = shot_result.measurement
@@ -2175,6 +2295,9 @@ def on_shot_detected(shot: Shot):
     shot.player_name = current_player_name
     logger.info("[SERVER] Shot callback: %.1f mph", shot.ball_speed_mph)
 
+    # Snapshot orientation before IWR capture can block, and select only data
+    # timestamped before impact so impact vibration cannot bias the geometry.
+    _snapshot_inclinometer_for_shot(shot)
     iwr6843_ms = _process_iwr6843_angle(shot)
     kld7_ms = None
     # Process K-LD7 angle radars (vertical = launch angle, horizontal = club path)
@@ -2601,6 +2724,7 @@ def on_shot_detected(shot: Shot):
                 spin_axis_deg=shot.spin_axis_deg,
                 impact_timestamp=shot.impact_timestamp,
                 player_name=shot.player_name,
+                inclinometer=shot.inclinometer,
                 pipeline_ms={
                     "iwr6843": (round(iwr6843_ms, 1) if iwr6843_ms is not None else None),
                     "kld7": round(kld7_ms, 1) if kld7_ms is not None else None,
@@ -2857,11 +2981,7 @@ def start_monitor(
             # anchor K-LD7 correlation to the OPS trigger_time instead of the
             # USB first-byte arrival time.
             radar = getattr(monitor, "radar", None)
-            if (
-                not swing_speed_mode
-                and radar is not None
-                and hasattr(radar, "read_clock_sync")
-            ):
+            if not swing_speed_mode and radar is not None and hasattr(radar, "read_clock_sync"):
                 try:
                     clock_sync = radar.read_clock_sync()
                     session_logger.log_clock_sync(
@@ -2880,6 +3000,14 @@ def start_monitor(
                 firmware="custom-l3-dump",
                 estimator="lcmf_v1",
                 trigger_pin_bcm=iwr6843_runtime_config.get("trigger_pin_bcm"),
+            )
+        if not mock and inclinometer_service is not None:
+            session_logger.log_connection(
+                device="lis3dh",
+                port=f"i2c-{inclinometer_runtime_config.get('i2c_bus', 1)}",
+                baud=0,
+                address=inclinometer_runtime_config.get("i2c_address", "0x18"),
+                sample_hz=inclinometer_runtime_config.get("sample_hz", 10.0),
             )
 
     if swing_speed_mode:
@@ -3522,6 +3650,17 @@ def main():
         help="Enable TI IWR6843 L3 capture and LCMF-v1 vertical launch angle",
     )
     parser.add_argument(
+        "--inclinometer",
+        action="store_true",
+        help="Enable LIS3DH enclosure pitch compensation for IWR6843 tilt",
+    )
+    parser.add_argument(
+        "--inclinometer-zero-offset",
+        type=float,
+        default=0.0,
+        help="Degrees added to raw LIS3DH pitch (default: 0)",
+    )
+    parser.add_argument(
         "--iwr6843-port", default=None, help="TI serial port (auto-detect by default)"
     )
     parser.add_argument(
@@ -3784,6 +3923,8 @@ def main():
         parser.error("--iwr6843 and vertical --kld7 cannot both own launch angle")
     if args.iwr6843 and args.kld7_horizontal:
         parser.error("--iwr6843 and horizontal --kld7 cannot both own club path")
+    if args.inclinometer and not args.iwr6843:
+        parser.error("--inclinometer requires --iwr6843")
     if args.iwr6843 and args.mock:
         parser.error("--iwr6843 cannot be used with --mock")
     if args.iwr6843 and args.trigger == "sound-gpio":
@@ -3947,6 +4088,10 @@ def main():
         else:
             print("ERROR: IWR6843 requested but failed to initialize. Exiting.")
             sys.exit(1)
+
+    if args.inclinometer:
+        if not init_inclinometer(zero_offset_deg=args.inclinometer_zero_offset):
+            print("WARNING: Inclinometer unavailable; continuing with configured IWR6843 tilt")
 
     # Initialize K-LD7 angle radars (if enabled)
     if args.kld7:

--- a/src/openflight/session_logger.py
+++ b/src/openflight/session_logger.py
@@ -364,6 +364,7 @@ class SessionLogger:
         pipeline_ms: Optional[Dict] = None,
         impact_timestamp: Optional[float] = None,
         player_name: Optional[str] = None,
+        inclinometer: Optional[Dict] = None,
     ):
         """
         Log a detected shot with all metrics.
@@ -398,6 +399,7 @@ class SessionLogger:
             carry_spin_adjusted: Carry distance adjusted for spin (rolling buffer mode only)
             mode: Radar mode ("rolling-buffer" or "mock")
             impact_timestamp: Host epoch timestamp aligned to impact/OPS trigger time
+            inclinometer: Enclosure orientation and effective IWR tilt used for the shot
         """
         if not self.enabled:
             return
@@ -458,6 +460,8 @@ class SessionLogger:
             data["spin_axis_deg"] = spin_axis_deg
         if pipeline_ms is not None:
             data["pipeline_ms"] = pipeline_ms
+        if inclinometer is not None:
+            data["inclinometer"] = inclinometer
 
         self._write_entry("shot_detected", data)
 

--- a/tests/test_inclinometer.py
+++ b/tests/test_inclinometer.py
@@ -1,0 +1,135 @@
+"""LIS3DH transport, pitch math, filtering, and snapshot selection tests."""
+
+import math
+
+import pytest
+
+from openflight.inclinometer import (
+    LIS3DH,
+    AccelerationSample,
+    InclinometerService,
+    LIS3DHIdentityError,
+)
+from openflight.inclinometer.service import pitch_degrees
+
+
+def _axis_bytes(value_g: float) -> list[int]:
+    counts = round(value_g / 0.001)
+    raw = (counts << 4) & 0xFFFF
+    return [raw & 0xFF, raw >> 8]
+
+
+class FakeBus:
+    def __init__(self, *, identity=0x33, axes=(0.0, 0.0, 1.0)):
+        self.identity = identity
+        self.axes = axes
+        self.writes = []
+        self.closed = False
+
+    def read_byte_data(self, address, register):
+        assert address == 0x18
+        assert register == LIS3DH.WHO_AM_I
+        return self.identity
+
+    def write_byte_data(self, address, register, value):
+        self.writes.append((address, register, value))
+
+    def read_i2c_block_data(self, address, register, length):
+        assert (address, register, length) == (0x18, 0xA8, 6)
+        return sum((_axis_bytes(axis) for axis in self.axes), [])
+
+    def close(self):
+        self.closed = True
+
+
+def test_lis3dh_initializes_high_resolution_xyz_mode_and_reads_signed_axes():
+    bus = FakeBus(axes=(-0.125, 0.25, 0.975))
+    sensor = LIS3DH(bus=bus)
+
+    sensor.initialize()
+    sample = sensor.read(timestamp=123.0)
+    sensor.close()
+
+    assert bus.writes == [(0x18, 0x20, 0x57), (0x18, 0x23, 0x88)]
+    assert sample == AccelerationSample(123.0, -0.125, 0.25, 0.975)
+    assert bus.closed
+
+
+def test_lis3dh_rejects_wrong_identity():
+    sensor = LIS3DH(bus=FakeBus(identity=0x00))
+
+    with pytest.raises(LIS3DHIdentityError, match="expected 0x33, got 0x00"):
+        sensor.initialize()
+
+
+def test_pitch_is_positive_when_sensor_y_tilts_back():
+    angle = math.radians(12.0)
+    sample = AccelerationSample(1.0, 0.0, math.sin(angle), math.cos(angle))
+
+    assert pitch_degrees(sample) == pytest.approx(12.0)
+
+
+def test_service_applies_zero_offset_and_selects_preimpact_snapshot():
+    service = InclinometerService(
+        sensor=None,
+        zero_offset_deg=1.5,
+        window_samples=4,
+        max_snapshot_age_s=2.0,
+    )
+    angle = math.radians(3.0)
+    for timestamp in (9.0, 9.1, 9.2, 9.3, 10.1):
+        service.add_sample(AccelerationSample(timestamp, 0.0, math.sin(angle), math.cos(angle)))
+
+    selection = service.snapshot_for_impact(10.0)
+
+    assert selection.status == "stable"
+    assert selection.age_s == pytest.approx(0.7)
+    assert selection.snapshot.timestamp == 9.3
+    assert selection.snapshot.raw_pitch_deg == pytest.approx(3.0)
+    assert selection.snapshot.calibrated_pitch_deg == pytest.approx(4.5)
+
+
+def test_service_rejects_moving_window_and_stale_snapshot():
+    service = InclinometerService(
+        sensor=None,
+        window_samples=4,
+        max_pitch_std_deg=0.2,
+        max_snapshot_age_s=1.0,
+    )
+    for timestamp, angle_deg in zip((1.0, 1.1, 1.2, 1.3), (0.0, 3.0, -2.0, 4.0)):
+        angle = math.radians(angle_deg)
+        assert (
+            service.add_sample(AccelerationSample(timestamp, 0.0, math.sin(angle), math.cos(angle)))
+            is None
+        )
+    assert service.snapshot_for_impact(1.4).status == "no_stable_preimpact_reading"
+
+    for timestamp in (2.0, 2.1, 2.2, 2.3):
+        service.add_sample(AccelerationSample(timestamp, 0.0, 0.0, 1.0))
+    selection = service.snapshot_for_impact(4.0)
+    assert selection.status == "stale"
+    assert selection.snapshot is None
+    assert selection.age_s == pytest.approx(1.7)
+
+
+def test_service_rejects_non_gravity_acceleration():
+    service = InclinometerService(sensor=None, window_samples=3)
+
+    for timestamp in (1.0, 1.1, 1.2):
+        assert service.add_sample(AccelerationSample(timestamp, 0.0, 0.0, 1.5)) is None
+
+    assert service.snapshot_for_impact(1.3).status == "no_stable_preimpact_reading"
+
+
+def test_service_does_not_reuse_old_position_after_movement():
+    service = InclinometerService(sensor=None, window_samples=3, max_pitch_std_deg=0.2)
+    for timestamp in (1.0, 1.1, 1.2):
+        service.add_sample(AccelerationSample(timestamp, 0.0, 0.0, 1.0))
+    assert service.snapshot_for_impact(1.25).status == "stable"
+
+    moved = math.radians(8.0)
+    service.add_sample(AccelerationSample(1.3, 0.0, math.sin(moved), math.cos(moved)))
+
+    selection = service.snapshot_for_impact(1.35)
+    assert selection.status == "moving"
+    assert selection.snapshot is None

--- a/tests/test_inclinometer_server.py
+++ b/tests/test_inclinometer_server.py
@@ -1,0 +1,167 @@
+"""Server integration for per-shot LIS3DH tilt compensation."""
+
+import json
+import math
+import sys
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from openflight import server
+from openflight.inclinometer import OrientationSnapshot, SnapshotSelection
+from openflight.iwr6843.calibration import Calibration
+from openflight.launch_monitor import Shot
+from openflight.session_logger import SessionLogger
+
+
+class FakeInclinometer:
+    def __init__(self, selection):
+        self.selection = selection
+        self.impact_timestamp = None
+
+    def snapshot_for_impact(self, impact_timestamp):
+        self.impact_timestamp = impact_timestamp
+        return self.selection
+
+
+def _stable_selection():
+    return SnapshotSelection(
+        snapshot=OrientationSnapshot(
+            timestamp=99.8,
+            x_g=0.0,
+            y_g=0.0523,
+            z_g=0.9986,
+            gravity_g=1.0,
+            raw_pitch_deg=3.0,
+            calibrated_pitch_deg=4.5,
+            pitch_std_deg=0.1,
+            sample_count=8,
+        ),
+        status="stable",
+        age_s=0.2,
+    )
+
+
+def test_server_passes_effective_preimpact_tilt_to_iwr(monkeypatch):
+    sensor = FakeInclinometer(_stable_selection())
+    calibration = Calibration.identity()
+    calibration.tilt_rad = math.radians(11.5)
+    seen = {}
+
+    def process_shot(**kwargs):
+        seen.update(kwargs)
+        return SimpleNamespace(capture=None, measurement=None, club_path=None)
+
+    monkeypatch.setattr(server, "inclinometer_service", sensor)
+    monkeypatch.setattr(server, "inclinometer_runtime_config", {"zero_offset_deg": 1.5})
+    monkeypatch.setattr(
+        server,
+        "iwr6843_runtime",
+        SimpleNamespace(calibration=calibration, process_shot=process_shot),
+    )
+    monkeypatch.setattr(server, "get_session_logger", lambda: None)
+    shot = Shot(ball_speed_mph=100.0, timestamp=datetime.now(), impact_timestamp=100.0)
+
+    server._snapshot_inclinometer_for_shot(shot)
+    server._process_iwr6843_angle(shot)
+
+    assert sensor.impact_timestamp == 100.0
+    assert shot.inclinometer["configured_iwr_tilt_deg"] == 11.5
+    assert shot.inclinometer["effective_iwr_tilt_deg"] == 16.0
+    assert shot.inclinometer["age_s"] == 0.2
+    assert seen["tilt_deg"] == 16.0
+
+
+def test_server_preserves_configured_tilt_without_stable_snapshot(monkeypatch):
+    sensor = FakeInclinometer(
+        SnapshotSelection(snapshot=None, status="no_stable_preimpact_reading")
+    )
+    calibration = Calibration.identity()
+    seen = {}
+
+    def process_shot(**kwargs):
+        seen.update(kwargs)
+        return SimpleNamespace(capture=None, measurement=None, club_path=None)
+
+    monkeypatch.setattr(server, "inclinometer_service", sensor)
+    monkeypatch.setattr(server, "inclinometer_runtime_config", {"zero_offset_deg": 1.5})
+    monkeypatch.setattr(
+        server,
+        "iwr6843_runtime",
+        SimpleNamespace(calibration=calibration, process_shot=process_shot),
+    )
+    monkeypatch.setattr(server, "get_session_logger", lambda: None)
+    shot = Shot(ball_speed_mph=100.0, timestamp=datetime.now(), impact_timestamp=100.0)
+
+    server._snapshot_inclinometer_for_shot(shot)
+    server._process_iwr6843_angle(shot)
+
+    assert shot.inclinometer["applied"] is False
+    assert shot.inclinometer["status"] == "no_stable_preimpact_reading"
+    assert seen["tilt_deg"] is None
+
+
+def test_init_inclinometer_is_fail_soft(monkeypatch):
+    class BrokenSensor:
+        def __init__(self, **_kwargs):
+            pass
+
+    class BrokenService:
+        def __init__(self, _sensor, **_kwargs):
+            pass
+
+        def start(self):
+            raise OSError("I2C unavailable")
+
+        def stop(self):
+            pass
+
+    monkeypatch.setattr("openflight.inclinometer.LIS3DH", BrokenSensor)
+    monkeypatch.setattr("openflight.inclinometer.InclinometerService", BrokenService)
+    monkeypatch.setattr(server, "log_session_error", lambda *_args, **_kwargs: None)
+
+    assert server.init_inclinometer(zero_offset_deg=1.5) is False
+    assert server.inclinometer_service is None
+    assert server.inclinometer_runtime_config["requested"] is True
+    assert server.inclinometer_runtime_config["error"] == "I2C unavailable"
+
+
+def test_inclinometer_flag_requires_iwr6843(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["openflight-server", "--inclinometer"])
+
+    with pytest.raises(SystemExit, match="2"):
+        server.main()
+
+
+def test_shot_dict_includes_inclinometer_provenance():
+    shot = Shot(ball_speed_mph=100.0, timestamp=datetime.now())
+    shot.inclinometer = {"applied": True, "effective_iwr_tilt_deg": 16.0}
+
+    assert server.shot_to_dict(shot)["inclinometer"] == shot.inclinometer
+
+
+def test_session_log_records_orientation_used_for_shot(tmp_path):
+    logger = SessionLogger(log_dir=tmp_path, enabled=True)
+    logger.start_session(mode="rolling-buffer", trigger_type="sound")
+    orientation = {
+        "applied": True,
+        "calibrated_pitch_deg": 4.5,
+        "effective_iwr_tilt_deg": 16.0,
+    }
+
+    logger.log_shot(
+        ball_speed_mph=100.0,
+        club_speed_mph=70.0,
+        smash_factor=1.43,
+        estimated_carry_yards=180.0,
+        club="7-iron",
+        peak_magnitude=10.0,
+        readings_count=1,
+        inclinometer=orientation,
+    )
+
+    entry = json.loads(logger.session_path.read_text().strip().splitlines()[-1])
+    assert entry["type"] == "shot_detected"
+    assert entry["inclinometer"] == orientation
+    logger.end_session()

--- a/tests/test_iwr6843_runtime_club.py
+++ b/tests/test_iwr6843_runtime_club.py
@@ -1,7 +1,11 @@
-"""Runtime forwards the TDM sign from the ball estimate, or falls back."""
+"""Runtime forwards per-shot geometry and club-path inputs."""
 
+import math
 from unittest.mock import patch
 
+import pytest
+
+from openflight.iwr6843.calibration import Calibration
 from openflight.iwr6843.club import ClubPathResult
 from openflight.iwr6843.runtime import IWR6843Runtime
 
@@ -43,8 +47,10 @@ def test_club_path_receives_ball_tdm_sign():
     class Measurement:
         tdm_sign_used = -1
 
-    with patch("openflight.iwr6843.runtime.estimate_lcmf_v1", return_value=Measurement()), \
-         patch("openflight.iwr6843.runtime.estimate_club_path", side_effect=fake_club):
+    with (
+        patch("openflight.iwr6843.runtime.estimate_lcmf_v1", return_value=Measurement()),
+        patch("openflight.iwr6843.runtime.estimate_club_path", side_effect=fake_club),
+    ):
         result = _runtime().process_shot(
             impact_timestamp=1.0, ball_speed_mph=100.0, club="7i", club_speed_mph=74.0
         )
@@ -80,8 +86,10 @@ def test_club_path_receives_the_configured_azimuth_offset():
     class Measurement:
         tdm_sign_used = 1
 
-    with patch("openflight.iwr6843.runtime.estimate_lcmf_v1", return_value=Measurement()), \
-         patch("openflight.iwr6843.runtime.estimate_club_path", side_effect=fake_club):
+    with (
+        patch("openflight.iwr6843.runtime.estimate_lcmf_v1", return_value=Measurement()),
+        patch("openflight.iwr6843.runtime.estimate_club_path", side_effect=fake_club),
+    ):
         _runtime(azimuth_offset_deg=1.5).process_shot(
             impact_timestamp=1.0, ball_speed_mph=100.0, club="7i", club_speed_mph=74.0
         )
@@ -99,8 +107,10 @@ def test_falls_back_to_policy_sign_when_ball_has_none():
     class Measurement:
         tdm_sign_used = None
 
-    with patch("openflight.iwr6843.runtime.estimate_lcmf_v1", return_value=Measurement()), \
-         patch("openflight.iwr6843.runtime.estimate_club_path", side_effect=fake_club):
+    with (
+        patch("openflight.iwr6843.runtime.estimate_lcmf_v1", return_value=Measurement()),
+        patch("openflight.iwr6843.runtime.estimate_club_path", side_effect=fake_club),
+    ):
         result = _runtime().process_shot(
             impact_timestamp=1.0, ball_speed_mph=100.0, club="7i", club_speed_mph=74.0
         )
@@ -116,6 +126,32 @@ def test_no_club_speed_skips_the_estimate():
             impact_timestamp=1.0, ball_speed_mph=100.0, club="7i", club_speed_mph=None
         )
     assert result.club_path is None
+
+
+def test_per_shot_tilt_uses_a_calibration_copy_without_mutating_runtime():
+    calibration = Calibration.identity()
+    runtime = IWR6843Runtime(
+        capture_monitor=FakeMonitor(),
+        calibration=calibration,
+        net_range_m=4.064,
+    )
+    seen = {}
+
+    def fake_lcmf(_raw, shot_calibration, **_kwargs):
+        seen["calibration"] = shot_calibration
+        return None
+
+    with patch("openflight.iwr6843.runtime.estimate_lcmf_v1", side_effect=fake_lcmf):
+        runtime.process_shot(
+            impact_timestamp=1.0,
+            ball_speed_mph=100.0,
+            club="7i",
+            tilt_deg=13.5,
+        )
+
+    assert seen["calibration"] is not calibration
+    assert math.degrees(seen["calibration"].tilt_rad) == pytest.approx(13.5)
+    assert calibration.tilt_rad == 0.0
 
 
 def test_ball_estimate_receives_the_configured_tdm_sign_policy():


### PR DESCRIPTION
## Summary

- Add optional LIS3DH enclosure-pitch compensation for IWR6843 launch-angle processing.
- Sample the sensor at 10 Hz and select a stable pre-impact reading for each shot.
- Apply the effective tilt through a per-shot calibration copy without mutating shared IWR calibration.
- Preserve shots and use the configured IWR tilt when the sensor is missing, moving, stale, or unreadable.
- Add standalone readout and calibration scripts plus startup and per-shot session logging.
- Document purchasing, exact physical-pin wiring, mounting, calibration, startup, and troubleshooting.

## Hardware documentation

- Adafruit LIS3DH breakout, product 2809.
- Exact Amazon JST-SH/STEMMA QT cable kit used in the build.
- Raspberry Pi physical pins 17 (3.3 V), 20 (GND), 3 (SDA), and 5 (SCL).

## Validation

- `uv run pytest tests/ -q`: 1224 passed, 8 skipped.
- Affected test suite: 171 passed, 1 skipped.
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run pylint ... --fail-under=9`: 9.61/10.
- `bash -n scripts/start-kiosk.sh`
- Kiosk command-construction dry run with both inclinometer flags.