### PR TITLE
fix(iwr6843): report low-quality track warnings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -86,6 +86,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--kld7-bypass-vertical-gate` renamed to `--kld7-vertical-raw`.
 
 ### Fixed
+- IWR6843 LCMF results now report `accepted_track_quality_warning` for
+  accepted low-quality tracks. The warning branch previously checked for
+  `reject`, which had already returned earlier and was therefore unreachable.
 - Session logging: serialize all access to the session JSONL file with a
   lock. The `log_*` methods are called concurrently from the OPS243
   capture thread, the K-LD7 stream thread, and Flask-SocketIO handlers;

--- a/src/openflight/iwr6843/lcmf.py
+++ b/src/openflight/iwr6843/lcmf.py
@@ -761,7 +761,7 @@ def estimate_lcmf_v1(
         )
     measured = measured_channels(channel_components, channel_evidence)
     result = _result_from_track(
-        "accepted_track_quality_warning" if shot.quality == "reject" else "accepted",
+        "accepted_track_quality_warning" if shot.quality == "low" else "accepted",
         shot,
     )
     result.angle_deg = raw_angle_deg + ANGLE_CORRECTION_DEG

--- a/tests/test_iwr6843_pipeline.py
+++ b/tests/test_iwr6843_pipeline.py
@@ -854,6 +854,27 @@ def test_lcmf_v1_reports_rejected_track_quality(cal):
     assert result.status == "rejected_track_quality"
 
 
+def test_lcmf_v1_warns_on_accepted_low_quality_track(cal, monkeypatch):
+    """An accepted low-quality track must retain its warning status."""
+    original_process_dump = lcmf.process_dump
+
+    def process_low_quality_dump(*args, **kwargs):
+        shot = original_process_dump(*args, **kwargs)
+        assert shot.track is not None
+        shot.quality = "low"
+        return shot
+
+    monkeypatch.setattr(lcmf, "process_dump", process_low_quality_dump)
+
+    result = estimate_lcmf_v1(
+        _range_snapshot_shot(), cal, ball_speed_mph=45.0 * 2.23694, club="9i"
+    )
+
+    assert result.accepted
+    assert result.tracker_quality == "low"
+    assert result.status == "accepted_track_quality_warning"
+
+
 def test_lcmf_v1_uses_tx2_effective_timing_on_three_tx_capture(cal):
     rng = np.random.default_rng(12)
     cube = (


### PR DESCRIPTION
## What does this PR do?

Fixes #173.

LCMF-v1 now reports `accepted_track_quality_warning` when a track with
`quality == "low"` still produces an accepted launch-angle estimate. The change
also adds a regression test and documents the fix in the changelog.

## Why was this required?

The warning branch checked `shot.quality == "reject"`, but rejected tracks had
already returned as `rejected_track_quality` earlier in `estimate_lcmf_v1`.
That made `accepted_track_quality_warning` unreachable and caused accepted
low-quality tracks to be mislabeled as plain `accepted`.

## Automated tests

- Added `test_lcmf_v1_warns_on_accepted_low_quality_track`, which forces an
  otherwise valid synthetic range-snapshot track to `quality == "low"` and
  asserts the accepted warning status.
- Confirmed the existing rejected-track test still returns
  `rejected_track_quality`.
- `uv run pytest tests/ -q`: 1,232 passed, 8 skipped.
- `uv run ruff check src/openflight/ tests/test_iwr6843_pipeline.py`: passed.
- `uv run pylint src/openflight/ --fail-under=9`: passed, 9.70/10.
- `cd ui && npm run lint`: passed.
- `cd ui && npm run build`: passed.

## Manual (human) testing

Ran the LCMF estimator directly against the repository's synthetic range
snapshot while forcing the detected track's quality to `low`. The resulting
record reported:

```text
status=accepted_track_quality_warning
accepted=True
tracker_quality=low
angle_deg=20.047
```

Also inspected the rejection path to verify that `quality == "reject"` still
returns before channel estimation and remains labeled `rejected_track_quality`.
No physical radar hardware was required for this status-only fix.

## Checklist

- [x] **Single feature/fix** — this PR is scoped to one thing with a clear story above
- [x] **Automated tests included** — new or updated tests cover this change
- [x] **Manual testing described** — I documented what I verified by hand above
- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [x] UI builds (`cd ui && npm run build`)
- [x] UI lint passes (`cd ui && npm run lint`)
- [x] Updated docs or CHANGELOG if needed
- [x] No unrelated changes mixed in
