### PR TITLE
docs: fix setup dependencies, workflow notes, and Pi 5 UART config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,9 @@ ui/playwright-report/
 ui/test-results/
 
 .superpowers/
+
+#Markdown preview files
+.crossnote/config.js
+.crossnote/head.html
+.crossnote/parser.js
+.crossnote/style.less

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **System Prerequisites:** Documented missing binary dependencies (`swig`, `liblgpio-dev`, `python3-dev`) required prior to executing `./scripts/setup/setup.sh`.
+- **Environment Reload Guidance:** Added instructions for reloading terminal environment variables (`source ~/.bashrc`) when installed dependencies or scripts (`setup.sh`, `start-kiosk.sh`) are not recognized in the current terminal session.
 - **OPS243 over the Raspberry Pi GPIO UART.** The radar can now run on the J3
   header instead of USB, which frees the Pi's USB power budget for the TI angle
   radar. Baud is the real wire rate on that transport and the factory default of
@@ -86,6 +88,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--kld7-bypass-vertical-gate` renamed to `--kld7-vertical-raw`.
 
 ### Fixed
+- **Raspberry Pi 5 & OS Compatibility:** Updated UART configuration documentation to support Debian Bookworm and Raspberry Pi 5 hardware using `dtparam=uart0=on` alongside legacy `enable_uart=1`.
+- **UART Diagnostic Commands:** Simplified UART verification instructions in `docs/iwr6843/README.md` and `docs/ops243-uart-migration.md` using `grep -E` to check for both legacy and modern device-tree parameters simultaneously across config paths.
 - Session logging: serialize all access to the session JSONL file with a
   lock. The `log_*` methods are called concurrently from the OPS243
   capture thread, the K-LD7 stream thread, and Flask-SocketIO handlers;

--- a/docs/iwr6843/README.md
+++ b/docs/iwr6843/README.md
@@ -217,13 +217,21 @@ to `/dev/ttyAMA10`, which is the separate debug-header UART rather than the
 If `/dev/ttyAMA0` is missing, confirm that UART0 is enabled:
 
 ```bash
-grep enable_uart /boot/firmware/config.txt /boot/config.txt 2>/dev/null
+grep -E "enable_uart|dtparam=uart0" /boot/firmware/config.txt /boot/config.txt 2>/dev/null
 ```
+
+Note for Raspberry Pi 5 & Newer OS Versions:
+Newer hardware and Debian Bookworm use dtparam=uart0=on instead of the legacy enable_uart=1 setting to enable the UART0 hardware block.
 
 At least one boot configuration should contain:
 
 ```text
 enable_uart=1
+```
+Or
+
+```text
+dtparam=uart0=on
 ```
 
 ## Prepare Serial And GPIO Permissions

--- a/docs/ops243-uart-migration.md
+++ b/docs/ops243-uart-migration.md
@@ -114,9 +114,12 @@ Confirm the device and that nothing else claims it:
 
 ```bash
 ls -l /dev/ttyAMA0
-grep -o 'console=serial0[^ ]*' /boot/firmware/cmdline.txt   # must print nothing
-grep enable_uart /boot/firmware/config.txt                  # expect enable_uart=1
+grep -o 'console=serial0[^ ]*' /boot/firmware/cmdline.txt      # must print nothing
+grep -E "enable_uart|dtparam=uart0" /boot/firmware/config.txt  # expect enable_uart=1 or dtparam=uart0=on
 ```
+
+Note for Raspberry Pi 5 & Newer OS Versions:
+Modern Pi OS (Debian Bookworm) and Pi 5 hardware use dtparam=uart0=on instead of the legacy enable_uart=1 setting to enable the UART0 hardware block.
 
 On a Pi 5 the 40-pin header is `/dev/ttyAMA0`. Do **not** use `/dev/serial0`,
 which points at `/dev/ttyAMA10` — the separate debug-header UART.

--- a/docs/raspberry-pi-setup.md
+++ b/docs/raspberry-pi-setup.md
@@ -24,9 +24,19 @@ Make sure you have all the hardware. See the **[Parts List](PARTS.md)** for what
 
 ## Setup
 
-### 1. Install Raspberry Pi OS
+### 1. Install Raspberry Pi OS and Dependencies
 
 Use Raspberry Pi Imager to flash **Raspberry Pi OS (64-bit)** to your SD card.
+
+On the first boot, before cloning OpenFlight, you'll likely need a few dependencies to run the setup.sh script.
+
+Run the following command:
+
+```bash
+sudo apt update && sudo apt install -y swig liblgpio-dev python3-dev
+```
+
+If the `./scripts/setup/setup.sh` or `./scripts/start-kiosk.sh` commands below don't pick up installed dependencies, it may be required to run `source ~/.bashrc` in the terminal. Edits to `~/.bashrc` only load automatically when a new terminal session starts. Running `source ~/.bashrc` forces your current terminal window to re-read the file so those new variables take effect immediately without needing to reboot or re-login.
 
 ### 2. Run the setup script
 

--- a/docs/raspberry-pi-setup.md
+++ b/docs/raspberry-pi-setup.md
@@ -36,7 +36,7 @@ Run the following command:
 sudo apt update && sudo apt install -y swig liblgpio-dev python3-dev
 ```
 
-If the `./scripts/setup/setup.sh` or `./scripts/start-kiosk.sh` commands below don't pick up installed dependencies, it may be required to run `source ~/.bashrc` in the terminal. Edits to `~/.bashrc` only load automatically when a new terminal session starts. Running `source ~/.bashrc` forces your current terminal window to re-read the file so those new variables take effect immediately without needing to reboot or re-login.
+If `./scripts/setup/setup.sh` updates `~/.bashrc`, you may need to run `source ~/.bashrc` (or open a new terminal) so your current shell picks up the new environment variables immediately without needing to reboot or re-login.
 
 ### 2. Run the setup script
 


### PR DESCRIPTION
What does this PR do?

Fixes #206  

<!--
Fix setup documentation by adding missing system build dependencies and modernizing Raspberry Pi UART configuration checks for Pi 5 / Bookworm support.
-->

## Why was this required?

Setting up OpenFlight on a fresh Raspberry Pi OS (64-bit) installation presented two main friction points for new builds:

1. **Missing Prerequisites:** The setup script relies on SWIG C-bindings and GPIO header files. On clean OS installs, running `./scripts/setup/setup.sh` failed due to missing `swig`, `liblgpio-dev`, and `python3-dev` packages. Additionally, users were hitting missing command errors when environment variables set during setup weren't reloaded into the active shell session.
2. **Raspberry Pi 5 / Bookworm UART Incompatibility:** Legacy documentation only referenced `enable_uart=1` in `/boot/config.txt`. Modern Raspberry Pi OS (Debian Bookworm) and Pi 5 hardware use `dtparam=uart0=on` located under `/boot/firmware/config.txt` to explicitly enable the UART0 hardware block. Without updating these checks, serial communication with connected radar modules fails silently or reports missing `/dev/ttyAMA0` devices.

---

## Automated tests

N/A — This PR contains documentation (`.md`) updates only. No executable source code or automated logic was modified.

---

## Manual (human) testing

Verified on a fresh **Raspberry Pi OS (64-bit / Bookworm)** setup:

- **Dependency & Workflow Test:** Flashed a clean OS image, ran `sudo apt update && sudo apt install -y swig liblgpio-dev python3-dev`, cloned the repository, and executed `./scripts/setup/setup.sh`. Verified the script completed without missing dependency/header errors.
- **Environment Reload Test:** Confirmed that executing `source ~/.bashrc` properly refreshed active shell variables without requiring a system reboot or re-login.
- **UART Verification:** Executed the updated `grep -E "enable_uart|dtparam=uart0" /boot/firmware/config.txt` command on a Pi 5. Verified that `dtparam=uart0=on` was correctly identified and that `/dev/ttyAMA0` was enumerated and active for radar communication.

---

## Checklist

- [x] **Single feature/fix** — this PR is scoped to one thing with a clear story above
- [ ] **Automated tests included** — N/A (Documentation changes only)
- [x] **Manual testing described** — I documented what I verified by hand above
- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [x] UI builds (`cd ui && npm run build`)
- [x] UI lint passes (`cd ui && npm run lint`)
- [x] Updated docs or CHANGELOG if needed
- [x] No unrelated changes mixed in
