### PR TITLE
fix(iwr6843): shut down capture cleanly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -88,6 +88,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--kld7-bypass-vertical-gate` renamed to `--kld7-vertical-raw`.
 
 ### Fixed
+- **Graceful IWR6843 shutdown.** Kiosk shutdown now asks the server to finish
+  hardware cleanup before escalating to process signals. An active TI dump is
+  allowed to complete, capture firmware is stopped and verified inactive, and
+  the serial port is then closed. This prevents an interrupted L3 transfer or
+  failed GPIO setup from leaving the radar unresponsive on the next startup.
 - **Raspberry Pi 5 & OS Compatibility:** Updated UART configuration documentation to support Debian Bookworm and Raspberry Pi 5 hardware using `dtparam=uart0=on` alongside legacy `enable_uart=1`.
 - **UART Diagnostic Commands:** Simplified UART verification instructions in `docs/iwr6843/README.md` and `docs/ops243-uart-migration.md` using `grep -E` to check for both legacy and modern device-tree parameters simultaneously across config paths.
 - Session logging: serialize all access to the session JSONL file with a

--- a/scripts/start-kiosk.sh
+++ b/scripts/start-kiosk.sh
@@ -408,13 +408,52 @@ if [ "$KLD7" = true ] && [ -z "$KLD7_MOUNT_TILT" ]; then
     exit 1
 fi
 
-cleanup() {
-    log "Shutting down..."
-    if [ -n "$SERVER_PID" ]; then
-        kill $SERVER_PID 2>/dev/null || true
+shutdown_server() {
+    if [ -z "$SERVER_PID" ] || ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        return 0
     fi
+
+    log "Requesting graceful hardware shutdown..."
+    if curl -fsS --max-time 2 -X POST "http://$HOST:$PORT/api/shutdown" >/dev/null 2>&1; then
+        # IWR dumps normally take 5-8 seconds. Allow the server to preserve an
+        # active dump, stop capture firmware, and close hardware in order.
+        for _ in {1..80}; do
+            if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+                wait "$SERVER_PID" 2>/dev/null || true
+                return 0
+            fi
+            sleep 0.25
+        done
+        warn "Server did not complete graceful shutdown within 20 seconds"
+    else
+        warn "Server shutdown API unavailable; falling back to process signal"
+    fi
+
+    if kill -0 "$SERVER_PID" 2>/dev/null; then
+        kill -TERM "$SERVER_PID" 2>/dev/null || true
+        for _ in {1..8}; do
+            if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+                wait "$SERVER_PID" 2>/dev/null || true
+                return 0
+            fi
+            sleep 0.25
+        done
+    fi
+
+    if kill -0 "$SERVER_PID" 2>/dev/null; then
+        warn "Forcing server exit; connected radar hardware may require reset"
+        kill -KILL "$SERVER_PID" 2>/dev/null || true
+    fi
+    wait "$SERVER_PID" 2>/dev/null || true
+}
+
+cleanup() {
+    # Prevent a second signal from re-entering cleanup while hardware drains.
+    trap - SIGINT SIGTERM
+    log "Shutting down..."
+    shutdown_server
     if [ -n "$BROWSER_PID" ]; then
-        kill $BROWSER_PID 2>/dev/null || true
+        kill "$BROWSER_PID" 2>/dev/null || true
     fi
     # Chromium forks child processes that survive kill — clean them all
     pkill -f "chromium.*--kiosk" 2>/dev/null || true

--- a/src/openflight/iwr6843/driver.py
+++ b/src/openflight/iwr6843/driver.py
@@ -192,6 +192,14 @@ class IWR6843Radar:
         """Firmware health line (frames/wraps/active/calib/rf_faults)."""
         return self.cmd("stats", 2.0)
 
+    def stop_sensor(self) -> None:
+        """Stop capture and verify the firmware returned to its idle CLI state."""
+        self._require_done("sensorStop", self.cmd("sensorStop", 3.0))
+        health = self.stats()
+        self._require_done("stats", health)
+        if "active=0" not in health:
+            raise RuntimeError(f"IWR6843 remained active after sensorStop: {health.strip()}")
+
     def close(self) -> None:
         """Release the serial port."""
         self.ser.close()

--- a/src/openflight/iwr6843/monitor.py
+++ b/src/openflight/iwr6843/monitor.py
@@ -18,7 +18,7 @@ from openflight.iwr6843.dump import HEADER, parse_header, payload_nbytes
 
 logger = logging.getLogger(__name__)
 
-_GRACEFUL_DUMP_SHUTDOWN_S = 8.0
+_GRACEFUL_DUMP_SHUTDOWN_S = 12.0
 
 
 def tx_order_from_config(config_path: str | Path) -> str:
@@ -108,8 +108,10 @@ class IWR6843CaptureMonitor:
             raise FileNotFoundError(f"IWR6843 config not found: {self.config_path}")
         if self.save_dumps:
             self.output_dir.mkdir(parents=True, exist_ok=True)
+        configured = False
         try:
             self.radar.send_config(str(self.config_path))
+            configured = True
 
             button_factory = self._button_factory
             if button_factory is None:
@@ -137,7 +139,10 @@ class IWR6843CaptureMonitor:
             if self._button is not None:
                 self._button.close()
                 self._button = None
-            self.radar.close()
+            if configured:
+                self._stop_sensor_and_close()
+            else:
+                self.radar.close()
             raise
         logger.info(
             "[IWR6843] Configured on BCM%d using %s (%s%s)",
@@ -298,7 +303,7 @@ class IWR6843CaptureMonitor:
                 self._condition.wait(remaining)
 
     def stop(self) -> None:
-        """Release GPIO, serial transport, and worker resources."""
+        """Drain active capture, stop firmware, then release host resources."""
         if not self._running:
             return
         self._armed = False
@@ -312,21 +317,36 @@ class IWR6843CaptureMonitor:
         except queue.Full:
             pass
         if self._worker is not None:
-            # Keep UART open long enough for a normal 550 KiB dump to finish.
-            # Closing it first strands the firmware in an abandoned transfer.
+            # Preserve a complete debug dump and its trailing CLI prompt before
+            # issuing sensorStop. Closing early strands firmware mid-transfer.
             self._worker.join(timeout=_GRACEFUL_DUMP_SHUTDOWN_S)
             if self._worker.is_alive():
                 logger.warning(
-                    "[IWR6843] Active dump did not finish during shutdown; forcing serial close"
+                    "[IWR6843] Active dump did not finish within %.1fs; "
+                    "forcing serial close (board reset may be required)",
+                    _GRACEFUL_DUMP_SHUTDOWN_S,
                 )
                 self.radar.close()
                 self._worker.join(timeout=2.0)
             else:
-                self.radar.close()
+                self._stop_sensor_and_close()
             self._worker = None
         else:
-            self.radar.close()
+            self._stop_sensor_and_close()
         logger.info("[IWR6843] Capture monitor stopped")
+
+    def _stop_sensor_and_close(self) -> None:
+        """Best-effort firmware stop that never leaks the serial descriptor."""
+        try:
+            self.radar.stop_sensor()
+            logger.info("[IWR6843] Firmware capture stopped and verified inactive")
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "[IWR6843] Firmware did not stop cleanly; board reset may be required",
+                exc_info=True,
+            )
+        finally:
+            self.radar.close()
 
 
 __all__ = [

--- a/tests/test_iwr6843_driver.py
+++ b/tests/test_iwr6843_driver.py
@@ -21,6 +21,32 @@ def test_send_config_rejects_missing_cli_acknowledgement(tmp_path, monkeypatch):
         radar.send_config(str(config))
 
 
+def test_stop_sensor_requires_acknowledgement_and_inactive_health(monkeypatch):
+    """Shutdown must leave firmware idle rather than merely close the host UART."""
+    radar = IWR6843Radar.__new__(IWR6843Radar)
+    responses = iter(["sensorStop\nDone\nl3dump:/>", "stats\nactive=0\nDone\nl3dump:/>"])
+    calls = []
+
+    def fake_cmd(command, window):
+        calls.append((command, window))
+        return next(responses)
+
+    monkeypatch.setattr(radar, "cmd", fake_cmd)
+
+    radar.stop_sensor()
+
+    assert calls == [("sensorStop", 3.0), ("stats", 2.0)]
+
+
+def test_stop_sensor_rejects_firmware_that_remains_active(monkeypatch):
+    radar = IWR6843Radar.__new__(IWR6843Radar)
+    responses = iter(["sensorStop\nDone\n", "stats\nactive=1\nDone\n"])
+    monkeypatch.setattr(radar, "cmd", lambda *_args: next(responses))
+
+    with pytest.raises(RuntimeError, match="remained active"):
+        radar.stop_sensor()
+
+
 class FakeSerial:
     """Serial double that exposes the in_waiting/read/write pieces read_dump uses."""
 

--- a/tests/test_iwr6843_monitor.py
+++ b/tests/test_iwr6843_monitor.py
@@ -22,6 +22,7 @@ class FakeRadar:
         self.configs = []
         self.closed = False
         self.read_started_at = None
+        self.shutdown_events = []
 
     def send_config(self, path: str):
         self.configs.append(path)
@@ -33,7 +34,11 @@ class FakeRadar:
         return self.raw
 
     def close(self):
+        self.shutdown_events.append("close")
         self.closed = True
+
+    def stop_sensor(self):
+        self.shutdown_events.append("sensorStop")
 
 
 class FakeButton:
@@ -213,6 +218,32 @@ def test_capture_monitor_finishes_active_dump_before_closing_serial(tmp_path):
     assert not stopper.is_alive()
     assert not radar.closed_before_read_finished
     assert radar.closed
+    assert radar.shutdown_events == ["sensorStop", "close"]
+
+
+def test_capture_monitor_closes_serial_when_sensor_stop_fails(tmp_path):
+    """A failed firmware stop must not leak the host serial descriptor."""
+    config = tmp_path / "radar.cfg"
+    config.write_text("sensorStart\n", encoding="utf-8")
+
+    class StopFailingRadar(FakeRadar):
+        def stop_sensor(self):
+            self.shutdown_events.append("sensorStop")
+            raise RuntimeError("firmware remained active")
+
+    radar = StopFailingRadar(_raw_dump())
+    monitor = IWR6843CaptureMonitor(
+        config_path=config,
+        output_dir=tmp_path / "dumps",
+        radar=radar,
+        button_factory=FakeButton,
+    )
+    monitor.start()
+
+    monitor.stop()
+
+    assert radar.shutdown_events == ["sensorStop", "close"]
+    assert radar.closed
 
 
 def test_capture_monitor_discards_stale_false_trigger(tmp_path):
@@ -294,4 +325,5 @@ def test_capture_monitor_closes_serial_when_gpio_setup_fails(tmp_path):
         assert str(error) == "GPIO unavailable"
     else:
         raise AssertionError("expected GPIO setup to fail")
+    assert radar.shutdown_events == ["sensorStop", "close"]
     assert radar.closed

--- a/tests/test_start_kiosk.py
+++ b/tests/test_start_kiosk.py
@@ -240,6 +240,19 @@ def test_startup_applies_kld7_latency_setup_before_server_start():
     assert setup_idx < server_start_idx
 
 
+def test_shutdown_requests_server_cleanup_before_forcing_process_exit():
+    """The wrapper must let the server drain IWR data and stop firmware first."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script = (repo_root / "scripts/start-kiosk.sh").read_text(encoding="utf-8")
+    cleanup = script[script.index("shutdown_server() {") : script.index("configure_kld7_latency()")]
+
+    api_idx = cleanup.index("/api/shutdown")
+    wait_idx = cleanup.index('kill -0 "$SERVER_PID"', api_idx)
+    term_idx = cleanup.index('kill -TERM "$SERVER_PID"')
+
+    assert api_idx < wait_idx < term_idx
+
+
 def test_radc_tuning_values_are_ignored_without_experimental_gate():
     """Loose tuning flags should not alter production extraction by accident."""
     result = _dry_run(


### PR DESCRIPTION
## What does this PR do?

This PR makes IWR6843 shutdown an ordered hardware lifecycle instead of an immediate process kill.

- `start-kiosk.sh` asks the server to run its shutdown API and waits up to 20 seconds before escalating to `SIGTERM` and, only as a final fallback, `SIGKILL`.
- The IWR capture monitor disarms GPIO, allows an in-flight L3 dump up to 12 seconds to finish, sends `sensorStop`, verifies firmware reports `active=0`, and only then closes the UART.
- If GPIO setup fails after radar configuration, the same firmware-stop sequence runs before the initialization error is returned.
- Forced shutdown remains bounded and warns when a physical board reset may be required.

No camera or OPS shutdown behavior is changed by this PR.

## Why was this required?

The kiosk wrapper previously sent a process signal immediately. Closing the TI UART while a multi-second L3 transfer was active could abandon the binary stream and leave the firmware unresponsive on the next OpenFlight startup, forcing the operator to reach the IWR6843LEVM reset button or power-cycle the board. This is especially disruptive once the radar is mounted inside an enclosure.

The monitor already attempted to keep the port open briefly, but it did not stop capture firmware or verify that the board returned to an idle CLI state before closing the serial descriptor. The new sequence preserves the active capture and leaves both sides of the transport in a known state.

## Automated tests

Added regression coverage for:

- requiring `sensorStop` acknowledgement and verified `active=0` health;
- rejecting firmware that remains active after `sensorStop`;
- waiting for an active dump before stopping firmware and closing UART;
- closing the host descriptor even when firmware shutdown fails;
- stopping firmware when GPIO initialization fails after configuration; and
- requesting server cleanup from the kiosk wrapper before forced process signals.

Validation performed:

- `uv run pytest tests/test_iwr6843_driver.py tests/test_iwr6843_monitor.py tests/test_iwr6843_pipeline.py tests/test_iwr6843_firmware_rearm.py tests/test_server.py tests/test_start_kiosk.py -q` -> **223 passed, 1 skipped**
- Pi combined camera-branch smoke suite for the driver, monitor, and kiosk contracts -> **49 passed**
- `uv run ruff check` and `uv run ruff format --check` on all changed Python/test files -> passed
- `bash -n scripts/start-kiosk.sh` -> passed
- Pylint on the changed IWR modules -> **9.97/10**

Repository-wide Ruff/Pylint currently report unrelated pre-existing findings in camera, cloud, simulator, and legacy radar files; none are introduced or modified by this branch.

## Manual (human) testing

Tested on a Raspberry Pi 5 with the IWR6843LEVM while a real firmware-frozen L3 dump was active:

1. Started OpenFlight with the IWR6843 dense capture configuration.
2. Triggered a capture and requested shutdown while the TI transfer was still in flight.
3. Observed the complete **549,764-byte** dump finish in **5.36 seconds**.
4. Observed `Firmware capture stopped and verified inactive` before `Capture monitor stopped`.
5. Confirmed the kiosk wrapper waited for the REST shutdown path instead of immediately killing the server.

The same changes were cherry-picked onto the Pi's camera-development branch for integration testing; camera code is not included here.

## Checklist

- [x] **Single feature/fix** - scoped to graceful IWR6843 lifecycle handling
- [x] **Automated tests included** - regression tests cover normal and failure shutdown paths
- [x] **Manual testing described** - verified with real IWR6843 hardware and an active dump
- [x] Focused Python shutdown suites pass
- [x] Pylint score exceeds 9.0 on changed IWR modules
- [x] Ruff passes on changed Python/test files
- [x] UI build not applicable - no UI files changed
- [x] UI lint not applicable - no UI files changed
- [x] Updated `docs/CHANGELOG.md` under `[Unreleased]`
- [x] No unrelated changes mixed in
