### PR TITLE
docs: align constants and architecture, reconcile PARTS.md WiFi OPS, add MLM2 Pro adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,8 +154,11 @@ React UI (WebSocket) ──► Flask Server ──► RollingBufferMonitor ─�
                               │                │
                               │                └── SoundTrigger (SEN-14262 → HOST_INT)
                               │
-                              ├── KLD7Tracker (vertical, RADC → launch angle)
-                              ├── KLD7Tracker (horizontal, RADC → aim direction)
+                              ├── IWR6843Runtime (optional, 60 GHz → launch angle & club path)
+                              ├── KLD7Tracker (vertical/horizontal, deprecated)
+                              ├── Ballistics Simulator (RK4 trajectory & carry)
+                              ├── SimConnectors (OpenGolfSim, GSPro, E6, etc.)
+                              ├── CloudSync (optional telemetry & session backup)
                               │
                               └── SessionLogger (JSONL files)
 ```
@@ -166,32 +169,38 @@ React UI (WebSocket) ──► Flask Server ──► RollingBufferMonitor ─�
 2. **OPS243Radar** (`ops243.py`) dumps rolling buffer I/Q data (4096 samples)
 3. **RollingBufferProcessor** (`rolling_buffer/processor.py`) runs FFT + mode-based speed extraction
 4. Creates `Shot` object with ball_speed, club_speed, spin, carry
-5. **KLD7Trackers** extract launch angle (vertical) and aim direction (horizontal) from RADC phase interferometry, filtered by OPS243 ball speed
-6. **Flask server** (`server.py`) emits WebSocket "shot" event
-7. **React UI** (`ui/src/`) renders shot data
+5. **IWR6843** (or legacy **KLD7Trackers**) extracts launch angle and club path from radar measurements
+6. **Ballistics engine** (`ballistics.py`) computes trajectory and carry distance
+7. **Flask server** (`server.py`) emits WebSocket "shot" event and forwards to connected simulator software
+8. **React UI** (`ui/src/`) renders shot data
 
 ### Key Modules
 
 - `ops243.py` - OPS243 radar driver, rolling buffer capture, I/Q processing
 - `launch_monitor.py` - Shot dataclass, ClubType enum, carry estimation
+- `ballistics.py` - Numerical ballistic trajectory simulation (drag + Magnus RK4)
+- `club_data.py` - Canonical club physics parameters, lofts, typical speeds, and optimal spin
+- `iwr6843/` - TI IWR6843 mmWave radar driver, L3 raw dump parser, LCMF-v1 launch angle & club path
+- `inclinometer.py` - LIS3DH accelerometer tilt compensation service
+- `sim/` - Simulator connectors (OpenGolfSim, GSPro, E6 Connect, Garmin) and network transports
+- `cloud/` - Telemetry, cloud configuration, session upload, and push error handling
 - `rolling_buffer/` - Trigger strategies, I/Q processor, spin detection
 - `kld7/` - K-LD7 angle radar (deprecated hardware): RADC streaming, phase interferometry, dual-radar support
 - `kld7/radc.py` - FFT, CFAR detection, per-bin angle extraction from raw ADC
-- `server.py` - Flask server, shot processing, K-LD7 correlation, carry estimation
+- `server.py` - Flask server, AppState runtime management, staged shot processing pipeline
 - `session_logger.py` - JSONL logging for post-session analysis
 
 ### Processing Mode
 
-**Rolling Buffer** is the default and only production mode. The OPS243-A continuously buffers I/Q data. When the sound trigger fires, the buffer is dumped and analyzed for ball speed, club speed, and spin rate. K-LD7 data is correlated via the OPS243 impact timestamp.
+**Rolling Buffer** is the default and only production mode. The OPS243-A continuously buffers I/Q data. When the sound trigger fires, the buffer is dumped and analyzed for ball speed, club speed, and spin rate. IWR6843 or legacy K-LD7 data is correlated via the OPS243 impact timestamp.
 
 ## Key Constants
 
 - Sample rate: 30,000 Hz
 - FFT window: 128 samples, zero-padded to 4096
-- CFAR threshold: SNR > 15.0
 - DC mask: 150 bins (~15 mph exclusion zone)
-- Shot timeout: 0.5 seconds
-- Min ball speed: 35 mph
+- Min ball speed: 15 mph (35 mph for speed-triggered mode)
+- K-LD7 OS-CFAR threshold factor: 8.0 (deprecated hardware)
 
 ## Session Logging
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Doppler radar, with an optional TI IWR6843 angle radar.
 
 ### What It Measures
 
-- **Ball Speed**: 35-200 mph range with ±0.5% accuracy (OPS243-A)
+- **Ball Speed**: 15-200 mph range with ±0.5% accuracy (OPS243-A)
 - **Club Speed**: Detected from pre-impact readings (OPS243-A)
 - **Smash Factor**: Ball speed / club speed ratio
 - **Launch Angle**: Measured by the IWR6843; estimated when no trusted radar angle is available
@@ -216,7 +216,7 @@ shares the OPS243 position.
 | Sample Rate    | 30 ksps                | Supports up to ~208 mph ball speed           |
 | Capture        | 4096 I/Q samples       | ~136 ms around impact                        |
 | Trigger        | Sound (SEN-14262)      | ~10 µs hardware latency via HOST_INT         |
-| Min Ball Speed | 35 mph                 | Filter club waggle and slow movements        |
+| Min Ball Speed | 15 mph                 | Minimum valid ball speed threshold (35 mph for speed-triggered mode) |
 | DC Mask        | ~15 mph exclusion zone | Reject body movement and environmental noise |
 
 These are applied automatically — the one-time flash configuration is handled

--- a/docs/PARTS.md
+++ b/docs/PARTS.md
@@ -14,7 +14,7 @@ Hardware components for building the OpenFlight golf launch monitor.
 | **Raspberry Pi 5** | Main compute unit (4GB+ recommended) | [Adafruit](https://www.adafruit.com/product/5812) | $130 |
 | **7" Touchscreen Display** | HMTECH 7" 1024x600 IPS display | [Amazon](https://www.amazon.com/dp/B0D3QB7X4Z) | $46 |
 
-> **WARNING: Do NOT buy the OPS243-A-W (WiFi version).** The WiFi module locks the serial baud rate to 19200, which is far too slow for I/Q data transfer. OpenFlight requires the standard **OPS243** (USB only) which runs at 57600 baud over CDC-ACM. The WiFi version is not compatible.
+> **NOTE on OPS243-A-W (WiFi version):** The standard **OPS243-A** (USB only) is strongly recommended. The WiFi module on the OPS243-A-W drives the internal UART receive line, preventing direct connection to the Raspberry Pi GPIO UART (Layout A). However, if you already have the WiFi version, it can still be used over USB with a powered USB hub (Layout B) when paired with the IWR6843 angle radar.
 
 > **Display alternative:** The [Raspberry Pi Touch Display 2](https://www.raspberrypi.com/products/touch-display-2/) (7" 720x1280, MIPI DSI) also works with the Pi 5. If you use it, print the `Touch_Display2_backplate.stl` and `Touch_Display2_shell.stl` from the IARC case instead of `monitor_shell.stl` — see the [IARC case instructions](../cad/IARC_case/README.md).
 

--- a/scripts/adapters/mlm2pro_adapter.py
+++ b/scripts/adapters/mlm2pro_adapter.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""Convert Rapsodo MLM2 Pro CSV export files to TrackMan-compatible CSV format.
+
+This adapter transforms session CSV exports from the Rapsodo MLM2 Pro mobile
+app into the TrackMan CSV layout expected by scripts/analysis/compare_trackman.py.
+
+Usage::
+
+    uv run python scripts/adapters/mlm2pro_adapter.py \\
+        --input ~/Downloads/mlm2pro_session_2026-08-20.csv \\
+        --output ~/openflight_sessions/mlm2pro_trackman_adapted.csv
+
+Then feed directly into compare_trackman.py::
+
+    uv run python scripts/analysis/compare_trackman.py \\
+        --openflight ~/openflight_sessions/session_20260820_*.jsonl \\
+        --trackman ~/openflight_sessions/mlm2pro_trackman_adapted.csv \\
+        --output ~/openflight_sessions/comparison_20260820.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+# Speed conversion constants
+KMH_TO_MPH = 1.0 / 1.609344
+MPS_TO_MPH = 2.2369362920544
+METRES_TO_YARDS = 1.0936132983377
+
+# Output TrackMan canonical CSV headers
+TRACKMAN_OUTPUT_HEADERS = [
+    "Date",
+    "Shot Number",
+    "Club",
+    "Ball Speed",
+    "Club Speed",
+    "Smash Factor",
+    "Launch Angle",
+    "Launch Direction",
+    "Spin Rate",
+    "Spin Axis",
+    "Carry Distance",
+    "Total Distance",
+    "Max Height - Height",
+    "Carry Flat - Side",
+]
+
+# Field match alias table for MLM2 Pro headers
+MLM2PRO_FIELD_ALIASES: Dict[str, List[str]] = {
+    "timestamp": [
+        "date & time",
+        "date/time",
+        "date time",
+        "datetime",
+        "timestamp",
+        "date",
+        "time",
+    ],
+    "shot_number": [
+        "shot number",
+        "shot #",
+        "shot no",
+        "shot_no",
+        "shot",
+        "tmd no",
+        "index",
+        "#",
+    ],
+    "club": [
+        "club type",
+        "club name",
+        "club",
+    ],
+    "ball_speed": [
+        "ball speed",
+        "ballspeed",
+        "ball_speed",
+        "ball velocity",
+    ],
+    "club_speed": [
+        "club speed",
+        "clubspeed",
+        "club_speed",
+        "club head speed",
+        "clubheadspeed",
+    ],
+    "smash_factor": [
+        "smash factor",
+        "smashfactor",
+        "smash",
+    ],
+    "launch_angle": [
+        "launch angle (deg)",
+        "launch angle v",
+        "launch angle",
+        "vertical launch",
+        "v. launch",
+    ],
+    "launch_direction": [
+        "launch direction (deg)",
+        "launch direction",
+        "launch angle h",
+        "horizontal launch",
+        "side angle",
+        "azimuth",
+        "h. launch",
+    ],
+    "spin_rate": [
+        "spin rate (rpm)",
+        "total spin (rpm)",
+        "spin rate",
+        "total spin",
+        "spinrate",
+        "spin",
+    ],
+    "spin_axis": [
+        "spin axis (deg)",
+        "spin axis",
+        "spin tilt",
+    ],
+    "carry_distance": [
+        "carry distance (yds)",
+        "carry distance (m)",
+        "carry distance",
+        "carry (yds)",
+        "carry (m)",
+        "carry",
+    ],
+    "total_distance": [
+        "total distance (yds)",
+        "total distance (m)",
+        "total distance",
+        "total (yds)",
+        "total (m)",
+        "total",
+    ],
+    "apex": [
+        "max height (ft)",
+        "max height (yds)",
+        "max height",
+        "apex (ft)",
+        "apex (yds)",
+        "apex",
+        "height",
+    ],
+    "offline": [
+        "side carry (yds)",
+        "carry side (yds)",
+        "carry flat - side",
+        "offline (yds)",
+        "side (yds)",
+        "offline",
+        "side",
+    ],
+}
+
+
+def _clean_header(header: str) -> str:
+    """Normalize a header string for alias matching."""
+    return re.sub(r"[\s_]+", " ", header.strip().lower())
+
+
+def detect_mlm2pro_column_map(headers: Iterable[str]) -> Dict[str, str]:
+    """Map canonical field names to actual CSV header names."""
+    mapping: Dict[str, str] = {}
+    cleaned_to_raw = {_clean_header(h): h for h in headers}
+
+    for canonical, aliases in MLM2PRO_FIELD_ALIASES.items():
+        for alias in aliases:
+            cleaned_alias = _clean_header(alias)
+            # Check exact match first
+            if cleaned_alias in cleaned_to_raw and canonical not in mapping:
+                mapping[canonical] = cleaned_to_raw[cleaned_alias]
+                break
+            # Check substring match
+            for cleaned_hdr, raw_hdr in cleaned_to_raw.items():
+                if cleaned_alias in cleaned_hdr and canonical not in mapping:
+                    mapping[canonical] = raw_hdr
+                    break
+            if canonical in mapping:
+                break
+
+    return mapping
+
+
+def detect_header_units(headers: Iterable[str]) -> Dict[str, str]:
+    """Detect units (speed, distance) from header suffixes."""
+    units: Dict[str, str] = {"speed": "mph", "distance": "yards"}
+    for h in headers:
+        ch = _clean_header(h)
+        if "ball" in ch or "club" in ch:
+            if "km/h" in ch or "kph" in ch or "kmh" in ch:
+                units["speed"] = "kph"
+            elif "m/s" in ch or "mps" in ch:
+                units["speed"] = "mps"
+            elif "mph" in ch:
+                units["speed"] = "mph"
+        if "carry" in ch or "total" in ch:
+            if "meter" in ch or "metre" in ch or "(m)" in ch or "[m]" in ch:
+                units["distance"] = "meters"
+            elif "yard" in ch or "(yd" in ch or "[yd" in ch:
+                units["distance"] = "yards"
+    return units
+
+
+def _parse_float(val: Any) -> Optional[float]:
+    """Safely parse float from string or number."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    if not s or s.lower() in ("nan", "none", "null", "-", "--", "n/a"):
+        return None
+    # Remove unit suffixes if embedded in value
+    s = re.sub(r"[^\d.\-+]", "", s)
+    if not s:
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def convert_speed_to_mph(val: Optional[float], unit: str) -> Optional[float]:
+    """Convert speed value to mph."""
+    if val is None:
+        return None
+    unit_lower = unit.lower()
+    if unit_lower in ("kph", "km/h", "kmh"):
+        return val * KMH_TO_MPH
+    if unit_lower in ("mps", "m/s"):
+        return val * MPS_TO_MPH
+    return val
+
+
+def convert_distance_to_yards(val: Optional[float], unit: str) -> Optional[float]:
+    """Convert distance value to yards."""
+    if val is None:
+        return None
+    unit_lower = unit.lower()
+    if unit_lower in ("meters", "meter", "m", "metres", "metre"):
+        return val * METRES_TO_YARDS
+    return val
+
+
+def adapt_mlm2pro_row(
+    row: Dict[str, Any],
+    col_map: Dict[str, str],
+    row_idx: int,
+    speed_unit: str = "mph",
+    distance_unit: str = "yards",
+    club_override: Optional[str] = None,
+) -> Dict[str, str]:
+    """Transform a single MLM2 Pro CSV row into a TrackMan CSV record."""
+
+    def get_val(key: str) -> Any:
+        raw_key = col_map.get(key)
+        return row.get(raw_key) if raw_key else None
+
+    # Date / Timestamp
+    ts_val = get_val("timestamp")
+    date_str = str(ts_val).strip() if ts_val is not None else ""
+    if not date_str:
+        date_str = datetime.now().strftime("%m/%d/%Y %I:%M:%S %p")
+
+    # Shot number
+    shot_no_raw = _parse_float(get_val("shot_number"))
+    shot_num = int(shot_no_raw) if shot_no_raw is not None else row_idx
+
+    # Club
+    club_val = club_override or get_val("club")
+    club_str = str(club_val).strip() if club_val is not None else ""
+
+    # Metrics
+    ball_speed_raw = _parse_float(get_val("ball_speed"))
+    ball_speed = convert_speed_to_mph(ball_speed_raw, speed_unit)
+
+    club_speed_raw = _parse_float(get_val("club_speed"))
+    club_speed = convert_speed_to_mph(club_speed_raw, speed_unit)
+
+    smash_raw = _parse_float(get_val("smash_factor"))
+    if smash_raw is None and ball_speed and club_speed and club_speed > 0:
+        smash_raw = ball_speed / club_speed
+
+    la_v = _parse_float(get_val("launch_angle"))
+    la_h = _parse_float(get_val("launch_direction"))
+    spin = _parse_float(get_val("spin_rate"))
+    spin_axis = _parse_float(get_val("spin_axis"))
+
+    carry_raw = _parse_float(get_val("carry_distance"))
+    carry = convert_distance_to_yards(carry_raw, distance_unit)
+
+    total_raw = _parse_float(get_val("total_distance"))
+    total = convert_distance_to_yards(total_raw, distance_unit)
+
+    apex = _parse_float(get_val("apex"))
+    offline = _parse_float(get_val("offline"))
+
+    def fmt_num(v: Optional[float], decimals: int = 1) -> str:
+        if v is None:
+            return ""
+        return f"{v:.{decimals}f}"
+
+    return {
+        "Date": date_str,
+        "Shot Number": str(shot_num),
+        "Club": club_str,
+        "Ball Speed": fmt_num(ball_speed, 1),
+        "Club Speed": fmt_num(club_speed, 1),
+        "Smash Factor": fmt_num(smash_raw, 2),
+        "Launch Angle": fmt_num(la_v, 1),
+        "Launch Direction": fmt_num(la_h, 1),
+        "Spin Rate": fmt_num(spin, 0),
+        "Spin Axis": fmt_num(spin_axis, 1),
+        "Carry Distance": fmt_num(carry, 1),
+        "Total Distance": fmt_num(total, 1),
+        "Max Height - Height": fmt_num(apex, 1),
+        "Carry Flat - Side": fmt_num(offline, 1),
+    }
+
+
+def adapt_mlm2pro_csv(
+    input_file: str | Path,
+    output_file: str | Path,
+    speed_unit: Optional[str] = None,
+    distance_unit: Optional[str] = None,
+    club_override: Optional[str] = None,
+) -> int:
+    """Read an MLM2 Pro CSV file, transform to TrackMan format, and save.
+
+    Returns the number of shots converted.
+    """
+    input_path = Path(input_file)
+    output_path = Path(output_file)
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file does not exist: {input_path}")
+
+    # Read lines and skip any metadata preamble (e.g. sep=,)
+    content = input_path.read_text(encoding="utf-8-sig", errors="replace")
+    lines = content.splitlines()
+    cleaned_lines = []
+    for line in lines:
+        s = line.strip()
+        if not s or s.startswith("sep=") or s.startswith("#"):
+            continue
+        cleaned_lines.append(line)
+
+    if not cleaned_lines:
+        raise ValueError(f"No valid CSV data found in {input_path}")
+
+    reader = csv.DictReader(cleaned_lines)
+    if not reader.fieldnames:
+        raise ValueError(f"Could not parse CSV headers from {input_path}")
+
+    col_map = detect_mlm2pro_column_map(reader.fieldnames)
+    detected_units = detect_header_units(reader.fieldnames)
+
+    effective_speed_unit = speed_unit or detected_units["speed"]
+    effective_dist_unit = distance_unit or detected_units["distance"]
+
+    adapted_rows: List[Dict[str, str]] = []
+    row_counter = 1
+    for row in reader:
+        # Check if row has any values
+        if not any(str(v).strip() for v in row.values() if v is not None):
+            continue
+        adapted = adapt_mlm2pro_row(
+            row=row,
+            col_map=col_map,
+            row_idx=row_counter,
+            speed_unit=effective_speed_unit,
+            distance_unit=effective_dist_unit,
+            club_override=club_override,
+        )
+        adapted_rows.append(adapted)
+        row_counter += 1
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=TRACKMAN_OUTPUT_HEADERS)
+        writer.writeheader()
+        writer.writerows(adapted_rows)
+
+    return len(adapted_rows)
+
+
+def main() -> None:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(
+        description="Adapt Rapsodo MLM2 Pro CSV export into TrackMan CSV format.",
+    )
+    parser.add_argument(
+        "--input",
+        "-i",
+        required=True,
+        help="Path to MLM2 Pro CSV export file.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        required=True,
+        help="Path to output TrackMan-compatible CSV.",
+    )
+    parser.add_argument(
+        "--speed-unit",
+        choices=["mph", "kph", "mps"],
+        default=None,
+        help="Override input speed unit (default: auto-detect from header or mph).",
+    )
+    parser.add_argument(
+        "--distance-unit",
+        choices=["yards", "meters"],
+        default=None,
+        help="Override input distance unit (default: auto-detect from header or yards).",
+    )
+    parser.add_argument(
+        "--club-override",
+        default=None,
+        help="Override club name for all shots in the file.",
+    )
+
+    args = parser.parse_args()
+    try:
+        count = adapt_mlm2pro_csv(
+            input_file=args.input,
+            output_file=args.output,
+            speed_unit=args.speed_unit,
+            distance_unit=args.distance_unit,
+            club_override=args.club_override,
+        )
+        print(f"Successfully converted {count} shots from {args.input} to {args.output}")
+    except Exception as e:
+        print(f"Error converting MLM2 Pro CSV: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/openflight/rolling_buffer/trigger.py
+++ b/src/openflight/rolling_buffer/trigger.py
@@ -583,10 +583,10 @@ class GPIOSoundTrigger(TriggerStrategy):
             gpio_pin: GPIO pin (BCM numbering) for GATE input (default: 17)
             pre_trigger_segments: Number of pre-trigger segments for S# command.
                 Each segment = 128 samples = ~4.27ms at 30ksps.
-                Default 20 gives ~85ms pre-trigger, ~51ms post-trigger.
+                Default 32 gives ~136ms total rolling window (50/50 pre/post split).
                 NOTE: This is passed to enter_rolling_buffer_mode() by the caller.
                 The trigger does NOT configure rolling buffer mode itself.
-            debounce_ms: Debounce time in ms to ignore rapid triggers (default: 200)
+            debounce_ms: Debounce time in ms to ignore rapid triggers (default: 20)
         """
         super().__init__(pre_trigger_segments=pre_trigger_segments)
         self.gpio_pin = gpio_pin
@@ -942,9 +942,7 @@ class SoundTrigger(TriggerStrategy):
         ):
             selected_sync = previous_sync
             selected_source = "previous"
-            selected_reason = (
-                f"fresh_rejected:{fresh_reason};previous_age:{previous_age_s:.1f}s"
-            )
+            selected_reason = f"fresh_rejected:{fresh_reason};previous_age:{previous_age_s:.1f}s"
         elif previous_valid and previous_age_s is not None:
             selected_reason = (
                 f"fresh_rejected:{fresh_reason};previous_too_old:{previous_age_s:.1f}s"

--- a/tests/test_mlm2pro_adapter.py
+++ b/tests/test_mlm2pro_adapter.py
@@ -1,0 +1,274 @@
+"""Unit tests for MLM2 Pro CSV to TrackMan CSV adapter script."""
+
+import csv
+import importlib.util
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_script_path = Path(__file__).resolve().parents[1] / "scripts" / "adapters" / "mlm2pro_adapter.py"
+_spec = importlib.util.spec_from_file_location("mlm2pro_adapter", _script_path)
+mlm2pro_adapter = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mlm2pro_adapter)
+
+METRES_TO_YARDS = mlm2pro_adapter.METRES_TO_YARDS
+TRACKMAN_OUTPUT_HEADERS = mlm2pro_adapter.TRACKMAN_OUTPUT_HEADERS
+adapt_mlm2pro_csv = mlm2pro_adapter.adapt_mlm2pro_csv
+adapt_mlm2pro_row = mlm2pro_adapter.adapt_mlm2pro_row
+convert_distance_to_yards = mlm2pro_adapter.convert_distance_to_yards
+convert_speed_to_mph = mlm2pro_adapter.convert_speed_to_mph
+detect_header_units = mlm2pro_adapter.detect_header_units
+detect_mlm2pro_column_map = mlm2pro_adapter.detect_mlm2pro_column_map
+
+
+class TestMlm2ProHeaderDetection:
+    """Test header alias resolution and unit detection."""
+
+    def test_detect_standard_mlm2pro_headers(self):
+        headers = [
+            "Date",
+            "Shot Number",
+            "Club",
+            "Ball Speed (mph)",
+            "Club Speed (mph)",
+            "Smash Factor",
+            "Launch Angle (deg)",
+            "Launch Direction (deg)",
+            "Spin Rate (rpm)",
+            "Spin Axis (deg)",
+            "Carry Distance (yds)",
+            "Total Distance (yds)",
+            "Apex (ft)",
+            "Side Carry (yds)",
+        ]
+        col_map = detect_mlm2pro_column_map(headers)
+        assert col_map["ball_speed"] == "Ball Speed (mph)"
+        assert col_map["club_speed"] == "Club Speed (mph)"
+        assert col_map["launch_angle"] == "Launch Angle (deg)"
+        assert col_map["launch_direction"] == "Launch Direction (deg)"
+        assert col_map["spin_rate"] == "Spin Rate (rpm)"
+        assert col_map["spin_axis"] == "Spin Axis (deg)"
+        assert col_map["carry_distance"] == "Carry Distance (yds)"
+        assert col_map["club"] == "Club"
+
+    def test_detect_alternate_aliases(self):
+        headers = [
+            "Timestamp",
+            "Shot #",
+            "Club Type",
+            "Ball Velocity",
+            "Club Head Speed",
+            "Smash",
+            "Vertical Launch",
+            "Side Angle",
+            "Total Spin",
+            "Spin Tilt",
+            "Carry",
+            "Total",
+            "Max Height",
+            "Offline",
+        ]
+        col_map = detect_mlm2pro_column_map(headers)
+        assert col_map["timestamp"] == "Timestamp"
+        assert col_map["shot_number"] == "Shot #"
+        assert col_map["club"] == "Club Type"
+        assert col_map["ball_speed"] == "Ball Velocity"
+        assert col_map["club_speed"] == "Club Head Speed"
+        assert col_map["smash_factor"] == "Smash"
+        assert col_map["launch_angle"] == "Vertical Launch"
+        assert col_map["launch_direction"] == "Side Angle"
+        assert col_map["spin_rate"] == "Total Spin"
+        assert col_map["spin_axis"] == "Spin Tilt"
+        assert col_map["carry_distance"] == "Carry"
+        assert col_map["total_distance"] == "Total"
+        assert col_map["apex"] == "Max Height"
+        assert col_map["offline"] == "Offline"
+
+    def test_detect_header_units_metric_kph_meters(self):
+        headers = [
+            "Date",
+            "Ball Speed (km/h)",
+            "Club Speed (km/h)",
+            "Carry Distance (m)",
+        ]
+        units = detect_header_units(headers)
+        assert units["speed"] == "kph"
+        assert units["distance"] == "meters"
+
+    def test_detect_header_units_metric_mps(self):
+        headers = [
+            "Date",
+            "Ball Speed (m/s)",
+            "Carry Distance (meters)",
+        ]
+        units = detect_header_units(headers)
+        assert units["speed"] == "mps"
+        assert units["distance"] == "meters"
+
+
+class TestUnitConversions:
+    """Test metric and imperial unit conversion routines."""
+
+    def test_convert_speed_to_mph(self):
+        assert convert_speed_to_mph(100.0, "mph") == 100.0
+        assert convert_speed_to_mph(160.9344, "kph") == pytest.approx(100.0)
+        assert convert_speed_to_mph(44.704, "mps") == pytest.approx(100.0)
+        assert convert_speed_to_mph(None, "mph") is None
+
+    def test_convert_distance_to_yards(self):
+        assert convert_distance_to_yards(150.0, "yards") == 150.0
+        assert convert_distance_to_yards(100.0, "meters") == pytest.approx(100.0 * METRES_TO_YARDS)
+        assert convert_distance_to_yards(None, "yards") is None
+
+
+class TestAdaptMlm2ProRow:
+    """Test transforming individual dictionary rows."""
+
+    def test_adapt_complete_row(self):
+        row = {
+            "Date": "5/6/2026 7:00:00 PM",
+            "Shot Number": "5",
+            "Club": "7-Iron",
+            "Ball Speed (mph)": "120.5",
+            "Club Speed (mph)": "85.2",
+            "Smash Factor": "1.41",
+            "Launch Angle (deg)": "16.5",
+            "Launch Direction (deg)": "-1.2",
+            "Spin Rate (rpm)": "5500",
+            "Spin Axis (deg)": "4.5",
+            "Carry Distance (yds)": "165.2",
+            "Total Distance (yds)": "175.0",
+            "Apex (ft)": "85.0",
+            "Side Carry (yds)": "-3.5",
+        }
+        col_map = detect_mlm2pro_column_map(row.keys())
+        adapted = adapt_mlm2pro_row(row, col_map, row_idx=1)
+
+        assert adapted["Date"] == "5/6/2026 7:00:00 PM"
+        assert adapted["Shot Number"] == "5"
+        assert adapted["Club"] == "7-Iron"
+        assert adapted["Ball Speed"] == "120.5"
+        assert adapted["Club Speed"] == "85.2"
+        assert adapted["Smash Factor"] == "1.41"
+        assert adapted["Launch Angle"] == "16.5"
+        assert adapted["Launch Direction"] == "-1.2"
+        assert adapted["Spin Rate"] == "5500"
+        assert adapted["Spin Axis"] == "4.5"
+        assert adapted["Carry Distance"] == "165.2"
+        assert adapted["Total Distance"] == "175.0"
+        assert adapted["Max Height - Height"] == "85.0"
+        assert adapted["Carry Flat - Side"] == "-3.5"
+
+    def test_adapt_row_calculates_missing_smash_factor(self):
+        row = {
+            "Ball Speed": "150.0",
+            "Club Speed": "100.0",
+            "Club": "Driver",
+        }
+        col_map = detect_mlm2pro_column_map(row.keys())
+        adapted = adapt_mlm2pro_row(row, col_map, row_idx=3)
+        assert adapted["Smash Factor"] == "1.50"
+        assert adapted["Shot Number"] == "3"
+
+    def test_adapt_row_with_club_override(self):
+        row = {
+            "Ball Speed": "150.0",
+            "Club": "Unknown",
+        }
+        col_map = detect_mlm2pro_column_map(row.keys())
+        adapted = adapt_mlm2pro_row(row, col_map, row_idx=1, club_override="Driver")
+        assert adapted["Club"] == "Driver"
+
+
+class TestAdaptMlm2ProCsvEndToEnd:
+    """Test full file conversion and integration with compare_trackman expectations."""
+
+    def test_convert_csv_file_with_preamble(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            input_csv = tmp_path / "raw_mlm2pro.csv"
+            output_csv = tmp_path / "adapted_trackman.csv"
+
+            raw_content = (
+                "sep=,\n"
+                "# Rapsodo MLM2 Pro Session Export\n"
+                "Date,Shot #,Club,Ball Speed (mph),Club Speed (mph),Smash Factor,Launch Angle (deg),Launch Direction (deg),Spin Rate (rpm),Spin Axis (deg),Carry Distance (yds),Total Distance (yds)\n"
+                "5/6/2026 6:58:02 PM,1,7 Iron,123.8,85.4,1.45,15.4,-1.2,5492,11.5,177.2,184.1\n"
+                "5/6/2026 6:58:43 PM,2,7 Iron,110.2,83.4,1.32,15.5,-0.3,5419,7.2,153.2,164.5\n"
+                "\n"
+            )
+            input_csv.write_text(raw_content, encoding="utf-8")
+
+            count = adapt_mlm2pro_csv(input_csv, output_csv)
+            assert count == 2
+            assert output_csv.exists()
+
+            with output_csv.open("r", encoding="utf-8") as f:
+                reader = csv.DictReader(f)
+                assert reader.fieldnames == TRACKMAN_OUTPUT_HEADERS
+                rows = list(reader)
+                assert len(rows) == 2
+                assert rows[0]["Club"] == "7 Iron"
+                assert rows[0]["Ball Speed"] == "123.8"
+                assert rows[0]["Spin Rate"] == "5492"
+                assert rows[1]["Ball Speed"] == "110.2"
+
+    def test_adapted_csv_matches_compare_trackman_aliases(self):
+        """Verify that adapted CSV is successfully parsed by compare_trackman._build_column_map."""
+        from scripts.analysis.compare_trackman import _build_column_map
+
+        col_map = _build_column_map(TRACKMAN_OUTPUT_HEADERS)
+        assert "ball_speed_mph" in col_map
+        assert "club_speed_mph" in col_map
+        assert "smash_factor" in col_map
+        assert "launch_angle_vertical" in col_map
+        assert "launch_angle_horizontal" in col_map
+        assert "spin_rpm" in col_map
+        assert "carry_yards" in col_map
+        assert "club" in col_map
+        assert "shot_number" in col_map
+        assert "timestamp" in col_map
+
+    def test_nonexistent_file_raises(self):
+        with pytest.raises(FileNotFoundError):
+            adapt_mlm2pro_csv("nonexistent_path_12345.csv", "out.csv")
+
+    def test_empty_file_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            empty_csv = Path(tmpdir) / "empty.csv"
+            empty_csv.write_text("", encoding="utf-8")
+            with pytest.raises(ValueError, match="No valid CSV data found"):
+                adapt_mlm2pro_csv(empty_csv, Path(tmpdir) / "out.csv")
+
+    def test_cli_execution(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            input_csv = tmp_path / "mlm2.csv"
+            output_csv = tmp_path / "out.csv"
+
+            input_csv.write_text(
+                "Date,Club,Ball Speed,Club Speed,Total Spin\n"
+                "5/6/2026 7:00 PM,Driver,150.0,100.0,2500\n",
+                encoding="utf-8",
+            )
+
+            monkeypatch.setattr(
+                "sys.argv",
+                [
+                    "mlm2pro_adapter.py",
+                    "--input",
+                    str(input_csv),
+                    "--output",
+                    str(output_csv),
+                ],
+            )
+            mlm2pro_adapter.main()
+            assert output_csv.exists()
+            with output_csv.open("r", encoding="utf-8") as f:
+                rows = list(csv.DictReader(f))
+                assert len(rows) == 1
+                assert rows[0]["Club"] == "Driver"
+                assert rows[0]["Ball Speed"] == "150.0"
+                assert rows[0]["Club Speed"] == "100.0"
+                assert rows[0]["Spin Rate"] == "2500"


### PR DESCRIPTION
## Summary

This PR addresses documentation drift and adds reference instrument tooling as outlined in Issues #16 and #11:

### 1. Documentation Drift Fixes (Issue #16)
- **Min Ball Speed Threshold**: Updated `CLAUDE.md` and `README.md` documentation to reflect the actual validation floor (15 mph) while noting that 35 mph is the threshold in `SpeedTriggeredCapture`.
- **CFAR Threshold & Timeout Alignment**: Replaced non-existent SNR > 15.0 with the actual K-LD7 OS-CFAR `threshold_factor=8.0` in `CLAUDE.md`, and removed obsolete streaming-mode 0.5s timeout.
- **Architecture & Key Modules**: Expanded `CLAUDE.md` architecture diagram and module list to include `iwr6843/`, `ballistics.py`, `club_data.py`, `inclinometer.py`, `sim/`, and `cloud/`.
- **OPS243-A-W (WiFi) Reconciled**: Updated `docs/PARTS.md` to clarify that while the standard OPS243-A (USB only) is strongly recommended, the WiFi variant can still be operated over USB with a powered USB hub (Layout B) alongside the IWR6843.
- **`GPIOSoundTrigger` Docstring**: Corrected default values in `src/openflight/rolling_buffer/trigger.py` (`pre_trigger_segments=32` and `debounce_ms=20`).

### 2. MLM2 Pro to TrackMan CSV Adapter (Issue #11)
- Built `scripts/adapters/mlm2pro_adapter.py` to reshape Rapsodo MLM2 Pro session CSV exports into the standard TrackMan CSV layout expected by `scripts/analysis/compare_trackman.py`.
- Supports automatic column alias resolution, unit conversions (mph, km/h, m/s, yards, meters), club overrides, and calculated smash factor fallback.
- Added comprehensive test suite in `tests/test_mlm2pro_adapter.py` (14 unit and end-to-end integration tests).

## Verification
- `uv run pytest tests/test_mlm2pro_adapter.py -v` (14 passed in 1.62s)
- `uv run ruff check src/openflight/ scripts/adapters/ tests/test_mlm2pro_adapter.py` (all passed cleanly)
- `uv run ruff format --check src/ scripts/ tests/` (100% formatted)
