### PR TITLE
style: Scaling of live view past 7inch display size 

### DIFF
--- a/ui/src/components/ShotDisplay.css
+++ b/ui/src/components/ShotDisplay.css
@@ -378,7 +378,6 @@
 }
 
 @keyframes ball-breathe {
-
   0%,
   100% {
     transform: scale(1);
@@ -433,7 +432,6 @@
 }
 
 @keyframes shadow-breathe {
-
   0%,
   100% {
     transform: translateX(-50%) scale(1);

--- a/ui/src/components/ShotDisplay.css
+++ b/ui/src/components/ShotDisplay.css
@@ -35,11 +35,13 @@
       0 0 0 0 rgba(212, 175, 55, 0.6),
       inset 0 0 30px rgba(212, 175, 55, 0.2);
   }
+
   70% {
     box-shadow:
       0 0 0 15px rgba(212, 175, 55, 0),
       inset 0 0 0 rgba(212, 175, 55, 0);
   }
+
   100% {
     box-shadow:
       0 0 0 0 rgba(212, 175, 55, 0),
@@ -65,6 +67,7 @@
 .shot-display__metrics {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-auto-rows: minmax(0, 1fr);
   gap: var(--space-sm);
   flex: 1.2;
 }
@@ -128,7 +131,7 @@
 /* Default: value fully visible, no animation */
 .speed-gauge__value {
   font-family: var(--font-display);
-  font-size: 5rem;
+  font-size: clamp(3.5rem, min(15vw, 10vh), 12rem);
   font-weight: 400;
   color: var(--color-gold);
   line-height: 1;
@@ -145,6 +148,7 @@
     opacity: 0;
     transform: scale(0.8);
   }
+
   100% {
     opacity: 1;
     transform: scale(1);
@@ -213,7 +217,7 @@
 /* Default: metric value fully visible, no animation */
 .metric-card__value {
   font-family: var(--font-display);
-  font-size: 5rem;
+  font-size: clamp(1.75rem, min(10vw, 7.5vh), 15rem);
   font-weight: 400;
   line-height: 1;
   color: var(--color-cream);
@@ -234,25 +238,33 @@
 }
 
 .metric-card__unit {
-  font-size: 1.75rem;
+  font-size: clamp(0.8rem, min(3vw, 2.5vh), 5rem);
   font-weight: 500;
   color: var(--text-secondary);
 }
 
 .metric-card__label {
-  font-size: 1rem;
+  font-size: clamp(0.56rem, min(1.5vw, 1.5vh), 3rem);
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.12em;
   margin-top: 6px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 
 .metric-card__subtext {
-  font-size: 0.5625rem;
+  font-size: clamp(0.5rem, min(1vw, 1vh), 2rem);
   color: var(--text-muted);
   margin-top: 2px;
   opacity: 0.7;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 
 /* Spin Confidence Indicator */
@@ -261,6 +273,8 @@
   align-items: center;
   gap: 6px;
   margin-top: 4px;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .metric-card__confidence-dots {
@@ -287,6 +301,9 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .metric-card__confidence--high .metric-card__confidence-label {
@@ -361,6 +378,7 @@
 }
 
 @keyframes ball-breathe {
+
   0%,
   100% {
     transform: scale(1);
@@ -369,6 +387,7 @@
       0 4px 20px rgba(0, 0, 0, 0.3),
       0 0 0 0 rgba(212, 175, 55, 0);
   }
+
   50% {
     transform: scale(1.02);
     box-shadow:
@@ -414,19 +433,21 @@
 }
 
 @keyframes shadow-breathe {
+
   0%,
   100% {
     transform: translateX(-50%) scale(1);
     opacity: 0.6;
   }
+
   50% {
     transform: translateX(-50%) scale(1.1);
     opacity: 0.4;
   }
 }
 
-/* Landscape 7" screen (800x480) */
-@media (max-height: 500px) {
+/* Landscape 7" screen or short browser windows */
+@media (max-height: 700px) {
   .shot-display {
     padding: var(--space-xs) var(--space-sm);
   }
@@ -463,21 +484,11 @@
     min-height: 0;
   }
 
-  .metric-card__value {
-    font-size: 1.75rem;
-  }
-
-  .metric-card__unit {
-    font-size: 0.8rem;
-  }
-
   .metric-card__label {
-    font-size: 0.5625rem;
     margin-top: 2px;
   }
 
   .metric-card__subtext {
-    font-size: 0.5rem;
     margin-top: 1px;
   }
 


### PR DESCRIPTION


## What does this PR do?
- Improves the scaling performance and responsiveness of the Shot Data in the live view.
- Introduces dynamic font scaling and proper text truncation across all metric cards.

New scaled version as seen here: 
<img width="3012" height="1760" alt="image" src="https://github.com/user-attachments/assets/ad501654-251b-4f53-b8b2-72ea7bddd32f" />

## Why was this required?
As seen in the image below: 
<img width="3004" height="1532" alt="image" src="https://github.com/user-attachments/assets/864c0d1f-8dd0-48a1-99e1-c65346a890d1" />

- Previously the text sizes were fixed or relied on hardcoded media query overrides within `ShotData.css`. This caused layout issues on larger/certain window sizes.

## Automated tests
- no tests were added.
- `make test`, `make lint`, `npm run build`, `npm run lint` passed successfully. 
- 1,231 passed, 8 skipped.
- Code rating 9.70/10

## Manual (human) testing
- Macbook 14" screen size tested and confirmed. Scaling the browser in both the vertical and horizontal directions is confirmed operational.
- Real Raspberry Pi and 7 inch display has not been validated. 
- TV scaling has not been validated

<!--
Every PR must describe the manual testing a human performed. Be specific:
- What did you actually run? (mock mode, real hardware, which UI flows)
- What did you observe? Include numbers/screenshots where relevant.
- What edge cases did you exercise by hand?

"Tests pass" is not manual testing — describe what YOU verified by hand.
-->

## Checklist

- [x] **Single feature/fix** — this PR is scoped to one thing with a clear story above
- [ x] **Automated tests included** — new or updated tests cover this change
- [ x] **Manual testing described** — I documented what I verified by hand above
- [ ] Python tests pass (`uv run pytest tests/ -v`)
- [x ] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [ x] Ruff passes (`uv run ruff check src/openflight/`)
- [ x] UI builds (`cd ui && npm run build`)
- [ x] UI lint passes (`cd ui && npm run lint`)
- [ x] Updated docs or CHANGELOG if needed — not required for this UI behavior change
- [ x] No unrelated changes mixed in