### PR TITLE
added light mode support

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -56,8 +56,12 @@ The app is entirely client-side. Everything flows through one socket connection.
 - **Shutdown** posts to `/api/shutdown` to stop the connected backend.
 
 **Display mode** lives at `/display`: a compact, fullscreen-friendly dashboard
-for mounted screens and TVs. The [root README](../README.md#tv-display-mode)
-covers casting it.
+for mounted screens and TVs. It always uses the dark theme for TV readability.
+The [root README](../README.md#tv-display-mode) covers casting it.
+
+**Theme** defaults to dark. Toggle light/dark from the sun/moon button in the
+header; the choice is stored in `localStorage` under `openflight.theme`. Tokens
+live in `src/index.css` (`:root` / `[data-theme]`).
 
 **Launch Daddy** is a hidden mode toggled by a tap area in the header. When on,
 new shots can fire an animated overlay.

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,10 +1,20 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ui</title>
+    <script>
+      (function () {
+        try {
+          var theme = localStorage.getItem('openflight.theme');
+          document.documentElement.setAttribute('data-theme', theme === 'light' ? 'light' : 'dark');
+        } catch (e) {
+          document.documentElement.setAttribute('data-theme', 'dark');
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -20,7 +20,7 @@
   justify-content: space-between;
   padding: var(--space-sm) var(--space-lg);
   background: linear-gradient(180deg, var(--color-bg-elevated) 0%, var(--color-bg-card) 100%);
-  border-bottom: 1px solid rgba(212, 175, 55, 0.15);
+  border-bottom: 1px solid var(--header-accent-border);
   flex-shrink: 0;
 }
 
@@ -40,9 +40,9 @@
   display: inline-flex;
   align-items: center;
   padding: 2px;
-  border: 1px solid rgba(245, 240, 230, 0.12);
+  border: 1px solid var(--border-default);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-overlay);
 }
 
 .unit-toggle__button {
@@ -59,8 +59,39 @@
 }
 
 .unit-toggle__button--active {
-  background: rgba(212, 175, 55, 0.16);
+  background: var(--accent-soft-active);
   color: var(--color-gold);
+}
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 1px solid var(--border-default);
+  border-radius: 50%;
+  background: var(--surface-overlay);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.theme-toggle:hover {
+  border-color: var(--accent-border);
+  color: var(--color-gold);
+  background: var(--accent-soft);
+}
+
+.theme-toggle:active {
+  transform: scale(0.96);
+}
+
+.theme-toggle svg {
+  width: 18px;
+  height: 18px;
 }
 
 /* Navigation */
@@ -80,7 +111,7 @@
   gap: var(--space-sm);
   padding: var(--space-sm) var(--space-md);
   background: transparent;
-  border: 1px solid rgba(245, 240, 230, 0.1);
+  border: 1px solid var(--gauge-track);
   border-radius: var(--radius-md);
   color: var(--text-muted);
   font-size: 0.8125rem;
@@ -112,8 +143,8 @@
 }
 
 .nav__button--active {
-  background: rgba(212, 175, 55, 0.08);
-  border-color: rgba(212, 175, 55, 0.25);
+  background: var(--accent-soft);
+  border-color: var(--accent-border-mid);
   color: var(--color-gold);
 }
 
@@ -135,7 +166,7 @@
   height: 1.25rem;
   padding: 0 0.375rem;
   background: var(--color-gold);
-  color: var(--color-bg-deep);
+  color: var(--color-on-gold);
   border-radius: 10px;
   font-size: 0.6875rem;
   font-weight: 700;
@@ -237,7 +268,7 @@
   background: linear-gradient(135deg, var(--color-gold-dim) 0%, var(--color-gold) 100%);
   border: none;
   border-radius: var(--radius-md);
-  color: var(--color-bg-deep);
+  color: var(--color-on-gold);
   font-size: 0.9375rem;
   font-weight: 700;
   letter-spacing: 0.02em;
@@ -245,12 +276,12 @@
   transition: all var(--transition-fast);
   min-height: 44px;
   flex-shrink: 0;
-  box-shadow: 0 4px 12px rgba(212, 175, 55, 0.3);
+  box-shadow: 0 4px 12px var(--accent-shadow);
 }
 
 .simulate-button:active {
   transform: scale(0.98);
-  box-shadow: 0 2px 8px rgba(212, 175, 55, 0.2);
+  box-shadow: 0 2px 8px var(--accent-border);
 }
 
 /* Power / Shutdown */
@@ -262,8 +293,8 @@
   height: 36px;
   border: none;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--color-text-muted);
+  background: var(--surface-overlay-strong);
+  color: var(--text-muted);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -276,7 +307,7 @@
 .shutdown-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--overlay-scrim);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -285,7 +316,7 @@
 
 .shutdown-dialog {
   background: var(--color-bg-card);
-  border: 1px solid rgba(212, 175, 55, 0.2);
+  border: 1px solid var(--accent-border);
   border-radius: 12px;
   padding: 2rem;
   text-align: center;
@@ -294,7 +325,7 @@
 
 .shutdown-dialog p {
   font-size: 1.125rem;
-  color: var(--color-text);
+  color: var(--text-primary);
   margin: 0 0 1.5rem;
 }
 
@@ -321,16 +352,16 @@
 
 .shutdown-dialog__cancel {
   padding: 0.625rem 1.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-strong);
   border-radius: 8px;
   background: transparent;
-  color: var(--color-text-muted);
+  color: var(--text-muted);
   font-size: 0.9375rem;
   cursor: pointer;
 }
 
 .shutdown-dialog__cancel:active {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--surface-hover);
 }
 
 /* Landscape 7" screen (800x480) */
@@ -346,6 +377,16 @@
   .unit-toggle__button {
     padding: 0.3rem 0.5rem;
     font-size: 0.625rem;
+  }
+
+  .theme-toggle {
+    width: 32px;
+    height: 32px;
+  }
+
+  .theme-toggle svg {
+    width: 16px;
+    height: 16px;
   }
 
   .header__logo {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -29,6 +29,8 @@ import {
   LaunchDaddySecretIndicator,
 } from './components/LaunchDaddy';
 import { useUnitPreference } from './state/useUnitPreference';
+import { useThemeStore } from './stores/useThemeStore';
+import { ThemeToggle } from './components/ThemeToggle';
 
 import Logo from './logo/Logo';
 
@@ -119,6 +121,7 @@ function AppContent() {
   const [showShutdown, setShowShutdown] = useState(false);
   const { isLaunchDaddyMode, isExploding, triggerExplosion, handleSecretTap } = useLaunchDaddy();
   const { unitSystem, setUnitSystem } = useUnitPreference();
+  const theme = useThemeStore((state) => state.theme);
   const isDisplayRoute = typeof window !== 'undefined' && window.location.pathname.replace(/\/$/, '') === '/display';
   const isSwingSpeedMode = triggerStatus.mode === 'swing-speed';
 
@@ -190,9 +193,14 @@ function AppContent() {
             userSelect: 'none',
           }}
         >
-          {isLaunchDaddyMode ? <LaunchDaddyBrand /> : <Logo size="small" variant="light" />}
+          {isLaunchDaddyMode ? (
+            <LaunchDaddyBrand />
+          ) : (
+            <Logo size="small" variant={theme === 'light' ? 'color' : 'light'} />
+          )}
         </div>
         <div className="header__controls">
+          <ThemeToggle />
           <div className="unit-toggle" role="group" aria-label="Display units">
             <button
               type="button"

--- a/ui/src/components/BallDetectionIndicator.css
+++ b/ui/src/components/BallDetectionIndicator.css
@@ -35,8 +35,8 @@
 }
 
 .ball-indicator--disabled {
-  background: rgba(245, 240, 230, 0.05);
-  border-color: rgba(245, 240, 230, 0.1);
+  background: var(--surface-hover);
+  border-color: var(--gauge-track);
   color: var(--text-muted);
 }
 

--- a/ui/src/components/CameraFeed.css
+++ b/ui/src/components/CameraFeed.css
@@ -4,7 +4,7 @@
   flex-direction: column;
   height: 100%;
   background: var(--color-bg-card);
-  border: 1px solid rgba(245, 240, 230, 0.06);
+  border: 1px solid var(--border-faint);
   border-radius: var(--radius-lg);
   overflow: hidden;
 }
@@ -20,14 +20,14 @@
   align-items: center;
   padding: var(--space-md);
   background: var(--color-bg-elevated);
-  border-bottom: 1px solid rgba(245, 240, 230, 0.06);
+  border-bottom: 1px solid var(--border-faint);
 }
 
 .camera-feed__title {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
-  color: var(--color-cream);
+  color: var(--text-primary);
   letter-spacing: 0.02em;
 }
 
@@ -38,7 +38,7 @@
 
 .camera-feed__button {
   padding: var(--space-xs) var(--space-md);
-  border: 1px solid rgba(245, 240, 230, 0.15);
+  border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-secondary);
@@ -50,8 +50,8 @@
 }
 
 .camera-feed__button:hover {
-  background: rgba(245, 240, 230, 0.05);
-  border-color: rgba(245, 240, 230, 0.25);
+  background: var(--surface-hover);
+  border-color: var(--border-stronger);
 }
 
 .camera-feed__button:active {
@@ -98,7 +98,7 @@
   margin: 0 0 var(--space-xs) 0;
   font-size: 1.125rem;
   font-weight: 600;
-  color: var(--color-cream);
+  color: var(--text-primary);
 }
 
 .camera-feed__message p {

--- a/ui/src/components/ClubPicker.css
+++ b/ui/src/components/ClubPicker.css
@@ -8,10 +8,10 @@
   align-items: center;
   gap: var(--space-sm);
   padding: var(--space-xs) var(--space-md);
-  background: rgba(212, 175, 55, 0.08);
-  border: 1px solid rgba(212, 175, 55, 0.2);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-border);
   border-radius: var(--radius-sm);
-  color: var(--color-cream);
+  color: var(--text-primary);
   font-size: 0.875rem;
   cursor: pointer;
   transition: all var(--transition-smooth);
@@ -20,8 +20,8 @@
 }
 
 .club-picker__trigger:hover {
-  background: rgba(212, 175, 55, 0.12);
-  border-color: rgba(212, 175, 55, 0.35);
+  background: var(--accent-ring);
+  border-color: var(--accent-border-strong);
 }
 
 .club-picker__trigger:active {
@@ -87,13 +87,13 @@
   right: 0;
   z-index: 101;
   background: var(--color-bg-elevated);
-  border: 1px solid rgba(212, 175, 55, 0.2);
+  border: 1px solid var(--accent-border);
   border-radius: var(--radius-lg);
   padding: var(--space-md);
   min-width: 260px;
   box-shadow:
     0 10px 40px rgba(0, 0, 0, 0.5),
-    0 0 0 1px rgba(212, 175, 55, 0.1);
+    0 0 0 1px var(--accent-soft-mid);
   animation: dropdown-enter 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
@@ -154,9 +154,9 @@
 .club-picker__option {
   padding: var(--space-sm);
   background: var(--color-bg-card);
-  border: 1px solid rgba(245, 240, 230, 0.08);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
-  color: var(--color-cream);
+  color: var(--text-primary);
   font-family: var(--font-display);
   font-size: 1rem;
   font-weight: 400;
@@ -167,7 +167,7 @@
 
 .club-picker__option:hover {
   background: var(--color-bg-hover);
-  border-color: rgba(245, 240, 230, 0.15);
+  border-color: var(--border-strong);
 }
 
 .club-picker__option:active {
@@ -175,14 +175,14 @@
 }
 
 .club-picker__option--selected {
-  background: rgba(212, 175, 55, 0.15);
+  background: var(--accent-soft-strong);
   border-color: var(--color-gold);
   color: var(--color-gold);
-  box-shadow: 0 0 12px rgba(212, 175, 55, 0.2);
+  box-shadow: 0 0 12px var(--accent-border);
 }
 
 .club-picker__option--family {
-  border-color: rgba(212, 175, 55, 0.18);
+  border-color: var(--accent-soft-strong);
   color: var(--color-gold);
 }
 
@@ -207,7 +207,7 @@
   min-height: 40px;
   padding: 0 var(--space-sm);
   background: transparent;
-  border: 1px solid rgba(245, 240, 230, 0.12);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
   font-size: 0.6875rem;
@@ -220,7 +220,7 @@
 .club-picker__remove:hover,
 .club-picker__add:hover {
   color: var(--color-gold);
-  border-color: rgba(212, 175, 55, 0.35);
+  border-color: var(--accent-border-strong);
 }
 
 .club-picker__add-row {
@@ -234,23 +234,23 @@
   min-height: 40px;
   min-width: 0;
   padding: 0 var(--space-sm);
-  background: rgba(5, 5, 8, 0.45);
-  border: 1px solid rgba(245, 240, 230, 0.12);
+  background: var(--surface-soft);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
-  color: var(--color-cream);
+  color: var(--text-primary);
   font-size: 0.875rem;
 }
 
 .club-picker__input:focus {
   outline: none;
-  border-color: rgba(212, 175, 55, 0.4);
-  box-shadow: 0 0 0 2px rgba(212, 175, 55, 0.12);
+  border-color: var(--accent-border-active);
+  box-shadow: 0 0 0 2px var(--accent-ring);
 }
 
 .club-picker__back {
   padding: var(--space-xs) var(--space-sm);
   background: transparent;
-  border: 1px solid rgba(245, 240, 230, 0.12);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
   font-size: 0.6875rem;
@@ -262,7 +262,7 @@
 
 .club-picker__back:hover {
   color: var(--color-gold);
-  border-color: rgba(212, 175, 55, 0.35);
+  border-color: var(--accent-border-strong);
 }
 
 /* Responsive for 7" screen - bottom sheet style */

--- a/ui/src/components/ClubSelectScreen.css
+++ b/ui/src/components/ClubSelectScreen.css
@@ -29,12 +29,12 @@
   max-height: 100%;
   overflow-y: auto;
   background: var(--color-bg-elevated);
-  border: 1px solid rgba(212, 175, 55, 0.2);
+  border: 1px solid var(--accent-border);
   border-radius: var(--radius-lg);
   padding: var(--space-md) var(--space-lg);
   box-shadow:
     0 10px 40px rgba(0, 0, 0, 0.5),
-    0 0 0 1px rgba(212, 175, 55, 0.1);
+    0 0 0 1px var(--accent-soft-mid);
 }
 
 .club-select__close {
@@ -62,7 +62,7 @@
 
 .club-select__close:hover {
   background: var(--color-bg-hover);
-  color: var(--color-cream);
+  color: var(--text-primary);
 }
 
 .club-select__close:active {
@@ -114,9 +114,9 @@
 .club-select__option {
   padding: var(--space-xs);
   background: var(--color-bg-card);
-  border: 1px solid rgba(245, 240, 230, 0.08);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
-  color: var(--color-cream);
+  color: var(--text-primary);
   font-family: var(--font-display);
   font-size: 1rem;
   font-weight: 400;
@@ -127,7 +127,7 @@
 
 .club-select__option:hover {
   background: var(--color-bg-hover);
-  border-color: rgba(245, 240, 230, 0.15);
+  border-color: var(--border-strong);
 }
 
 .club-select__option:active {
@@ -135,8 +135,8 @@
 }
 
 .club-select__option--selected {
-  background: rgba(212, 175, 55, 0.15);
+  background: var(--accent-soft-strong);
   border-color: var(--color-gold);
   color: var(--color-gold);
-  box-shadow: 0 0 12px rgba(212, 175, 55, 0.2);
+  box-shadow: 0 0 12px var(--accent-border);
 }

--- a/ui/src/components/DebugPanel.css
+++ b/ui/src/components/DebugPanel.css
@@ -4,10 +4,10 @@
   flex-direction: column;
   height: 100%;
   background: var(--color-bg-card);
-  border: 1px solid rgba(245, 240, 230, 0.06);
+  border: 1px solid var(--border-faint);
   border-radius: var(--radius-lg);
   padding: var(--space-md);
-  color: var(--color-cream);
+  color: var(--text-primary);
   overflow: hidden;
 }
 
@@ -37,7 +37,7 @@
 .debug-tabs__tab {
   padding: var(--space-xs) var(--space-md);
   background: transparent;
-  border: 1px solid rgba(245, 240, 230, 0.1);
+  border: 1px solid var(--gauge-track);
   border-radius: 999px;
   color: var(--text-muted);
   font-size: 0.75rem;
@@ -54,8 +54,8 @@
 }
 
 .debug-tabs__tab--active {
-  background: rgba(212, 175, 55, 0.1);
-  border-color: rgba(212, 175, 55, 0.4);
+  background: var(--accent-soft-mid);
+  border-color: var(--accent-border-active);
   color: var(--color-gold);
 }
 
@@ -70,8 +70,8 @@
 
 /* Sections */
 .debug-panel__section {
-  background: rgba(245, 240, 230, 0.02);
-  border: 1px solid rgba(245, 240, 230, 0.04);
+  background: var(--surface-faint);
+  border: 1px solid var(--surface-soft);
   border-radius: var(--radius-md);
   padding: var(--space-md);
   margin-bottom: var(--space-md);
@@ -237,7 +237,7 @@
   color: var(--text-secondary);
   margin-bottom: var(--space-sm);
   padding-bottom: var(--space-xs);
-  border-bottom: 1px solid rgba(245, 240, 230, 0.06);
+  border-bottom: 1px solid var(--border-faint);
 }
 
 .last-trigger__data {
@@ -283,7 +283,7 @@
 .last-trigger__meta-item {
   font-size: 0.6875rem;
   color: var(--text-muted);
-  background: rgba(245, 240, 230, 0.04);
+  background: var(--surface-soft);
   padding: 2px 6px;
   border-radius: var(--radius-sm);
 }
@@ -293,7 +293,7 @@
   grid-template-columns: repeat(2, 1fr);
   gap: var(--space-xs);
   padding-top: var(--space-xs);
-  border-top: 1px solid rgba(245, 240, 230, 0.06);
+  border-top: 1px solid var(--border-faint);
 }
 
 .last-trigger__shot-item {
@@ -328,7 +328,7 @@
 .trigger-row {
   padding: var(--space-xs) var(--space-sm);
   border-radius: var(--radius-sm);
-  background: rgba(245, 240, 230, 0.02);
+  background: var(--surface-faint);
   flex-shrink: 0;
 }
 
@@ -438,7 +438,7 @@
   appearance: none;
   width: 100%;
   height: 6px;
-  background: rgba(245, 240, 230, 0.1);
+  background: var(--gauge-track);
   border-radius: 3px;
   outline: none;
   cursor: pointer;

--- a/ui/src/components/DisplayMode.css
+++ b/ui/src/components/DisplayMode.css
@@ -2,7 +2,7 @@
   min-height: 100vh;
   width: 100%;
   padding: clamp(1rem, 2vw, 2rem);
-  background: radial-gradient(ellipse at top left, rgba(212, 175, 55, 0.1), transparent 38rem), var(--color-bg-deep);
+  background: radial-gradient(ellipse at top left, var(--accent-soft-mid), transparent 38rem), var(--color-bg-deep);
   color: var(--text-primary);
   overflow: hidden;
 }
@@ -24,9 +24,9 @@
   display: flex;
   flex-direction: column;
   min-height: 24rem;
-  border: 1px solid rgba(245, 240, 230, 0.12);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
-  background: #050508;
+  background: var(--color-bg-camera);
   overflow: hidden;
   box-shadow: var(--shadow-card);
 }
@@ -37,7 +37,7 @@
   min-height: 0;
   flex: 1;
   object-fit: cover;
-  background: #050508;
+  background: var(--color-bg-camera);
 }
 
 .display-mode__camera-placeholder {
@@ -68,9 +68,9 @@
   align-items: center;
   min-height: 2rem;
   padding: 0.4rem 0.75rem;
-  border: 1px solid rgba(245, 240, 230, 0.14);
+  border: 1px solid var(--border-default);
   border-radius: 999px;
-  background: rgba(10, 10, 15, 0.78);
+  background: var(--surface-status);
   color: var(--text-secondary);
   font-size: clamp(0.8rem, 1.1vw, 1rem);
   font-weight: 700;
@@ -105,7 +105,7 @@
 
 .display-mode__title {
   margin: 0;
-  color: var(--color-cream);
+  color: var(--text-primary);
   font-family: var(--font-display);
   font-size: clamp(3rem, 5vw, 6rem);
   font-weight: 400;
@@ -134,7 +134,7 @@
   justify-content: center;
   min-height: 8.5rem;
   padding: clamp(0.8rem, 1.4vw, 1.25rem);
-  border: 1px solid rgba(245, 240, 230, 0.1);
+  border: 1px solid var(--gauge-track);
   border-radius: var(--radius-md);
   background: rgba(18, 18, 26, 0.86);
   box-shadow: var(--shadow-card);
@@ -142,8 +142,8 @@
 
 .display-metric--featured {
   min-height: clamp(10rem, 18vh, 15rem);
-  border-color: rgba(212, 175, 55, 0.35);
-  background: linear-gradient(145deg, rgba(212, 175, 55, 0.18), rgba(18, 18, 26, 0.92));
+  border-color: var(--accent-border-strong);
+  background: linear-gradient(145deg, var(--accent-soft-strong), var(--color-bg-card));
 }
 
 .display-metric__label,
@@ -163,7 +163,7 @@
 }
 
 .display-metric__value {
-  color: var(--color-cream);
+  color: var(--text-primary);
   font-size: clamp(2.35rem, 4vw, 4.75rem);
   font-weight: 800;
   line-height: 1;
@@ -197,7 +197,7 @@
 .display-mode__empty-strip,
 .display-shot-chip {
   min-height: 4.9rem;
-  border: 1px solid rgba(245, 240, 230, 0.1);
+  border: 1px solid var(--gauge-track);
   border-radius: var(--radius-md);
   background: rgba(18, 18, 26, 0.78);
 }

--- a/ui/src/components/DisplayMode.tsx
+++ b/ui/src/components/DisplayMode.tsx
@@ -147,7 +147,7 @@ export function DisplayMode({ connected, cameraStatus, latestShot, shots }: Disp
   const cameraError = failedCameraKey === cameraKey;
 
   return (
-    <main className="display-mode">
+    <main className="display-mode" data-theme="dark">
       <section className="display-mode__hero" aria-label="TV display mode">
         <div className="display-mode__camera">
           {cameraError ? (

--- a/ui/src/components/ShotDisplay.css
+++ b/ui/src/components/ShotDisplay.css
@@ -1,7 +1,7 @@
 /* Shot Display Container */
 .shot-display {
   background: linear-gradient(145deg, var(--color-bg-card) 0%, var(--color-bg-elevated) 100%);
-  border: 1px solid rgba(212, 175, 55, 0.1);
+  border: 1px solid var(--accent-soft-mid);
   border-radius: var(--radius-lg);
   padding: var(--space-md);
   color: var(--text-primary);
@@ -20,7 +20,7 @@
   right: 0;
   width: 100px;
   height: 100px;
-  background: radial-gradient(circle at top right, rgba(212, 175, 55, 0.08) 0%, transparent 70%);
+  background: radial-gradient(circle at top right, var(--accent-soft) 0%, transparent 70%);
   pointer-events: none;
 }
 
@@ -32,18 +32,18 @@
 @keyframes shot-glow {
   0% {
     box-shadow:
-      0 0 0 0 rgba(212, 175, 55, 0.6),
-      inset 0 0 30px rgba(212, 175, 55, 0.2);
+      0 0 0 0 var(--color-gold-glow),
+      inset 0 0 30px var(--accent-border);
   }
   70% {
     box-shadow:
-      0 0 0 15px rgba(212, 175, 55, 0),
-      inset 0 0 0 rgba(212, 175, 55, 0);
+      0 0 0 15px transparent,
+      inset 0 0 0 transparent;
   }
   100% {
     box-shadow:
-      0 0 0 0 rgba(212, 175, 55, 0),
-      inset 0 0 0 rgba(212, 175, 55, 0);
+      0 0 0 0 transparent,
+      inset 0 0 0 transparent;
   }
 }
 
@@ -70,7 +70,7 @@
 }
 
 .shot-display--swing-speed {
-  border-color: rgba(212, 175, 55, 0.22);
+  border-color: var(--accent-border);
 }
 
 .shot-display--swing-speed .shot-display__primary {
@@ -176,8 +176,8 @@
   align-items: center;
   justify-content: center;
   padding: var(--space-sm) var(--space-md);
-  background: rgba(245, 240, 230, 0.03);
-  border: 1px solid rgba(245, 240, 230, 0.08);
+  background: var(--surface-muted);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   flex: 1;
   text-align: center;
@@ -185,8 +185,8 @@
 }
 
 .metric-card--primary {
-  background: rgba(212, 175, 55, 0.08);
-  border-color: rgba(212, 175, 55, 0.2);
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
 }
 
 .metric-card--secondary {
@@ -216,7 +216,7 @@
   font-size: 5rem;
   font-weight: 400;
   line-height: 1;
-  color: var(--color-cream);
+  color: var(--text-primary);
 }
 
 /* Animated: metric value pops in */
@@ -367,14 +367,14 @@
     box-shadow:
       inset -8px -8px 20px rgba(0, 0, 0, 0.15),
       0 4px 20px rgba(0, 0, 0, 0.3),
-      0 0 0 0 rgba(212, 175, 55, 0);
+      0 0 0 0 transparent;
   }
   50% {
     transform: scale(1.02);
     box-shadow:
       inset -8px -8px 20px rgba(0, 0, 0, 0.15),
       0 4px 20px rgba(0, 0, 0, 0.3),
-      0 0 20px 5px rgba(212, 175, 55, 0.2);
+      0 0 20px 5px var(--accent-border);
   }
 }
 

--- a/ui/src/components/ShotDisplay.tsx
+++ b/ui/src/components/ShotDisplay.tsx
@@ -57,7 +57,7 @@ function SpeedGauge({
   return (
     <div className="speed-gauge">
       <svg viewBox="0 0 200 140" className="speed-gauge__svg">
-        <path d={backgroundArc} fill="none" stroke="rgba(245, 240, 230, 0.1)" strokeWidth="12" strokeLinecap="round" />
+        <path d={backgroundArc} fill="none" stroke="var(--gauge-track)" strokeWidth="12" strokeLinecap="round" />
         <path
           d={valueArc}
           fill="none"
@@ -68,8 +68,8 @@ function SpeedGauge({
         />
         <defs>
           <linearGradient id="goldGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-            <stop offset="0%" stopColor="#A68B2A" />
-            <stop offset="100%" stopColor="#F4CF47" />
+            <stop offset="0%" stopColor="var(--color-gold-dim)" />
+            <stop offset="100%" stopColor="var(--color-gold-bright)" />
           </linearGradient>
         </defs>
       </svg>

--- a/ui/src/components/ShotList.css
+++ b/ui/src/components/ShotList.css
@@ -20,8 +20,8 @@
   justify-content: space-between;
   gap: var(--space-md);
   padding: var(--space-sm) var(--space-md);
-  background: rgba(245, 240, 230, 0.03);
-  border: 1px solid rgba(245, 240, 230, 0.08);
+  background: var(--surface-muted);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   flex-shrink: 0;
 }
@@ -32,7 +32,7 @@
 }
 
 .shot-list__title {
-  color: var(--color-cream);
+  color: var(--text-primary);
   font-size: 0.875rem;
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -47,8 +47,8 @@
 
 .shot-list__export {
   padding: var(--space-sm) var(--space-md);
-  background: rgba(212, 175, 55, 0.1);
-  border: 1px solid rgba(212, 175, 55, 0.25);
+  background: var(--accent-soft-mid);
+  border: 1px solid var(--accent-border-mid);
   border-radius: var(--radius-sm);
   color: var(--color-gold);
   font-size: 0.75rem;
@@ -84,7 +84,7 @@
   min-height: 0;
   padding-right: var(--space-xs);
   scrollbar-width: thin;
-  scrollbar-color: rgba(212, 175, 55, 0.45) transparent;
+  scrollbar-color: var(--accent-border-focus) transparent;
 }
 
 .shot-list__rows::-webkit-scrollbar {
@@ -96,7 +96,7 @@
 }
 
 .shot-list__rows::-webkit-scrollbar-thumb {
-  background: rgba(212, 175, 55, 0.35);
+  background: var(--accent-border-strong);
   border-radius: var(--radius-sm);
 }
 
@@ -107,7 +107,7 @@
   justify-content: space-between;
   padding: var(--space-md) var(--space-lg);
   background: var(--color-bg-card);
-  border: 1px solid rgba(245, 240, 230, 0.06);
+  border: 1px solid var(--border-faint);
   border-radius: var(--radius-md);
   min-height: 60px;
   transition: all var(--transition-smooth);
@@ -115,12 +115,12 @@
 
 .shot-row:hover {
   background: var(--color-bg-elevated);
-  border-color: rgba(212, 175, 55, 0.15);
+  border-color: var(--accent-soft-strong);
 }
 
 .shot-row--swing-speed {
-  border-color: rgba(212, 175, 55, 0.16);
-  background: linear-gradient(90deg, rgba(212, 175, 55, 0.08), var(--color-bg-card));
+  border-color: var(--accent-soft-active);
+  background: linear-gradient(90deg, var(--accent-soft), var(--color-bg-card));
 }
 
 .shot-row--validation {
@@ -150,7 +150,7 @@
   font-size: 0.75rem;
   font-weight: 700;
   color: var(--color-gold);
-  background: rgba(212, 175, 55, 0.12);
+  background: var(--accent-ring);
   padding: var(--space-xs) var(--space-sm);
   border-radius: var(--radius-sm);
   text-transform: uppercase;
@@ -165,7 +165,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--color-cream);
+  color: var(--text-primary);
   background: rgba(96, 165, 250, 0.12);
   border: 1px solid rgba(96, 165, 250, 0.22);
   border-radius: var(--radius-sm);
@@ -189,7 +189,7 @@
   font-family: var(--font-display);
   font-size: 1.375rem;
   font-weight: 400;
-  color: var(--color-cream);
+  color: var(--text-primary);
   line-height: 1;
 }
 
@@ -216,7 +216,7 @@
   flex-shrink: 0;
   padding: var(--space-xs) var(--space-sm);
   background: transparent;
-  border: 1px solid rgba(245, 240, 230, 0.12);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
   font-size: 0.6875rem;
@@ -232,13 +232,13 @@
 
 .shot-row__delete:hover {
   color: var(--color-gold);
-  border-color: rgba(212, 175, 55, 0.35);
-  background: rgba(212, 175, 55, 0.08);
+  border-color: var(--accent-border-strong);
+  background: var(--accent-soft);
 }
 
 .shot-row__delete:active {
   transform: scale(0.95);
-  background: rgba(212, 175, 55, 0.1);
+  background: var(--accent-soft-mid);
 }
 
 .shot-row__validation {
@@ -247,7 +247,7 @@
   gap: var(--space-sm);
   align-items: end;
   padding-top: var(--space-xs);
-  border-top: 1px solid rgba(245, 240, 230, 0.06);
+  border-top: 1px solid var(--border-faint);
 }
 
 .validation-field {
@@ -273,16 +273,16 @@
   min-height: 34px;
   padding: 0 var(--space-sm);
   background: rgba(0, 0, 0, 0.18);
-  border: 1px solid rgba(245, 240, 230, 0.1);
+  border: 1px solid var(--gauge-track);
   border-radius: var(--radius-sm);
-  color: var(--color-cream);
+  color: var(--text-primary);
   font-size: 0.875rem;
 }
 
 .validation-field input:focus,
 .validation-field select:focus {
   outline: none;
-  border-color: rgba(212, 175, 55, 0.45);
+  border-color: var(--accent-border-focus);
 }
 
 .validation-diff {

--- a/ui/src/components/SimStatus.css
+++ b/ui/src/components/SimStatus.css
@@ -69,10 +69,10 @@
 .sim-status__pill--off {
   background: rgba(148, 163, 184, 0.08);
   border: 1px solid rgba(148, 163, 184, 0.25);
-  color: var(--color-text-muted, #94a3b8);
+  color: var(--text-muted, #94a3b8);
 }
 .sim-status__pill--off .sim-status__dot {
-  background: var(--color-text-muted, #94a3b8);
+  background: var(--text-muted, #94a3b8);
 }
 
 @media (max-height: 500px) {

--- a/ui/src/components/StatsView.css
+++ b/ui/src/components/StatsView.css
@@ -24,7 +24,7 @@
 .club-tabs__tab {
   padding: var(--space-sm) var(--space-md);
   background: transparent;
-  border: 1px solid rgba(245, 240, 230, 0.1);
+  border: 1px solid var(--gauge-track);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
   font-size: 0.8125rem;
@@ -41,8 +41,8 @@
 }
 
 .club-tabs__tab--active {
-  background: rgba(212, 175, 55, 0.1);
-  border-color: rgba(212, 175, 55, 0.4);
+  background: var(--accent-soft-mid);
+  border-color: var(--accent-border-active);
   color: var(--color-gold);
 }
 
@@ -65,22 +65,22 @@
   justify-content: center;
   padding: var(--space-md);
   background: var(--color-bg-card);
-  border: 1px solid rgba(245, 240, 230, 0.06);
+  border: 1px solid var(--border-faint);
   border-radius: var(--radius-md);
   text-align: center;
   transition: all var(--transition-smooth);
 }
 
 .stat-card--primary {
-  background: linear-gradient(145deg, rgba(212, 175, 55, 0.1) 0%, rgba(212, 175, 55, 0.05) 100%);
-  border-color: rgba(212, 175, 55, 0.2);
+  background: linear-gradient(145deg, var(--accent-soft-mid) 0%, var(--accent-wash) 100%);
+  border-color: var(--accent-border);
 }
 
 .stat-card__value {
   font-family: var(--font-display);
   font-size: 2rem;
   font-weight: 400;
-  color: var(--color-cream);
+  color: var(--text-primary);
   line-height: 1;
 }
 

--- a/ui/src/components/ThemeToggle.tsx
+++ b/ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,28 @@
+import { useThemeStore } from '../stores/useThemeStore';
+
+export function ThemeToggle() {
+  const theme = useThemeStore((state) => state.theme);
+  const toggleTheme = useThemeStore((state) => state.toggleTheme);
+  const isLight = theme === 'light';
+
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      onClick={toggleTheme}
+      aria-label={isLight ? 'Switch to dark mode' : 'Switch to light mode'}
+      title={isLight ? 'Dark mode' : 'Light mode'}
+    >
+      {isLight ? (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      ) : (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -5,7 +5,9 @@
   box-sizing: border-box;
 }
 
-:root {
+/* Dark theme (default) */
+:root,
+[data-theme='dark'] {
   /* Typography */
   --font-display: 'DM Serif Display', Georgia, serif;
   --font-body: 'Outfit', system-ui, -apple-system, sans-serif;
@@ -15,6 +17,8 @@
   --color-bg-card: #12121a;
   --color-bg-elevated: #1a1a24;
   --color-bg-hover: #222230;
+  --color-bg-camera: #050508;
+  --color-on-gold: #0a0a0f;
 
   /* Gold accent (primary) */
   --color-gold: #d4af37;
@@ -22,7 +26,7 @@
   --color-gold-dim: #a68b2a;
   --color-gold-glow: rgba(212, 175, 55, 0.4);
 
-  /* Cream/ivory (secondary) */
+  /* Cream/ivory (secondary brand) */
   --color-cream: #f5f0e6;
   --color-cream-dim: rgba(245, 240, 230, 0.7);
   --color-cream-muted: rgba(245, 240, 230, 0.5);
@@ -37,6 +41,41 @@
   --text-primary: var(--color-cream);
   --text-secondary: var(--color-cream-dim);
   --text-muted: var(--color-cream-muted);
+
+  /* Semantic surfaces & borders */
+  --border-faint: rgba(245, 240, 230, 0.06);
+  --border-subtle: rgba(245, 240, 230, 0.08);
+  --border-default: rgba(245, 240, 230, 0.12);
+  --border-strong: rgba(245, 240, 230, 0.15);
+  --border-stronger: rgba(245, 240, 230, 0.25);
+  --surface-faint: rgba(245, 240, 230, 0.02);
+  --surface-muted: rgba(245, 240, 230, 0.03);
+  --surface-soft: rgba(245, 240, 230, 0.04);
+  --surface-hover: rgba(245, 240, 230, 0.05);
+  --surface-overlay: rgba(255, 255, 255, 0.04);
+  --surface-overlay-strong: rgba(255, 255, 255, 0.08);
+  --surface-status: rgba(10, 10, 15, 0.78);
+  --accent-soft: rgba(212, 175, 55, 0.08);
+  --accent-soft-mid: rgba(212, 175, 55, 0.1);
+  --accent-soft-strong: rgba(212, 175, 55, 0.15);
+  --accent-soft-active: rgba(212, 175, 55, 0.16);
+  --accent-border: rgba(212, 175, 55, 0.2);
+  --accent-border-mid: rgba(212, 175, 55, 0.25);
+  --accent-border-strong: rgba(212, 175, 55, 0.35);
+  --accent-border-active: rgba(212, 175, 55, 0.4);
+  --accent-border-focus: rgba(212, 175, 55, 0.45);
+  --accent-shadow: rgba(212, 175, 55, 0.3);
+  --accent-shadow-soft: rgba(212, 175, 55, 0.2);
+  --accent-ring: rgba(212, 175, 55, 0.12);
+  --accent-wash: rgba(212, 175, 55, 0.03);
+  --gauge-track: rgba(245, 240, 230, 0.1);
+  --scrollbar-track: rgba(255, 255, 255, 0.02);
+  --scrollbar-thumb: rgba(212, 175, 55, 0.3);
+  --scrollbar-thumb-hover: rgba(212, 175, 55, 0.5);
+  --overlay-scrim: rgba(0, 0, 0, 0.7);
+  --header-accent-border: rgba(212, 175, 55, 0.15);
+  --body-wash: rgba(212, 175, 55, 0.03);
+  --noise-opacity: 0.03;
 
   /* Spacing - compact for 7" */
   --space-xs: 0.25rem;
@@ -72,15 +111,83 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Light theme */
+[data-theme='light'] {
+  --color-bg-deep: #f7f4ee;
+  --color-bg-card: #fffcf7;
+  --color-bg-elevated: #f0ebe3;
+  --color-bg-hover: #e5dfd4;
+  --color-bg-camera: #0a0a0f;
+  --color-on-gold: #0a0a0f;
+
+  --color-gold: #b8922a;
+  --color-gold-bright: #c9a227;
+  --color-gold-dim: #8f7120;
+  --color-gold-glow: rgba(184, 146, 42, 0.3);
+
+  --color-cream: #f5f0e6;
+  --color-cream-dim: rgba(26, 24, 20, 0.72);
+  --color-cream-muted: rgba(26, 24, 20, 0.5);
+
+  --color-success: #16a34a;
+  --color-info: #2563eb;
+  --color-warning: #d97706;
+  --color-danger: #dc2626;
+
+  --text-primary: #1a1814;
+  --text-secondary: rgba(26, 24, 20, 0.72);
+  --text-muted: rgba(26, 24, 20, 0.5);
+
+  --border-faint: rgba(26, 24, 20, 0.06);
+  --border-subtle: rgba(26, 24, 20, 0.08);
+  --border-default: rgba(26, 24, 20, 0.12);
+  --border-strong: rgba(26, 24, 20, 0.16);
+  --border-stronger: rgba(26, 24, 20, 0.24);
+  --surface-faint: rgba(26, 24, 20, 0.02);
+  --surface-muted: rgba(26, 24, 20, 0.03);
+  --surface-soft: rgba(26, 24, 20, 0.04);
+  --surface-hover: rgba(26, 24, 20, 0.05);
+  --surface-overlay: rgba(26, 24, 20, 0.04);
+  --surface-overlay-strong: rgba(26, 24, 20, 0.08);
+  --surface-status: rgba(255, 252, 247, 0.88);
+  --accent-soft: rgba(184, 146, 42, 0.1);
+  --accent-soft-mid: rgba(184, 146, 42, 0.12);
+  --accent-soft-strong: rgba(184, 146, 42, 0.16);
+  --accent-soft-active: rgba(184, 146, 42, 0.18);
+  --accent-border: rgba(184, 146, 42, 0.28);
+  --accent-border-mid: rgba(184, 146, 42, 0.32);
+  --accent-border-strong: rgba(184, 146, 42, 0.42);
+  --accent-border-active: rgba(184, 146, 42, 0.48);
+  --accent-border-focus: rgba(184, 146, 42, 0.55);
+  --accent-shadow: rgba(184, 146, 42, 0.28);
+  --accent-shadow-soft: rgba(184, 146, 42, 0.18);
+  --accent-ring: rgba(184, 146, 42, 0.16);
+  --accent-wash: rgba(184, 146, 42, 0.06);
+  --gauge-track: rgba(26, 24, 20, 0.1);
+  --scrollbar-track: rgba(26, 24, 20, 0.04);
+  --scrollbar-thumb: rgba(184, 146, 42, 0.4);
+  --scrollbar-thumb-hover: rgba(184, 146, 42, 0.6);
+  --overlay-scrim: rgba(26, 24, 20, 0.45);
+  --header-accent-border: rgba(184, 146, 42, 0.22);
+  --body-wash: rgba(184, 146, 42, 0.07);
+  --noise-opacity: 0.025;
+
+  --shadow-glow: 0 0 18px var(--color-gold-glow);
+  --shadow-card: 0 4px 18px rgba(26, 24, 20, 0.08);
+
+  color-scheme: light;
+  color: var(--text-primary);
+  background-color: var(--color-bg-deep);
+}
+
 body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
   font-family: var(--font-body);
   background: var(--color-bg-deep);
-  /* Subtle texture overlay */
   background-image:
-    radial-gradient(ellipse at 50% 0%, rgba(212, 175, 55, 0.03) 0%, transparent 50%),
+    radial-gradient(ellipse at 50% 0%, var(--body-wash) 0%, transparent 50%),
     url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.03'/%3E%3C/svg%3E");
 }
 
@@ -98,16 +205,16 @@ button {
 }
 
 ::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--scrollbar-track);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(212, 175, 55, 0.3);
+  background: var(--scrollbar-thumb);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(212, 175, 55, 0.5);
+  background: var(--scrollbar-thumb-hover);
 }
 
 /* Utility classes */
@@ -115,7 +222,7 @@ button {
   color: var(--color-gold);
 }
 .text-cream {
-  color: var(--color-cream);
+  color: var(--text-primary);
 }
 .text-muted {
   color: var(--text-muted);

--- a/ui/src/logo/Logo.tsx
+++ b/ui/src/logo/Logo.tsx
@@ -11,7 +11,7 @@ function getColor(variant: LogoVariant) {
     case 'light':
       return '#d4af37'; // var(--color-gold)
     case 'dark':
-      return '##1A3617';
+      return '#1A3617';
     case 'color':
       return null;
     default:

--- a/ui/src/stores/useThemeStore.test.ts
+++ b/ui/src/stores/useThemeStore.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  THEME_STORAGE_KEY,
+  applyThemeToDocument,
+  readStoredTheme,
+  useThemeStore,
+} from './useThemeStore';
+
+const storage = new Map<string, string>();
+
+const documentElement = {
+  attrs: new Map<string, string>(),
+  setAttribute(name: string, value: string) {
+    this.attrs.set(name, value);
+  },
+  getAttribute(name: string) {
+    return this.attrs.get(name) ?? null;
+  },
+  removeAttribute(name: string) {
+    this.attrs.delete(name);
+  },
+};
+
+describe('useThemeStore', () => {
+  beforeEach(() => {
+    storage.clear();
+    documentElement.attrs.clear();
+
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+        clear: () => storage.clear(),
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+      },
+    });
+
+    vi.stubGlobal('document', {
+      documentElement,
+    });
+
+    useThemeStore.setState({ theme: 'dark' });
+    applyThemeToDocument('dark');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults to dark when nothing is stored', () => {
+    expect(readStoredTheme()).toBe('dark');
+  });
+
+  it('reads a stored light preference', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'light');
+    expect(readStoredTheme()).toBe('light');
+  });
+
+  it('persists theme and updates the document attribute', () => {
+    useThemeStore.getState().setTheme('light');
+
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(useThemeStore.getState().theme).toBe('light');
+  });
+
+  it('toggles between light and dark', () => {
+    useThemeStore.getState().setTheme('dark');
+    useThemeStore.getState().toggleTheme();
+
+    expect(useThemeStore.getState().theme).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+
+    useThemeStore.getState().toggleTheme();
+
+    expect(useThemeStore.getState().theme).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+});

--- a/ui/src/stores/useThemeStore.ts
+++ b/ui/src/stores/useThemeStore.ts
@@ -1,0 +1,55 @@
+import { create } from 'zustand';
+
+export type Theme = 'light' | 'dark';
+
+export const THEME_STORAGE_KEY = 'openflight.theme';
+
+export function applyThemeToDocument(theme: Theme): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  document.documentElement.setAttribute('data-theme', theme);
+}
+
+export function readStoredTheme(): Theme {
+  if (typeof window === 'undefined') {
+    return 'dark';
+  }
+
+  try {
+    const storedValue = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return storedValue === 'light' ? 'light' : 'dark';
+  } catch {
+    return 'dark';
+  }
+}
+
+interface ThemeState {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+export const useThemeStore = create<ThemeState>((set, get) => ({
+  theme: readStoredTheme(),
+  setTheme: (theme) => {
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+      } catch {
+        // Ignore quota / private browsing failures.
+      }
+    }
+
+    applyThemeToDocument(theme);
+    set({ theme });
+  },
+  toggleTheme: () => {
+    const nextTheme: Theme = get().theme === 'light' ? 'dark' : 'light';
+    get().setTheme(nextTheme);
+  },
+}));
+
+// Sync DOM on module load (FOUC script usually already set this).
+applyThemeToDocument(readStoredTheme());


### PR DESCRIPTION
## What does this PR do?

Adds a first-class **light theme** to the OpenFlight UI alongside the existing dark theme.

- Dual theme tokens in `ui/src/index.css` (`[data-theme="dark"]` / `[data-theme="light"]`) plus semantic surface/border/accent CSS variables
- Header sun/moon toggle (`ThemeToggle`) via `useThemeStore`, persisted as `openflight.theme` in `localStorage`
- FOUC prevention with an inline script in `ui/index.html`
- Component CSS updated to use tokens instead of hardcoded cream/gold `rgba()` values
- Logo uses the color variant in light mode; **`/display` stays forced dark** for TV readability
- Launch Daddy left dark-only (unchanged)

## Why was this required?

The UI was dark-only (`color-scheme: dark` with cream-on-dark literals). Light mode is needed for daytime / bright environments (desk, range) without changing the gold golf aesthetic — backgrounds, text, and borders flip via tokens; layout and accent stay the same.

## Automated tests

- Added `ui/src/stores/useThemeStore.test.ts` covering:
  - default theme (`dark` when unset)
  - reading a stored `light` preference
  - persisting to `localStorage` and setting `document.documentElement` `data-theme`
  - toggling light ↔ dark  
  (stubs `window` / `document` — no JSDOM)

## Manual (human) testing

From `ui/` on `feat/lightmode` (needs a backend — `npm run dev` against Python mock, or `npm run dev:mock` if the mock-server PR is available):

1. **Default** — app loads dark; no light flash on refresh when preference is unset/`dark`
2. **Toggle** — sun/moon button switches themes; header, nav, Live / Stats / Shots / Camera / Debug stay readable in both
3. **Persistence** — switch to light, refresh; theme stays light (`openflight.theme`)
4. **Display mode** — `/display` stays dark even when the main UI is light
5. **Overlays** — club select, pickers, shutdown dialog look correct in both themes
6. Confirmed: `npm run test`, `npm run lint`, `npm run build`

> Add any contrast/visual issues you spot before merging.

## Checklist

- [x] **Single feature/fix** — light mode only (mock server is on `feat/ui-mock-server`)
- [x] **Automated tests included** — theme store tests cover persist, DOM attribute, and toggle
- [ ] **Manual testing described** — *check after you run the flows above*
- [ ] Python tests pass (`uv run pytest tests/ -v`) — *N/A for UI-only*
- [ ] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`) — *N/A*
- [ ] Ruff passes (`uv run ruff check src/openflight/`) — *N/A*
- [x] UI builds (`cd ui && npm run build`)
- [x] UI lint passes (`cd ui && npm run lint`)
- [x] Updated docs or CHANGELOG if needed — `ui/README.md` documents theme toggle / storage key
- [x] No unrelated changes mixed in