### PR TITLE
Feat/stat view default club

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -363,7 +363,9 @@ function AppContent() {
             )}
           </div>
         )}
-        {currentView === 'stats' && <StatsView shots={shots} onClearSession={() => socketService.clearSession()} />}
+        {currentView === 'stats' && (
+          <StatsView shots={shots} activeClub={selectedClub} onClearSession={() => socketService.clearSession()} />
+        )}
         {currentView === 'shots' && (
           <ShotList shots={shots} onDeleteShot={(timestamp) => socketService.deleteShot(timestamp)} />
         )}

--- a/ui/src/components/StatsView.tsx
+++ b/ui/src/components/StatsView.tsx
@@ -15,13 +15,13 @@ export function StatsView({ shots, activeClub, onClearSession }: StatsViewProps)
   const hasShotsForActiveClub = shots.some((s) => s.club === activeClub);
   const [selectedClub, setSelectedClub] = useState<string | null>(hasShotsForActiveClub ? activeClub : null);
   const [prevActiveClub, setPrevActiveClub] = useState(activeClub);
-  
+
   // React recommended pattern: update state during render when a prop changes, rather than in useEffect
   if (activeClub !== prevActiveClub) {
     setPrevActiveClub(activeClub);
     setSelectedClub(hasShotsForActiveClub ? activeClub : null);
   }
-  
+
   const { unitSystem } = useUnitPreference();
   const speedUnit = getSpeedUnit(unitSystem);
   const distanceUnit = getDistanceUnit(unitSystem);

--- a/ui/src/components/StatsView.tsx
+++ b/ui/src/components/StatsView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useUnitPreference } from '../state/useUnitPreference';
 import type { Shot } from '../types/shot';
 import { computeStats, computeSwingSpeedStats, getUniqueClubs, isSwingSpeedShot } from '../types/shot';
@@ -7,11 +7,23 @@ import './StatsView.css';
 
 interface StatsViewProps {
   shots: Shot[];
+  activeClub: string;
   onClearSession: () => void;
 }
 
-export function StatsView({ shots, onClearSession }: StatsViewProps) {
-  const [selectedClub, setSelectedClub] = useState<string | null>(null);
+export function StatsView({ shots, activeClub, onClearSession }: StatsViewProps) {
+  // Only default to the active club if we actually have shots recorded for it. Otherwise, default to 'All' (null).
+  const hasShotsForActiveClub = shots.some((s) => s.club === activeClub);
+  const [selectedClub, setSelectedClub] = useState<string | null>(hasShotsForActiveClub ? activeClub : null);
+  
+  // Watch for changes to the active club from the top bar and update our local tab selection
+  useEffect(() => {
+    const hasShots = shots.some((s) => s.club === activeClub);
+    setSelectedClub(hasShots ? activeClub : null);
+    // We intentionally exclude `shots` from dependencies so hitting a new shot doesn't reset the user's tab selection.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeClub]);
+  
   const { unitSystem } = useUnitPreference();
   const speedUnit = getSpeedUnit(unitSystem);
   const distanceUnit = getDistanceUnit(unitSystem);

--- a/ui/src/components/StatsView.tsx
+++ b/ui/src/components/StatsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useUnitPreference } from '../state/useUnitPreference';
 import type { Shot } from '../types/shot';
 import { computeStats, computeSwingSpeedStats, getUniqueClubs, isSwingSpeedShot } from '../types/shot';
@@ -12,17 +12,15 @@ interface StatsViewProps {
 }
 
 export function StatsView({ shots, activeClub, onClearSession }: StatsViewProps) {
-  // Only default to the active club if we actually have shots recorded for it. Otherwise, default to 'All' (null).
   const hasShotsForActiveClub = shots.some((s) => s.club === activeClub);
   const [selectedClub, setSelectedClub] = useState<string | null>(hasShotsForActiveClub ? activeClub : null);
+  const [prevActiveClub, setPrevActiveClub] = useState(activeClub);
   
-  // Watch for changes to the active club from the top bar and update our local tab selection
-  useEffect(() => {
-    const hasShots = shots.some((s) => s.club === activeClub);
-    setSelectedClub(hasShots ? activeClub : null);
-    // We intentionally exclude `shots` from dependencies so hitting a new shot doesn't reset the user's tab selection.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeClub]);
+  // React recommended pattern: update state during render when a prop changes, rather than in useEffect
+  if (activeClub !== prevActiveClub) {
+    setPrevActiveClub(activeClub);
+    setSelectedClub(hasShotsForActiveClub ? activeClub : null);
+  }
   
   const { unitSystem } = useUnitPreference();
   const speedUnit = getSpeedUnit(unitSystem);


### PR DESCRIPTION
## What does this PR do?

- Sets the default Stats view selection to the current active club.
- If the current `activeClub` has no shots recorded the page defaults to the `All`.
- If the user selects a new club and shots exist for this club then the Stats page `activeClub` updates to the newly selected club.

```mermaid
flowchart TD
    A[User changes active club in top bar] --> B[StatsView receives new activeClub prop]
    B --> C{Does activeClub match prevActiveClub?}
    
    C -- Yes --> D[Render normally]
    
    C -- No --> E{Do we have recorded shots for the new activeClub?}
    
    E -- Yes --> F[Set selected tab to activeClub]
    E -- No --> G[Set selected tab to 'All']
    
    F --> H[Update prevActiveClub state & Render]
    G --> H
```

## Why was this required?

- `All` selection uses the average carry distance. However, the average carry distance between a driver and a wedge is very different and will average out to a mid-iron. 
- It is more useful for the user to instantly see the average carry distance of the current club they have selected. \
- The user still has the ability to click the `All` tab. 

## Automated tests
- `make lint` ran successfully.
- `make test` 1321 passed, 8 skipped, 17 warnings.
- `npm run lint`, `npm run build` ran successfully.
- no new tests: UI change tested through manual testing.

## Manual (human) testing

- Ran manual testing in mock mode
- Verified that when shots go from 0 to greater than 0 on the selected club that stats view chooses the selected club.
- If the club is changed and no shots have been generated with the new selected club then stats view defaults to `All`.
- If a new club with no shots is selected and then a shot is generated, the stats view updates to the new club. `All` --> `activeClub`.
- If shots exists for both the `previousClub` and `activeClub`, the `activeClub` is displayed in `Stats` View
- If both the `previousClub` and `activeClub` are the same the stats view stays on the `previousClub`/`activeClub`.

## Checklist

- [x] **Single feature/fix** — this PR is scoped to one thing with a clear story above
- [x] **Automated tests included** — new or updated tests cover this change
- [x] **Manual testing described** — I documented what I verified by hand above
- [x] Python tests pass (`uv run pytest tests/ -v`) 
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [x] UI builds (`cd ui && npm run build`)
- [x] UI lint passes (`cd ui && npm run lint`)
- [x] Updated docs or CHANGELOG if needed (not required: UI change tested through manual testing)
- [x] No unrelated changes mixed in
