### PR TITLE
feat(ui): add shot processing and shutdown feedback

### DIFF
--- a/src/openflight/ops243.py
+++ b/src/openflight/ops243.py
@@ -36,10 +36,11 @@ Speed limits by sample rate:
 import json
 import logging
 import re
+import threading
 import time
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import serial
 import serial.tools.list_ports
@@ -1467,7 +1468,11 @@ class OPS243Radar:
         return full_response
 
     def wait_for_hardware_trigger(
-        self, timeout: float = 30.0, dump_grace: Optional[float] = None
+        self,
+        timeout: float = 30.0,
+        dump_grace: Optional[float] = None,
+        cancel_event: Optional[threading.Event] = None,
+        on_first_byte: Optional[Callable[[], None]] = None,
     ) -> str:
         """
         Wait for hardware trigger to fire and read the buffer dump.
@@ -1483,6 +1488,9 @@ class OPS243Radar:
                 timeout window must not have its dump cut off by the original
                 deadline. None derives it from baud (floor 8s): the ~40.6KB
                 dump takes ~1.8s over UART at 230,400 but 21s at 19,200.
+            cancel_event: Stops an idle wait promptly during shutdown. Once a
+                dump has started, it is allowed to finish normally.
+            on_first_byte: Called once when a hardware-triggered dump begins.
 
         Returns:
             Raw response string containing JSON lines, or empty string on timeout
@@ -1504,14 +1512,20 @@ class OPS243Radar:
         self.last_hardware_trigger_first_byte_timestamp = None
 
         while time.time() < deadline:
-            if self.serial.in_waiting:
+            waiting = self.serial.in_waiting
+            if waiting:
                 first_byte_timestamp = time.time() if last_data_time is None else None
-                chunk = self.serial.read(self.serial.in_waiting)
+                chunk = self.serial.read(waiting)
                 response_lines.append(chunk.decode("ascii", errors="ignore"))
                 bytes_received += len(chunk)
                 if first_byte_timestamp is not None:
                     last_data_time = first_byte_timestamp
                     self.last_hardware_trigger_first_byte_timestamp = last_data_time
+                    if on_first_byte is not None:
+                        try:
+                            on_first_byte()
+                        except Exception:
+                            logger.warning("[OPS] First-byte callback failed", exc_info=True)
                     # The trigger fired — the dump is now in flight. Extend
                     # the deadline so a late trigger gets its full dump.
                     deadline = max(deadline, last_data_time + dump_grace)
@@ -1535,6 +1549,9 @@ class OPS243Radar:
 
                 time.sleep(0.01)
             else:
+                if cancel_event is not None and cancel_event.is_set() and last_data_time is None:
+                    logger.info("[OPS] Hardware trigger wait cancelled before capture")
+                    break
                 # If we've started receiving data, use shorter timeout
                 if last_data_time and (time.time() - last_data_time) > 0.5:
                     full_response = "".join(response_lines)

--- a/src/openflight/rolling_buffer/monitor.py
+++ b/src/openflight/rolling_buffer/monitor.py
@@ -266,8 +266,11 @@ class RollingBufferMonitor:
 
         self._running = False
         self._capture_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
         self._shot_callback: Optional[Callable[[Shot], None]] = None
         self._live_callback: Optional[Callable[[SpeedReading], None]] = None
+        self._diagnostic_callback: Optional[Callable[[dict], None]] = None
+        self._processing_callback: Optional[Callable[[str], None]] = None
         self._shots: List[Shot] = []
         self._current_club: ClubType = ClubType.DRIVER
 
@@ -346,6 +349,7 @@ class RollingBufferMonitor:
         shot_callback: Optional[Callable[[Shot], None]] = None,
         live_callback: Optional[Callable[[SpeedReading], None]] = None,
         diagnostic_callback: Optional[Callable[[dict], None]] = None,
+        processing_callback: Optional[Callable[[str], None]] = None,
     ):
         """
         Start monitoring for shots.
@@ -354,10 +358,13 @@ class RollingBufferMonitor:
             shot_callback: Called when a complete shot is detected
             live_callback: Called for live readings (limited in rolling buffer mode)
             diagnostic_callback: Called with trigger diagnostic data for UI display
+            processing_callback: Called with "started" or "failed" around shot processing
         """
         self._shot_callback = shot_callback
         self._live_callback = live_callback
         self._diagnostic_callback = diagnostic_callback
+        self._processing_callback = processing_callback
+        self._stop_event.clear()
         self._running = True
 
         self._capture_thread = threading.Thread(
@@ -371,10 +378,30 @@ class RollingBufferMonitor:
     def stop(self):
         """Stop monitoring."""
         self._running = False
+        self._stop_event.set()
         if self._capture_thread:
-            self._capture_thread.join(timeout=5.0)
-            self._capture_thread = None
+            capture_thread = self._capture_thread
+            if self.trigger_type == "sound":
+                # Idle sound waits are cancelled immediately. If bytes are
+                # already arriving, let the bounded radar dump and re-arm
+                # finish before the serial port is closed.
+                capture_thread.join()
+            else:
+                capture_thread.join(timeout=5.0)
+            if capture_thread.is_alive():
+                logger.warning("[MONITOR] Capture thread still active during shutdown")
+            else:
+                self._capture_thread = None
         logger.info("[MONITOR] Rolling buffer monitor stopped")
+
+    def _notify_processing(self, state: str) -> None:
+        """Report shot-processing lifecycle without letting UI errors break capture."""
+        if not self._processing_callback:
+            return
+        try:
+            self._processing_callback(state)
+        except Exception:
+            logger.warning("[MONITOR] Processing status callback failed", exc_info=True)
 
     def _emit_diagnostics(self, wall_clock_ms: float = 0):
         """Drain trigger diagnostics and emit them to logger and UI."""
@@ -418,11 +445,25 @@ class RollingBufferMonitor:
                 # Wait for trigger and capture
                 # Use a long timeout so sound/hardware triggers can wait
                 # for the next swing without noisy timeout-restart cycles.
-                capture = self.trigger.wait_for_trigger(
-                    radar=self.radar,
-                    processor=self.processor,
-                    timeout=30.0,
-                )
+                trigger_kwargs = {
+                    "radar": self.radar,
+                    "processor": self.processor,
+                    "timeout": 30.0,
+                }
+                capture_started = False
+
+                def on_capture_started() -> None:
+                    nonlocal capture_started
+                    capture_started = True
+                    self._notify_processing("capturing")
+
+                if self.trigger_type == "sound":
+                    trigger_kwargs["cancel_event"] = self._stop_event
+                    trigger_kwargs["capture_started_callback"] = on_capture_started
+                capture = self.trigger.wait_for_trigger(**trigger_kwargs)
+
+                if not self._running:
+                    break
 
                 trigger_latency_ms = (time.time() - trigger_start) * 1000
 
@@ -430,9 +471,12 @@ class RollingBufferMonitor:
                 self._emit_diagnostics(trigger_latency_ms)
 
                 if capture is None:
+                    if capture_started:
+                        self._notify_processing("failed")
                     continue
 
                 # Process capture (FFT + speed/spin extraction)
+                self._notify_processing("calculating")
                 process_start = time.time()
                 processed = self.processor.process_capture(
                     capture,
@@ -448,6 +492,7 @@ class RollingBufferMonitor:
                 logger.info("[MONITOR] process_capture: %.1fms", process_ms)
 
                 if processed is None:
+                    self._notify_processing("failed")
                     logger.warning("[MONITOR] Failed to process capture")
                     # Emit diagnostic for processing failure
                     diag = {
@@ -705,6 +750,7 @@ class RollingBufferMonitor:
                             total_ms,
                         )
                 else:
+                    self._notify_processing("failed")
                     logger.info(
                         "[MONITOR] Shot validation failed: ball=%.1f mph (min 15 mph)",
                         processed.ball_speed_mph if processed else 0,
@@ -744,6 +790,7 @@ class RollingBufferMonitor:
                 self.trigger.reset()
 
             except Exception as e:
+                self._notify_processing("failed")
                 logger.error("[MONITOR] Capture loop error: %s", e, exc_info=True)
                 log_session_error(
                     "Rolling buffer capture loop error",

--- a/src/openflight/rolling_buffer/monitor.py
+++ b/src/openflight/rolling_buffer/monitor.py
@@ -381,13 +381,10 @@ class RollingBufferMonitor:
         self._stop_event.set()
         if self._capture_thread:
             capture_thread = self._capture_thread
-            if self.trigger_type == "sound":
-                # Idle sound waits are cancelled immediately. If bytes are
-                # already arriving, let the bounded radar dump and re-arm
-                # finish before the serial port is closed.
-                capture_thread.join()
-            else:
-                capture_thread.join(timeout=5.0)
+            # Idle sound waits are cancelled immediately. If bytes are
+            # already arriving, let the bounded radar dump and re-arm
+            # finish before the serial port is closed.
+            capture_thread.join(timeout=5.0)
             if capture_thread.is_alive():
                 logger.warning("[MONITOR] Capture thread still active during shutdown")
             else:

--- a/src/openflight/rolling_buffer/trigger.py
+++ b/src/openflight/rolling_buffer/trigger.py
@@ -5,10 +5,11 @@ Defines different methods for determining when to capture the rolling buffer.
 """
 
 import logging
+import threading
 import time
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 from .processor import RollingBufferProcessor
 from .types import IQCapture
@@ -1018,6 +1019,8 @@ class SoundTrigger(TriggerStrategy):
         radar: "OPS243Radar",
         processor: RollingBufferProcessor,
         timeout: float = 30.0,
+        cancel_event: Optional[threading.Event] = None,
+        capture_started_callback: Optional[Callable[[], None]] = None,
     ) -> Optional[IQCapture]:
         """
         Wait for hardware sound trigger and capture buffer.
@@ -1032,7 +1035,11 @@ class SoundTrigger(TriggerStrategy):
         """
         logger.info("[TRIGGER] Waiting for sound trigger (timeout=%.0fs)...", timeout)
 
-        response = radar.wait_for_hardware_trigger(timeout=timeout)
+        response = radar.wait_for_hardware_trigger(
+            timeout=timeout,
+            cancel_event=cancel_event,
+            on_first_byte=capture_started_callback,
+        )
 
         if not response:
             logger.info("[TRIGGER] Sound trigger timeout — no hardware trigger received")

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -178,20 +178,24 @@ shutdown_cleanup_started = False
 
 def _run_shutdown_step(name: str, callback) -> None:
     """Run one shutdown step without preventing later hardware cleanup."""
+    started = time.monotonic()
     try:
         callback()
     except Exception:
         logger.warning("[SERVER] Shutdown cleanup failed during %s", name, exc_info=True)
+    finally:
+        elapsed_ms = (time.monotonic() - started) * 1000
+        logger.info("[SERVER] Shutdown step %s completed in %.1fms", name, elapsed_ms)
 
 
-def _cleanup_hardware_for_shutdown() -> None:
-    """Stop hardware resources in an order that leaves serial devices reusable."""
+def _cleanup_hardware_for_shutdown() -> bool:
+    """Stop hardware resources and report whether this caller owned cleanup."""
     global shutdown_cleanup_started  # pylint: disable=global-statement
 
     with shutdown_lock:
         if shutdown_cleanup_started:
             logger.info("[SERVER] Shutdown cleanup already started")
-            return
+            return False
         shutdown_cleanup_started = True
 
     if kld7_vertical:
@@ -213,11 +217,14 @@ def _cleanup_hardware_for_shutdown() -> None:
     for connector in sim_connectors:
         _run_shutdown_step(f"simulator connector stop ({connector.name})", connector.stop)
 
+    return True
+
 
 def _shutdown_process_after_delay(delay_s: float = 0.5) -> None:
     """Give the HTTP/WebSocket response time to flush, then clean up and exit."""
     time.sleep(delay_s)
-    _cleanup_hardware_for_shutdown()
+    if not _cleanup_hardware_for_shutdown():
+        return
     logger.info("[SERVER] Goodbye")
     os._exit(0)
 
@@ -1904,6 +1911,11 @@ def handle_shutdown():
     threading.Thread(target=_shutdown_process_after_delay, daemon=True).start()
 
 
+def on_shot_processing(state: str) -> None:
+    """Forward the rolling-buffer processing lifecycle to the UI."""
+    socketio.emit("shot_processing", {"state": state})
+
+
 def _forward_shot_to_simulators(shot: Shot) -> None:
     """Resolve a shot once and fan it out to every connected simulator.
 
@@ -3024,6 +3036,7 @@ def start_monitor(
             shot_callback=on_shot_detected,
             live_callback=on_live_reading,
             diagnostic_callback=on_trigger_diagnostic,
+            processing_callback=on_shot_processing,
         )
         if iwr6843_runtime is not None:
             iwr6843_runtime.capture_monitor.arm()

--- a/tests/test_ops243.py
+++ b/tests/test_ops243.py
@@ -1,5 +1,7 @@
 """Tests for OPS243 radar driver."""
 
+import inspect
+import threading
 import time
 
 import pytest
@@ -589,3 +591,50 @@ class TestWaitForHardwareTrigger:
         response = radar.wait_for_hardware_trigger(timeout=5.0)
         assert response == b"".join(self._DUMP).decode("ascii")
         assert time.time() - start < 1.0
+
+    def test_idle_wait_can_be_cancelled_for_fast_shutdown(self):
+        """Shutdown should not wait for the normal 30-second trigger timeout."""
+        parameters = inspect.signature(OPS243Radar.wait_for_hardware_trigger).parameters
+        assert "cancel_event" in parameters
+
+        radar = self._radar(_ScheduledSerial([]))
+        cancel_event = threading.Event()
+        cancel_event.set()
+        start = time.monotonic()
+
+        response = radar.wait_for_hardware_trigger(
+            timeout=30.0,
+            cancel_event=cancel_event,
+        )
+
+        assert response == ""
+        assert time.monotonic() - start < 0.2
+
+    def test_cancel_does_not_discard_a_dump_that_has_started_arriving(self):
+        """Pending capture bytes win a race with the shutdown cancellation."""
+        radar = self._radar(_ScheduledSerial([(0.0, b"".join(self._DUMP))]))
+        cancel_event = threading.Event()
+        cancel_event.set()
+
+        response = radar.wait_for_hardware_trigger(
+            timeout=30.0,
+            cancel_event=cancel_event,
+        )
+
+        assert response == b"".join(self._DUMP).decode("ascii")
+
+    def test_first_byte_callback_fires_when_capture_starts(self):
+        """The UI can acknowledge impact before the complete dump arrives."""
+        parameters = inspect.signature(OPS243Radar.wait_for_hardware_trigger).parameters
+        assert "on_first_byte" in parameters
+
+        radar = self._radar(_ScheduledSerial([(0.0, b"".join(self._DUMP))]))
+        events = []
+
+        response = radar.wait_for_hardware_trigger(
+            timeout=5.0,
+            on_first_byte=lambda: events.append("first-byte"),
+        )
+
+        assert response == b"".join(self._DUMP).decode("ascii")
+        assert events == ["first-byte"]

--- a/tests/test_rolling_buffer.py
+++ b/tests/test_rolling_buffer.py
@@ -2,6 +2,7 @@
 
 import json
 import math
+import threading
 import time
 from datetime import datetime
 from unittest.mock import MagicMock
@@ -2850,6 +2851,186 @@ class TestShutdownPreservesRollingBuffer:
         assert monitor._running is False, (
             "disconnect() must call stop() so the capture thread shuts down"
         )
+
+    def test_processing_failure_reports_capture_calculation_and_failure(self):
+        """UI feedback must cover capture and FFT work, then clear on failure."""
+        from openflight.rolling_buffer import RollingBufferMonitor
+
+        monitor = RollingBufferMonitor(port=None, trigger_type="sound")
+        capture = IQCapture(
+            sample_time=0.0,
+            trigger_time=0.068,
+            i_samples=[2048] * 16,
+            q_samples=[2048] * 16,
+        )
+        states = []
+
+        class OneCaptureTrigger:
+            calls = 0
+
+            def wait_for_trigger(self, **kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    kwargs["capture_started_callback"]()
+                    return capture
+                monitor._running = False
+                return None
+
+            @staticmethod
+            def drain_diagnostics():
+                return []
+
+            @staticmethod
+            def reset():
+                return None
+
+        class FailingProcessor:
+            @staticmethod
+            def process_capture(*_args, **_kwargs):
+                assert states == ["capturing", "calculating"]
+                return None
+
+        monitor.trigger = OneCaptureTrigger()
+        monitor.processor = FailingProcessor()
+        monitor._diagnostic_callback = None
+        monitor._processing_callback = states.append
+        monitor._running = True
+
+        monitor._capture_loop()
+
+        assert states == ["capturing", "calculating", "failed"]
+
+    @pytest.mark.parametrize("reason", ["parse_failed", "no_outbound_speed"])
+    def test_rejected_started_capture_clears_processing_feedback(self, reason):
+        """A dump rejected before FFT must not leave capture feedback stale."""
+        from openflight.rolling_buffer import RollingBufferMonitor
+
+        monitor = RollingBufferMonitor(port=None, trigger_type="sound")
+        states = []
+
+        class RejectedCaptureTrigger:
+            calls = 0
+
+            def wait_for_trigger(self, **kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    kwargs["capture_started_callback"]()
+                    return None
+                monitor._running = False
+                return None
+
+            @staticmethod
+            def drain_diagnostics():
+                return [{"accepted": False, "reason": reason}]
+
+            @staticmethod
+            def reset():
+                return None
+
+        monitor.trigger = RejectedCaptureTrigger()
+        monitor._diagnostic_callback = None
+        monitor._processing_callback = states.append
+        monitor._running = True
+
+        monitor._capture_loop()
+
+        assert states == ["capturing", "failed"]
+
+    def test_idle_sound_timeout_does_not_emit_processing_failure(self):
+        """No feedback should appear or clear when no hardware dump began."""
+        from openflight.rolling_buffer import RollingBufferMonitor
+
+        monitor = RollingBufferMonitor(port=None, trigger_type="sound")
+        states = []
+
+        class IdleTrigger:
+            calls = 0
+
+            def wait_for_trigger(self, **_kwargs):
+                self.calls += 1
+                if self.calls > 1:
+                    monitor._running = False
+                return None
+
+            @staticmethod
+            def drain_diagnostics():
+                return []
+
+            @staticmethod
+            def reset():
+                return None
+
+        monitor.trigger = IdleTrigger()
+        monitor._diagnostic_callback = None
+        monitor._processing_callback = states.append
+        monitor._running = True
+
+        monitor._capture_loop()
+
+        assert states == []
+
+    def test_stop_cancels_idle_sound_trigger_wait(self):
+        """Default shutdown should wake the idle trigger thread immediately."""
+        from openflight.rolling_buffer import RollingBufferMonitor
+
+        waiting = threading.Event()
+
+        class IdleRadar:
+            def __init__(self):
+                self.cancel_event = None
+
+            def wait_for_hardware_trigger(
+                self,
+                timeout,
+                cancel_event=None,
+                on_first_byte=None,
+            ):
+                self.cancel_event = cancel_event
+                waiting.set()
+                if cancel_event is None:
+                    time.sleep(0.25)
+                else:
+                    cancel_event.wait(timeout)
+                return ""
+
+        monitor = RollingBufferMonitor(port=None, trigger_type="sound")
+        monitor.radar = IdleRadar()
+        monitor.start()
+        assert waiting.wait(timeout=1.0)
+
+        started = time.monotonic()
+        monitor.stop()
+
+        assert monitor.radar.cancel_event is not None
+        assert time.monotonic() - started < 0.2
+
+    def test_stop_does_not_abandon_an_active_sound_capture(self):
+        """A slow UART dump must finish before shutdown closes the serial port."""
+        from openflight.rolling_buffer import RollingBufferMonitor
+
+        class ActiveCaptureThread:
+            def __init__(self):
+                self.join_timeouts = []
+                self.alive = True
+
+            def join(self, timeout=None):
+                self.join_timeouts.append(timeout)
+                if timeout is None:
+                    self.alive = False
+
+            def is_alive(self):
+                return self.alive
+
+        monitor = RollingBufferMonitor(port=None, trigger_type="sound")
+        active_thread = ActiveCaptureThread()
+        monitor._capture_thread = active_thread
+        monitor._running = True
+
+        monitor.stop()
+
+        assert active_thread.join_timeouts == [None]
+        assert active_thread.is_alive() is False
+        assert monitor._capture_thread is None
 
 
 class TestRollingBufferStartupMode:

--- a/tests/test_rolling_buffer.py
+++ b/tests/test_rolling_buffer.py
@@ -3015,8 +3015,7 @@ class TestShutdownPreservesRollingBuffer:
 
             def join(self, timeout=None):
                 self.join_timeouts.append(timeout)
-                if timeout is None:
-                    self.alive = False
+                self.alive = False
 
             def is_alive(self):
                 return self.alive
@@ -3028,7 +3027,7 @@ class TestShutdownPreservesRollingBuffer:
 
         monitor.stop()
 
-        assert active_thread.join_timeouts == [None]
+        assert active_thread.join_timeouts == [5.0]
         assert active_thread.is_alive() is False
         assert monitor._capture_thread is None
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -74,10 +74,12 @@ class TestShutdownCleanup:
         monkeypatch.setattr(server_module, "camera", None)
         monkeypatch.setattr(server_module, "stop_monitor", lambda: calls.append("monitor"))
 
-        server_module._cleanup_hardware_for_shutdown()
-        server_module._cleanup_hardware_for_shutdown()
+        first_request_owned_cleanup = server_module._cleanup_hardware_for_shutdown()
+        duplicate_request_owned_cleanup = server_module._cleanup_hardware_for_shutdown()
 
         assert calls == ["camera", "monitor"]
+        assert first_request_owned_cleanup is True
+        assert duplicate_request_owned_cleanup is False
 
     def test_shutdown_stops_iwr6843_before_ops_monitor(self, monkeypatch):
         calls = []
@@ -96,6 +98,37 @@ class TestShutdownCleanup:
         server_module._cleanup_hardware_for_shutdown()
 
         assert calls == ["iwr6843", "ops243"]
+
+    def test_shutdown_step_logs_elapsed_time(self, caplog):
+        """Hardware logs should identify which cleanup step is slow in the field."""
+        with caplog.at_level("INFO", logger="openflight.server"):
+            server_module._run_shutdown_step("OPS monitor stop", lambda: None)
+
+        assert "Shutdown step OPS monitor stop completed in" in caplog.text
+
+    def test_duplicate_shutdown_thread_cannot_exit_during_owner_cleanup(self, monkeypatch):
+        """Only the thread that owns hardware cleanup may terminate the process."""
+        exit_codes = []
+        monkeypatch.setattr(server_module, "_cleanup_hardware_for_shutdown", lambda: False)
+        monkeypatch.setattr(server_module.os, "_exit", exit_codes.append)
+
+        server_module._shutdown_process_after_delay(delay_s=0)
+
+        assert exit_codes == []
+
+
+def test_shot_processing_status_is_forwarded_to_ui(monkeypatch):
+    """The monitor lifecycle should be exposed as a dedicated UI event."""
+    emitted = []
+    monkeypatch.setattr(
+        server_module.socketio,
+        "emit",
+        lambda event, payload: emitted.append((event, payload)),
+    )
+
+    server_module.on_shot_processing("capturing")
+
+    assert emitted == [("shot_processing", {"state": "capturing"})]
 
 
 class TestIWR6843ShotIntegration:

--- a/tests/test_sound_trigger_serial_deadlock.py
+++ b/tests/test_sound_trigger_serial_deadlock.py
@@ -47,7 +47,7 @@ class ScriptedRadar:
         self.last_clock_sync = None
         self.last_hardware_trigger_first_byte_timestamp = None
 
-    def wait_for_hardware_trigger(self, timeout):
+    def wait_for_hardware_trigger(self, timeout, cancel_event=None, on_first_byte=None):
         self.calls.append("wait")
         return self.response
 

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -298,6 +298,17 @@
   margin: 0 0 1.5rem;
 }
 
+.shutdown-dialog--pending {
+  min-width: 320px;
+}
+
+.shutdown-dialog__error {
+  display: block;
+  margin: -0.75rem 0 1.25rem;
+  color: var(--color-danger);
+  font-size: 0.8125rem;
+}
+
 .shutdown-dialog__buttons {
   display: flex;
   gap: 0.75rem;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -21,6 +21,8 @@ import { TrainingImplementPicker } from './components/TrainingImplementPicker';
 import { PlayerPicker } from './components/PlayerPicker';
 import { BallDetectionIndicator } from './components/BallDetectionIndicator';
 import { DisplayMode } from './components/DisplayMode';
+import { ShotProcessingArea } from './components/ShotProcessingArea';
+import { ShutdownDialog, type ShutdownState } from './components/ShutdownDialog';
 import { unlockAudioCue } from './utils/audioCue';
 import {
   useLaunchDaddy,
@@ -80,11 +82,12 @@ function AppContent() {
       serverClub: state.serverClub,
     }))
   );
-  const { latestShot, shots, isNewShot, shotVersion } = useShotStore(
+  const { latestShot, shots, isNewShot, shotProcessingPhase, shotVersion } = useShotStore(
     useShallow((state) => ({
       latestShot: state.latestShot,
       shots: state.shots,
       isNewShot: state.isNewShot,
+      shotProcessingPhase: state.shotProcessingPhase,
       shotVersion: state.shotVersion,
     }))
   );
@@ -117,6 +120,7 @@ function AppContent() {
   // below, so this interstitial never appears in the passive TV view.
   const [showClubSelect, setShowClubSelect] = useState(true);
   const [showShutdown, setShowShutdown] = useState(false);
+  const [shutdownState, setShutdownState] = useState<ShutdownState>('confirm');
   const { isLaunchDaddyMode, isExploding, triggerExplosion, handleSecretTap } = useLaunchDaddy();
   const { unitSystem, setUnitSystem } = useUnitPreference();
   const isDisplayRoute = typeof window !== 'undefined' && window.location.pathname.replace(/\/$/, '') === '/display';
@@ -149,6 +153,20 @@ function AppContent() {
   const handleTrainingImplementChange = (implement: string) => {
     setSelectedTrainingImplement(implement);
     socketService.setTrainingImplement(implement);
+  };
+
+  const handleShutdown = async () => {
+    setShutdownState('pending');
+    try {
+      await shutdown();
+    } catch {
+      setShutdownState('error');
+    }
+  };
+
+  const closeShutdown = () => {
+    setShowShutdown(false);
+    setShutdownState('confirm');
   };
 
   if (isDisplayRoute) {
@@ -229,7 +247,14 @@ function AppContent() {
           />
           <SimStatus statuses={simStatuses} />
           <ConnectionStatus connected={connected} />
-          <button className="power-button" onClick={() => setShowShutdown(true)} title="Shut down">
+          <button
+            className="power-button"
+            onClick={() => {
+              setShutdownState('confirm');
+              setShowShutdown(true);
+            }}
+            title="Shut down"
+          >
             <svg
               viewBox="0 0 24 24"
               fill="none"
@@ -247,27 +272,9 @@ function AppContent() {
         </div>
       </header>
 
-      {showShutdown && (
-        <div className="shutdown-overlay">
-          <div className="shutdown-dialog">
-            <p>Shut down OpenFlight?</p>
-            <div className="shutdown-dialog__buttons">
-              <button
-                className="shutdown-dialog__confirm"
-                onClick={() => {
-                  shutdown();
-                  setShowShutdown(false);
-                }}
-              >
-                Shut Down
-              </button>
-              <button className="shutdown-dialog__cancel" onClick={() => setShowShutdown(false)}>
-                Cancel
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      {showShutdown ? (
+        <ShutdownDialog state={shutdownState} onConfirm={handleShutdown} onCancel={closeShutdown} />
+      ) : null}
 
       <nav className="nav">
         <button
@@ -314,14 +321,16 @@ function AppContent() {
         {currentView === 'live' && (
           <div className="live-view">
             {isNewShot && <div key={shotVersion} className="shot-flash" />}
-            <ShotDisplay
-              key={shotVersion}
-              shot={latestShot}
-              shots={shots}
-              animate={isNewShot}
-              activePlayerName={selectedPlayer}
-              activeTrainingImplement={isSwingSpeedMode ? selectedTrainingImplement : undefined}
-            />
+            <ShotProcessingArea phase={shotProcessingPhase}>
+              <ShotDisplay
+                key={shotVersion}
+                shot={latestShot}
+                shots={shots}
+                animate={isNewShot}
+                activePlayerName={selectedPlayer}
+                activeTrainingImplement={isSwingSpeedMode ? selectedTrainingImplement : undefined}
+              />
+            </ShotProcessingArea>
             {debugMode && <SimShotBadges latestSimShots={latestSimShots} />}
             {mockMode && (
               <button className="simulate-button" onClick={() => socketService.simulateShot()}>

--- a/ui/src/components/ProgressIndicator.css
+++ b/ui/src/components/ProgressIndicator.css
@@ -1,0 +1,77 @@
+.progress-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  color: var(--text-primary);
+}
+
+.progress-indicator--inline {
+  flex: 0 0 auto;
+  min-height: 34px;
+  padding: 0.35rem var(--space-md);
+  border: 1px solid rgba(212, 175, 55, 0.28);
+  border-radius: var(--radius-md);
+  background: rgba(212, 175, 55, 0.08);
+}
+
+.progress-indicator--dialog {
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.progress-indicator__spinner {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  border: 2px solid rgba(212, 175, 55, 0.24);
+  border-top-color: var(--color-gold-bright);
+  border-radius: 50%;
+  animation: progress-indicator-spin 0.8s linear infinite;
+}
+
+.progress-indicator--dialog .progress-indicator__spinner {
+  width: 38px;
+  height: 38px;
+  border-width: 3px;
+}
+
+.progress-indicator__copy {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+}
+
+.progress-indicator--dialog .progress-indicator__copy {
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.progress-indicator__title {
+  color: var(--color-gold-bright);
+  font-size: 0.875rem;
+  letter-spacing: 0.02em;
+}
+
+.progress-indicator--dialog .progress-indicator__title {
+  font-size: 1.125rem;
+}
+
+.progress-indicator__detail {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+@keyframes progress-indicator-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-indicator__spinner {
+    animation: none;
+    border-color: var(--color-gold-bright);
+  }
+}

--- a/ui/src/components/ProgressIndicator.test.tsx
+++ b/ui/src/components/ProgressIndicator.test.tsx
@@ -1,0 +1,29 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { ProgressIndicator } from './ProgressIndicator';
+
+describe('ProgressIndicator', () => {
+  it('renders shot processing as an inline status that does not cover metrics', () => {
+    const html = renderToString(
+      <ProgressIndicator
+        variant="inline"
+        title="Shot captured"
+        detail="Calculating metrics…"
+      />
+    );
+
+    expect(html).toContain('progress-indicator--inline');
+    expect(html).toContain('Shot captured');
+    expect(html).toContain('Calculating metrics…');
+    expect(html).not.toContain('shutdown-overlay');
+  });
+
+  it('renders an accessible live status', () => {
+    const html = renderToString(
+      <ProgressIndicator variant="dialog" title="Shutting down OpenFlight…" />
+    );
+
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-live="polite"');
+  });
+});

--- a/ui/src/components/ProgressIndicator.test.tsx
+++ b/ui/src/components/ProgressIndicator.test.tsx
@@ -5,11 +5,7 @@ import { ProgressIndicator } from './ProgressIndicator';
 describe('ProgressIndicator', () => {
   it('renders shot processing as an inline status that does not cover metrics', () => {
     const html = renderToString(
-      <ProgressIndicator
-        variant="inline"
-        title="Shot captured"
-        detail="Calculating metrics…"
-      />
+      <ProgressIndicator variant="inline" title="Shot captured" detail="Calculating metrics…" />
     );
 
     expect(html).toContain('progress-indicator--inline');
@@ -19,9 +15,7 @@ describe('ProgressIndicator', () => {
   });
 
   it('renders an accessible live status', () => {
-    const html = renderToString(
-      <ProgressIndicator variant="dialog" title="Shutting down OpenFlight…" />
-    );
+    const html = renderToString(<ProgressIndicator variant="dialog" title="Shutting down OpenFlight…" />);
 
     expect(html).toContain('role="status"');
     expect(html).toContain('aria-live="polite"');

--- a/ui/src/components/ProgressIndicator.tsx
+++ b/ui/src/components/ProgressIndicator.tsx
@@ -1,0 +1,23 @@
+import './ProgressIndicator.css';
+
+interface ProgressIndicatorProps {
+  variant: 'inline' | 'dialog';
+  title: string;
+  detail?: string;
+}
+
+export function ProgressIndicator({ variant, title, detail }: ProgressIndicatorProps) {
+  return (
+    <div
+      className={`progress-indicator progress-indicator--${variant}`}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="progress-indicator__spinner" aria-hidden="true" />
+      <span className="progress-indicator__copy">
+        <strong className="progress-indicator__title">{title}</strong>
+        {detail ? <span className="progress-indicator__detail">{detail}</span> : null}
+      </span>
+    </div>
+  );
+}

--- a/ui/src/components/ProgressIndicator.tsx
+++ b/ui/src/components/ProgressIndicator.tsx
@@ -8,11 +8,7 @@ interface ProgressIndicatorProps {
 
 export function ProgressIndicator({ variant, title, detail }: ProgressIndicatorProps) {
   return (
-    <div
-      className={`progress-indicator progress-indicator--${variant}`}
-      role="status"
-      aria-live="polite"
-    >
+    <div className={`progress-indicator progress-indicator--${variant}`} role="status" aria-live="polite">
       <span className="progress-indicator__spinner" aria-hidden="true" />
       <span className="progress-indicator__copy">
         <strong className="progress-indicator__title">{title}</strong>

--- a/ui/src/components/ShotProcessingArea.test.tsx
+++ b/ui/src/components/ShotProcessingArea.test.tsx
@@ -1,0 +1,30 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { ShotProcessingArea } from './ShotProcessingArea';
+
+describe('ShotProcessingArea', () => {
+  it('keeps current metrics rendered while calculation status is visible', () => {
+    const html = renderToString(
+      <ShotProcessingArea phase="calculating">
+        <div className="current-shot-metrics">145.2 mph · 258 yds</div>
+      </ShotProcessingArea>
+    );
+
+    expect(html).toContain('Shot captured');
+    expect(html).toContain('Calculating metrics…');
+    expect(html).toContain('current-shot-metrics');
+    expect(html).toContain('145.2 mph · 258 yds');
+  });
+
+  it('reports capture activity before metric calculation starts', () => {
+    const html = renderToString(
+      <ShotProcessingArea phase="capturing">
+        <div>Previous metrics</div>
+      </ShotProcessingArea>
+    );
+
+    expect(html).toContain('Impact detected');
+    expect(html).toContain('Capturing radar data…');
+    expect(html).toContain('Previous metrics');
+  });
+});

--- a/ui/src/components/ShotProcessingArea.tsx
+++ b/ui/src/components/ShotProcessingArea.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+import type { ShotProcessingPhase } from '../stores/useShotStore';
+import { ProgressIndicator } from './ProgressIndicator';
+
+interface ShotProcessingAreaProps {
+  phase: ShotProcessingPhase | null;
+  children: ReactNode;
+}
+
+export function ShotProcessingArea({ phase, children }: ShotProcessingAreaProps) {
+  return (
+    <>
+      {phase ? (
+        <ProgressIndicator
+          variant="inline"
+          title={phase === 'capturing' ? 'Impact detected' : 'Shot captured'}
+          detail={phase === 'capturing' ? 'Capturing radar data…' : 'Calculating metrics…'}
+        />
+      ) : null}
+      {children}
+    </>
+  );
+}

--- a/ui/src/components/ShutdownDialog.test.tsx
+++ b/ui/src/components/ShutdownDialog.test.tsx
@@ -1,0 +1,32 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { ShutdownDialog } from './ShutdownDialog';
+
+const noop = () => {};
+
+describe('ShutdownDialog', () => {
+  it('replaces the confirmation controls with persistent shutdown feedback', () => {
+    const html = renderToString(
+      <ShutdownDialog state="pending" onConfirm={noop} onCancel={noop} />
+    );
+
+    expect(html).toContain('Shutting down OpenFlight…');
+    expect(html).toContain('Safely stopping radar services');
+    expect(html).toContain('role="dialog"');
+    expect(html).toContain('aria-modal="true"');
+    expect(html).toContain('aria-label="Shutting down OpenFlight"');
+    expect(html).not.toContain('>Shut Down</button>');
+    expect(html).not.toContain('>Cancel</button>');
+  });
+
+  it('keeps retry and cancel controls available after a request failure', () => {
+    const html = renderToString(
+      <ShutdownDialog state="error" onConfirm={noop} onCancel={noop} />
+    );
+
+    expect(html).toContain('Could not start shutdown');
+    expect(html).toContain('aria-labelledby="shutdown-dialog-title"');
+    expect(html).toContain('>Try Again</button>');
+    expect(html).toContain('>Cancel</button>');
+  });
+});

--- a/ui/src/components/ShutdownDialog.test.tsx
+++ b/ui/src/components/ShutdownDialog.test.tsx
@@ -6,9 +6,7 @@ const noop = () => {};
 
 describe('ShutdownDialog', () => {
   it('replaces the confirmation controls with persistent shutdown feedback', () => {
-    const html = renderToString(
-      <ShutdownDialog state="pending" onConfirm={noop} onCancel={noop} />
-    );
+    const html = renderToString(<ShutdownDialog state="pending" onConfirm={noop} onCancel={noop} />);
 
     expect(html).toContain('Shutting down OpenFlight…');
     expect(html).toContain('Safely stopping radar services');
@@ -20,9 +18,7 @@ describe('ShutdownDialog', () => {
   });
 
   it('keeps retry and cancel controls available after a request failure', () => {
-    const html = renderToString(
-      <ShutdownDialog state="error" onConfirm={noop} onCancel={noop} />
-    );
+    const html = renderToString(<ShutdownDialog state="error" onConfirm={noop} onCancel={noop} />);
 
     expect(html).toContain('Could not start shutdown');
     expect(html).toContain('aria-labelledby="shutdown-dialog-title"');

--- a/ui/src/components/ShutdownDialog.tsx
+++ b/ui/src/components/ShutdownDialog.tsx
@@ -1,0 +1,53 @@
+import { ProgressIndicator } from './ProgressIndicator';
+
+export type ShutdownState = 'confirm' | 'pending' | 'error';
+
+interface ShutdownDialogProps {
+  state: ShutdownState;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ShutdownDialog({ state, onConfirm, onCancel }: ShutdownDialogProps) {
+  if (state === 'pending') {
+    return (
+      <div className="shutdown-overlay">
+        <div
+          className="shutdown-dialog shutdown-dialog--pending"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Shutting down OpenFlight"
+        >
+          <ProgressIndicator
+            variant="dialog"
+            title="Shutting down OpenFlight…"
+            detail="Safely stopping radar services"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const hasError = state === 'error';
+  return (
+    <div className="shutdown-overlay">
+      <div
+        className="shutdown-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="shutdown-dialog-title"
+      >
+        <p id="shutdown-dialog-title">{hasError ? 'Could not start shutdown' : 'Shut down OpenFlight?'}</p>
+        {hasError ? <span className="shutdown-dialog__error">Check the server and try again.</span> : null}
+        <div className="shutdown-dialog__buttons">
+          <button className="shutdown-dialog__confirm" onClick={onConfirm} autoFocus>
+            {hasError ? 'Try Again' : 'Shut Down'}
+          </button>
+          <button className="shutdown-dialog__cancel" onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/ShutdownDialog.tsx
+++ b/ui/src/components/ShutdownDialog.tsx
@@ -31,12 +31,7 @@ export function ShutdownDialog({ state, onConfirm, onCancel }: ShutdownDialogPro
   const hasError = state === 'error';
   return (
     <div className="shutdown-overlay">
-      <div
-        className="shutdown-dialog"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="shutdown-dialog-title"
-      >
+      <div className="shutdown-dialog" role="dialog" aria-modal="true" aria-labelledby="shutdown-dialog-title">
         <p id="shutdown-dialog-title">{hasError ? 'Could not start shutdown' : 'Shut down OpenFlight?'}</p>
         {hasError ? <span className="shutdown-dialog__error">Check the server and try again.</span> : null}
         <div className="shutdown-dialog__buttons">

--- a/ui/src/hooks/useSocket.ts
+++ b/ui/src/hooks/useSocket.ts
@@ -6,8 +6,11 @@ export function useSocket() {
     socketService.connect();
   }, []);
 
-  const shutdown = useCallback(() => {
-    fetch('/api/shutdown', { method: 'POST' }).catch(() => {});
+  const shutdown = useCallback(async () => {
+    const response = await fetch('/api/shutdown', { method: 'POST' });
+    if (!response.ok) {
+      throw new Error(`Shutdown request failed (${response.status})`);
+    }
   }, []);
 
   return { shutdown };

--- a/ui/src/services/socketService.ts
+++ b/ui/src/services/socketService.ts
@@ -51,6 +51,16 @@ class SocketService {
     this.socket.on('disconnect', () => {
       console.log('Disconnected from server');
       useSystemStore.getState().setConnected(false);
+      useShotStore.getState().finishShotProcessing();
+    });
+
+    this.socket.on('shot_processing', (data: { state: 'capturing' | 'calculating' | 'failed' }) => {
+      const shotStore = useShotStore.getState();
+      if (data.state === 'failed') {
+        shotStore.finishShotProcessing();
+      } else {
+        shotStore.startShotProcessing(data.state);
+      }
     });
 
     this.socket.on('shot', (data: { shot: Shot; stats: SessionStats }) => {

--- a/ui/src/stores/useShotStore.test.ts
+++ b/ui/src/stores/useShotStore.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Shot } from '../types/shot';
+import { useShotStore } from './useShotStore';
+
+const shot = {
+  ball_speed_mph: 145,
+  timestamp: '2026-08-12T12:00:00Z',
+} as Shot;
+
+describe('useShotStore processing lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useShotStore.setState({
+      latestShot: null,
+      shots: [],
+      isNewShot: false,
+      shotProcessingPhase: null,
+      shotVersion: 0,
+    });
+  });
+
+  it('keeps current shot data while marking the next shot as processing', () => {
+    useShotStore.setState({ latestShot: shot, shots: [shot] });
+
+    useShotStore.getState().startShotProcessing('capturing');
+
+    expect(useShotStore.getState().shotProcessingPhase).toBe('capturing');
+    expect(useShotStore.getState().latestShot).toBe(shot);
+    expect(useShotStore.getState().shots).toEqual([shot]);
+  });
+
+  it('clears processing when the completed shot arrives', () => {
+    useShotStore.getState().startShotProcessing('capturing');
+    useShotStore.getState().startShotProcessing('calculating');
+
+    useShotStore.getState().addShot(shot);
+
+    expect(useShotStore.getState().shotProcessingPhase).toBeNull();
+  });
+
+  it('clears a stale processing state after the watchdog timeout', () => {
+    useShotStore.getState().startShotProcessing('capturing');
+
+    vi.advanceTimersByTime(30_000);
+
+    expect(useShotStore.getState().shotProcessingPhase).toBeNull();
+  });
+});

--- a/ui/src/stores/useShotStore.test.ts
+++ b/ui/src/stores/useShotStore.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Shot } from '../types/shot';
 import { useShotStore } from './useShotStore';
 
@@ -17,6 +17,11 @@ describe('useShotStore processing lifecycle', () => {
       shotProcessingPhase: null,
       shotVersion: 0,
     });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('keeps current shot data while marking the next shot as processing', () => {

--- a/ui/src/stores/useShotStore.ts
+++ b/ui/src/stores/useShotStore.ts
@@ -3,12 +3,17 @@ import type { Shot } from '../types/shot';
 
 /** Duration to keep isNewShot true — covers the longest animation (shot-glow: 2s) */
 const NEW_SHOT_DURATION_MS = 2500;
+const SHOT_PROCESSING_TIMEOUT_MS = 30_000;
+export type ShotProcessingPhase = 'capturing' | 'calculating';
 
 interface ShotState {
   latestShot: Shot | null;
   shots: Shot[];
   isNewShot: boolean;
+  shotProcessingPhase: ShotProcessingPhase | null;
   shotVersion: number;
+  startShotProcessing: (phase: ShotProcessingPhase) => void;
+  finishShotProcessing: () => void;
   addShot: (shot: Shot) => void;
   setShots: (shots: Shot[]) => void;
   clearShots: () => void;
@@ -16,13 +21,29 @@ interface ShotState {
 
 export const useShotStore = create<ShotState>((set) => {
   let timerRef: ReturnType<typeof setTimeout> | null = null;
+  let processingTimerRef: ReturnType<typeof setTimeout> | null = null;
+
+  const finishShotProcessing = () => {
+    if (processingTimerRef) clearTimeout(processingTimerRef);
+    processingTimerRef = null;
+    set({ shotProcessingPhase: null });
+  };
 
   return {
     latestShot: null,
     shots: [],
     isNewShot: false,
+    shotProcessingPhase: null,
     shotVersion: 0,
+    startShotProcessing: (shotProcessingPhase) => {
+      if (processingTimerRef) clearTimeout(processingTimerRef);
+      set({ shotProcessingPhase });
+      processingTimerRef = setTimeout(finishShotProcessing, SHOT_PROCESSING_TIMEOUT_MS);
+    },
+    finishShotProcessing,
     addShot: (shot) => {
+      if (processingTimerRef) clearTimeout(processingTimerRef);
+      processingTimerRef = null;
       set((state) => {
         const updated = [...state.shots, shot];
         const newShots = updated.length > 200 ? updated.slice(-200) : updated;
@@ -30,6 +51,7 @@ export const useShotStore = create<ShotState>((set) => {
           latestShot: shot,
           shots: newShots,
           isNewShot: true,
+          shotProcessingPhase: null,
           shotVersion: state.shotVersion + 1,
         };
       });
@@ -40,6 +62,7 @@ export const useShotStore = create<ShotState>((set) => {
       }, NEW_SHOT_DURATION_MS);
     },
     setShots: (newShots) => {
+      finishShotProcessing();
       set({
         shots: newShots,
         latestShot: newShots.length > 0 ? newShots[newShots.length - 1] : null,
@@ -47,10 +70,13 @@ export const useShotStore = create<ShotState>((set) => {
     },
     clearShots: () => {
       if (timerRef) clearTimeout(timerRef);
+      if (processingTimerRef) clearTimeout(processingTimerRef);
+      processingTimerRef = null;
       set({
         latestShot: null,
         shots: [],
         isNewShot: false,
+        shotProcessingPhase: null,
       });
     },
   };


### PR DESCRIPTION
## What does this PR do?

- Shows two-stage shot status (`Impact detected` then `Calculating metrics`) in normal page flow while keeping the current shot metrics visible.
- Adds persistent, accessible shutdown progress and retry feedback.
- Wakes idle sound-trigger waits promptly during shutdown while allowing active radar dumps to finish safely, and logs shutdown-step timing.

## Why was this required?

Shot processing takes roughly three seconds and full shutdown can take roughly ten seconds. Previously neither path acknowledged the user action, making a captured shot look missed and making shutdown look stalled. The shutdown path also waited on an idle capture thread longer than necessary.

## Automated tests

- Added UI tests for processing-state lifecycle, retained metric rendering, shutdown states, accessibility, and reduced motion.
- Added backend regression tests for first-byte notification, cancellation races, rejected captures, idle timeout behavior, active-capture shutdown, and duplicate shutdown ownership.
- `npm test`: 29 passed.
- Affected backend suite: 326 passed, 1 skipped.
- Full runnable backend suite: 1,240 passed, 6 skipped; two recorded-capture tests are unavailable locally because their `.l3dump` fixtures are absent.
- `npm run build`, `npm run lint`, `npm run test:e2e` (6 passed), Ruff, and Pylint (9.56/10) completed successfully.

## Manual (human) testing

Real Raspberry Pi and OPS243 radar testing has not been performed from this development environment. On-device validation is pending: confirm that the inline status appears immediately after impact without covering the previous metrics, and confirm that Close OpenFlight shows shutdown progress and powers down faster while idle.

## Checklist

- [x] **Single feature/fix** — long-running OpenFlight actions now provide timely status feedback
- [x] **Automated tests included** — new and updated tests cover this change
- [x] **Manual testing described** — pending on-device checks are documented above
- [ ] Python tests pass (`uv run pytest tests/ -v`) — two external `.l3dump` fixtures are absent locally; 1,240 runnable tests pass
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [x] UI builds (`cd ui && npm run build`)
- [x] UI lint passes (`cd ui && npm run lint`)
- [x] Updated docs or CHANGELOG if needed — not required for this UI behavior change
- [x] No unrelated changes mixed in