### PR TITLE
test(ballistics): assert carry accuracy against committed TrackMan capture

### DIFF
--- a/tests/test_ballistics_trackman_regression.py
+++ b/tests/test_ballistics_trackman_regression.py
@@ -1,0 +1,105 @@
+"""Regression guard: ballistic model accuracy against committed TrackMan data.
+
+The repo ships paired TrackMan reference captures in ``session_logs/`` and a
+manual validator (``scripts/analysis/validate_ballistics.py``), but nothing in
+the test suite reads them. That gap lets an accuracy regression ship green:
+``test_ballistics.py`` asserts driver carry only within 250-300 yd, a 50-yard
+window, so a 20-40 yard model bias passes unnoticed.
+
+This module closes it by replaying the committed capture through the production
+``resolve_launch``/``simulate`` path and asserting per-club error against a
+budget. The budget is seeded at the CURRENT measured error, not at zero, so it
+blocks *new* error immediately while leaving the existing bias to be paid down
+deliberately. Ratchet the numbers down when the model improves; never up.
+
+Reuses the validator's own loading/statistics helpers so the test and the
+manual tool can never disagree about what the reference data means.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_ANALYSIS = _REPO_ROOT / "scripts" / "analysis"
+if str(_ANALYSIS) not in sys.path:
+    sys.path.insert(0, str(_ANALYSIS))
+
+from validate_ballistics import (  # noqa: E402  (path set up above)
+    _stats,
+    load_trackman,
+    validate_tm_inputs,
+)
+
+TRACKMAN_CSV = _REPO_ROOT / "session_logs" / "OpenFlight-Test.Normalized.csv"
+
+# Per-club RMSE ceilings in yards, seeded from the measured baseline on
+# c9d0cc7 (2026-08-18) with a small tolerance for float/platform drift:
+#
+#   club              n   rmse    mae    bias
+#   7-iron            9   11.64  11.00  +11.00
+#   driver            8   38.60  37.18  -37.18
+#   pitching wedge    7   13.56  13.16  +11.02
+#   OVERALL          24   24.52  20.36   -5.05
+#
+# The driver number is large because Cl is mis-fit at low spin parameter
+# (CL_HALF_SP=0.15 sits above the driver's whole Sp range, so the lift curve
+# never leaves its low-lift regime). Fixing the aero constants should drop
+# driver RMSE substantially -- when it does, lower these ceilings.
+RMSE_BUDGET_YARDS = {
+    "driver": 40.0,
+    "7-iron": 13.0,
+    "pitching wedge": 15.0,
+}
+OVERALL_RMSE_BUDGET_YARDS = 26.0
+
+# The reference capture is a fixed, committed file: if the shot count changes,
+# the fixture changed and every budget above needs re-deriving.
+EXPECTED_SHOT_COUNT = 24
+
+
+@pytest.fixture(scope="module")
+def validation_rows():
+    if not TRACKMAN_CSV.exists():
+        pytest.skip(f"TrackMan reference capture not present: {TRACKMAN_CSV}")
+    rows = validate_tm_inputs(load_trackman(TRACKMAN_CSV))
+    if not rows:
+        pytest.skip("TrackMan reference capture produced no usable shots")
+    return rows
+
+
+def test_reference_capture_shot_count(validation_rows):
+    """Pin the fixture size so budget drift cannot hide behind a changed file."""
+    assert len(validation_rows) == EXPECTED_SHOT_COUNT, (
+        f"Reference capture has {len(validation_rows)} usable shots, expected "
+        f"{EXPECTED_SHOT_COUNT}. If the fixture changed intentionally, re-derive "
+        f"the RMSE budgets in this module from a fresh validator run."
+    )
+
+
+def test_overall_carry_rmse_within_budget(validation_rows):
+    """Model carry vs TrackMan carry, fed TrackMan's own launch conditions."""
+    stats = _stats([r.delta_yards for r in validation_rows])
+    assert stats["rmse"] <= OVERALL_RMSE_BUDGET_YARDS, (
+        f"Overall carry RMSE {stats['rmse']:.2f} yd exceeds budget "
+        f"{OVERALL_RMSE_BUDGET_YARDS} yd (bias {stats['mean']:+.2f}, "
+        f"max |delta| {stats['max_abs']:.2f}, n={stats['n']}). "
+        f"The ballistic model got less accurate against the reference capture."
+    )
+
+
+@pytest.mark.parametrize("club", sorted(RMSE_BUDGET_YARDS))
+def test_per_club_carry_rmse_within_budget(validation_rows, club):
+    """Per-club budgets: a club-specific regression cannot hide in the average."""
+    deltas = [r.delta_yards for r in validation_rows if r.club == club]
+    assert deltas, f"No reference shots for club {club!r}"
+    stats = _stats(deltas)
+    budget = RMSE_BUDGET_YARDS[club]
+    assert stats["rmse"] <= budget, (
+        f"{club}: carry RMSE {stats['rmse']:.2f} yd exceeds budget {budget} yd "
+        f"(bias {stats['mean']:+.2f}, max |delta| {stats['max_abs']:.2f}, "
+        f"n={stats['n']})."
+    )


### PR DESCRIPTION
## What does this PR do?

Adds a regression test that replays the committed TrackMan reference capture through the production `resolve_launch`/`simulate` path and asserts per-club carry RMSE against a budget.

One new file, `tests/test_ballistics_trackman_regression.py`. No source changes.

Addresses #218.

## Why was this required?

`session_logs/OpenFlight-Test.Normalized.csv` is committed and `scripts/analysis/validate_ballistics.py` can score against it, but nothing in `tests/` or CI reads either — so carry accuracy isn't measured on PRs.

The existing carry tests are broad by design: `test_ballistics.py:87` asserts `250 <= carry <= 300`. That catches gross breakage but not a systematic offset. Current measured error, with the model fed TrackMan's own launch conditions:

| club | n | bias | rmse | max&#124;d&#124; |
|---|---|---|---|---|
| 7-iron | 9 | +11.00 | 11.64 | 16.25 |
| driver | 8 | -37.18 | 38.60 | 52.29 |
| pitching wedge | 7 | +11.02 | 13.56 | 16.54 |
| **OVERALL** | 24 | -5.05 | 24.52 | 52.29 |

Budgets are seeded at these values rather than at zero, so this blocks **new** error today without blocking anyone on the existing offset. Ratchet them down as the model improves.

A side benefit: this makes an aero-constant fix defensible. Right now there's no way to change `CL_SATURATION` and demonstrate the change helped.

## Automated tests

5 tests: overall RMSE budget, per-club RMSE budget (3 clubs, parametrised), and a fixture-size pin so budget drift can't hide behind a changed capture file.

Reuses `load_trackman` / `validate_tm_inputs` / `_stats` from `validate_ballistics.py` rather than reimplementing them, so the test and the manual tool can't disagree about what the reference data means. Skips cleanly if the capture is absent.

## Manual (human) testing

Ran a known-answer control: injected coefficient changes and compared what each suite catches.

| injected | overall rmse | existing ballistics tests | this test |
|---|---|---|---|
| shipped `0.32 / 0.15` | 24.5 | 21 pass | 5 pass |
| `0.34 / 0.14` | 21.2 | **21 pass** | **fails** |
| `0.30 / 0.17` | 30.0 | 1 fail | fails |
| `0.36 / 0.13` | 19.1 | 1 fail | fails |

Row 2 is the interesting one — it passes every existing ballistics test. This catches it because overall RMSE *improves* (24.5→21.2) while 7-iron (11.6→16.0) and pitching wedge (13.6→15.5) both regress. A single aggregate number would wave that through.

Confirmed the failure output is actionable:

```
driver: carry RMSE 49.26 yd exceeds budget 40.0 yd (bias -48.14, max |delta| 63.33, n=8).
```

Also verified it passes on unmodified `main` (`c9d0cc7`) and restored `ballistics.py` to its committed state afterwards (`git diff` clean apart from the new file).

One caveat I can't close myself: I only have Python 3.13/3.14 locally, so I haven't run this on the 3.10-3.12 matrix CI uses. The module is stdlib-only with `from __future__ import annotations`, and `validate_ballistics` imports nothing beyond stdlib at module scope (matplotlib is imported lazily inside a function this test never calls), so I don't expect trouble — but CI will confirm.

## Checklist

- [x] **Single feature/fix** — one test module, no source changes
- [x] **Automated tests included** — the PR is the test
- [x] **Manual testing described** — known-answer control above
- [x] Python tests pass (`1326 passed, 8 skipped`)
- [x] Pylint passes (9.70/10, unchanged — no source touched)
- [x] Ruff passes (`ruff check` and `ruff format --check` both clean)
- [ ] UI builds — n/a, no UI changes
- [ ] UI lint passes — n/a, no UI changes
- [x] Updated docs or CHANGELOG if needed — n/a; the module docstring explains the budget and how to ratchet it
- [x] No unrelated changes mixed in
