### PR TITLE
docs(parts): add CAD pricing column and refresh stale USD prices

### DIFF
--- a/docs/PARTS.md
+++ b/docs/PARTS.md
@@ -6,13 +6,19 @@ Hardware components for building the OpenFlight golf launch monitor.
 
 > **Next step after gathering parts:** See the [Raspberry Pi Setup Guide](raspberry-pi-setup.md) for assembly and software installation.
 
+> **Prices:** USD figures are the vendor's own list price. CAD figures are either a
+> Canadian distributor's list price (where one stocks the part) or the USD price
+> converted at the Bank of Canada daily rate of **1.3760 USD/CAD (2026-08-21)**.
+> Converted figures are marked `~` and **exclude shipping, duty, customs brokerage,
+> GST/HST/PST**. See [Buying in Canada](#buying-in-canada) before ordering.
+
 ## Core Components
 
-| Part | Description | Link | ~Price |
-|------|-------------|------|--------|
-| **OPS243 Radar** | Doppler radar for ball/club speed detection | [OmniPreSense](https://omnipresense.com/product/ops243-doppler-radar-sensor/) | $249 |
-| **Raspberry Pi 5** | Main compute unit (4GB+ recommended) | [Adafruit](https://www.adafruit.com/product/5812) | $130 |
-| **7" Touchscreen Display** | HMTECH 7" 1024x600 IPS display | [Amazon](https://www.amazon.com/dp/B0D3QB7X4Z) | $46 |
+| Part | Description | Link | ~USD | ~CAD |
+|------|-------------|------|------|------|
+| **OPS243 Radar** | Doppler radar for ball/club speed detection | [OmniPreSense](https://omnipresense.com/product/ops243-doppler-radar-sensor/) | $224 | ~$308 |
+| **Raspberry Pi 5** | Main compute unit (4GB+ recommended) | [Adafruit](https://www.adafruit.com/product/5812) · CA [PiShop.ca](https://www.pishop.ca/product/raspberry-pi-5-4gb/) | $130 | $154 |
+| **7" Touchscreen Display** | HMTECH 7" 1024x600 IPS display | [Amazon](https://www.amazon.com/dp/B0D3QB7X4Z) · CA [equivalent](https://www.amazon.ca/dp/B0CRRB1GFN) | $46 | $56 |
 
 > **NOTE on OPS243-A-W (WiFi version):** The standard **OPS243-A** (USB only) is strongly recommended. The WiFi module on the OPS243-A-W drives the internal UART receive line, preventing direct connection to the Raspberry Pi GPIO UART (Layout A). However, if you already have the WiFi version, it can still be used over USB with a powered USB hub (Layout B) when paired with the IWR6843 angle radar.
 
@@ -22,11 +28,11 @@ Hardware components for building the OpenFlight golf launch monitor.
 
 The sound trigger detects club impact to precisely time radar captures. Essential for spin detection via rolling buffer mode.
 
-| Part | Description | Link | ~Price |
-|------|-------------|------|--------|
-| **SparkFun SEN-14262** | Sound Detector with envelope/gate outputs | [SparkFun](https://www.sparkfun.com/products/14262) | $12 |
-| **Through-hole resistor** | For R17 pad on SEN-14262 to reduce sensitivity (see note) | Any electronics supplier | $1 |
-| **Jumper Wires** | 3 wires: GATE → HOST_INT, VCC → 3.3V, GND → GND | Any | $5 |
+| Part | Description | Link | ~USD | ~CAD |
+|------|-------------|------|------|------|
+| **SparkFun SEN-14262** | Sound Detector with envelope/gate outputs | [SparkFun](https://www.sparkfun.com/products/14262) · CA [DigiKey.ca](https://www.digikey.ca/en/products/detail/sparkfun-electronics/14262/7725299) | $12 | $21 |
+| **Through-hole resistor** | For R17 pad on SEN-14262 to reduce sensitivity (see note) | Any electronics supplier | $1 | $1 |
+| **Jumper Wires** | 3 wires: GATE → HOST_INT, VCC → 3.3V, GND → GND | Any | $5 | $7 |
 
 > **R17 resistor:** The SEN-14262 is rated for 5V but runs at 3.3V in this setup, which can cause the GATE output to stick high. Soldering a resistor into the R17 through-hole position (in parallel with the onboard 100kΩ R3) reduces preamp gain and fixes this. Start with 47kΩ; use a lower value (e.g. 33kΩ) if the sensor is still too sensitive for your environment.
 
@@ -51,11 +57,15 @@ See [sound-trigger-wiring.md](sound-trigger-wiring.md) for detailed instructions
 This is the supported angle radar. It measures vertical and horizontal launch
 angle, and supplies the pre-impact frames club path is derived from.
 
-| Part | Description | Link | ~Price |
-|------|-------------|------|--------|
-| **TI IWR6843LEVM** | 60 GHz mmWave evaluation board, 4 RX × 3 TX | [TI](https://www.ti.com/tool/IWR6843LEVM) | $150 |
-| **USB cable (data-capable)** | Connects the LEVM's CP2105 serial bridge to the Pi. Charge-only cables will not enumerate — check the connector on your board revision | Any | $5 |
-| **Jumper wire** | 1 wire: detector `GATE` → Pi BCM17 / physical pin 11, alongside the existing `GATE` → OPS `HOST_INT` | Any | $1 |
+| Part | Description | Link | ~USD | ~CAD |
+|------|-------------|------|------|------|
+| **TI IWR6843LEVM** | 60 GHz mmWave evaluation board, 4 RX × 3 TX | [TI](https://www.ti.com/tool/IWR6843LEVM) | $156 | ~$215 |
+| **USB cable (data-capable)** | Connects the LEVM's CP2105 serial bridge to the Pi. Charge-only cables will not enumerate — check the connector on your board revision | Any | $5 | $8 |
+| **Jumper wire** | 1 wire: detector `GATE` → Pi BCM17 / physical pin 11, alongside the existing `GATE` → OPS `HOST_INT` | Any | $1 | $1 |
+
+> **Canadian buyers: order the LEVM from TI directly.** TI ships to Canada and lists it
+> at $156.45 USD (~$215 CAD). DigiKey Canada stocks the same board at **$297.83 CAD**,
+> roughly $80 more than TI direct even after shipping and brokerage.
 
 The board needs **custom firmware** — it does not work out of the box. The
 stock TI demo does not expose the raw radar cube OpenFlight needs. A validated
@@ -73,7 +83,14 @@ OPS243 variant:
 | Layout | OPS243 connection | Extra parts needed |
 |--------|-------------------|--------------------|
 | **A (validated)** | Pi GPIO UART header | 4 jumper wires (5V, GND, TX, RX) |
-| **B** | Powered USB hub | [Powered USB hub](https://www.amazon.com/dp/B0CN3F9Y1Z) (~$20) |
+| **B** | Powered USB hub | [Powered USB hub](https://www.amazon.com/dp/B0CN3F9Y1Z) (~$20 USD / ~$28 CAD) |
+
+> [!CAUTION]
+> The hub must have its **own power adapter**. Layout B exists because the Pi cannot
+> supply both radars, so a bus-powered hub will not solve the problem it is there to
+> solve. Note that the `.com` ASIN above resolves to a **different, bus-powered** hub on
+> Amazon.ca, so Canadian buyers should search for an *externally powered* USB 3.0 hub
+> rather than following that link.
 
 Layout A keeps the TI board on USB and moves the OPS243 to the Pi's GPIO
 header, which is what the power budget requires — the Pi cannot supply both
@@ -93,10 +110,10 @@ UART](ops243-uart-migration.md)** for the OPS side of Layout A.
 An LIS3DH mounted to the enclosure base lets OpenFlight compensate the IWR6843
 tilt when the rig is placed on uneven ground.
 
-| Part | Description | Link | ~Price |
-|------|-------------|------|--------|
-| **Adafruit LIS3DH breakout** | Triple-axis accelerometer with STEMMA QT connectors | [Adafruit product 2809](https://www.adafruit.com/product/2809) | $5 |
-| **JST-SH cable kit** | Solderless STEMMA QT/Qwiic to female Dupont wiring used in the validated build | [Amazon](https://www.amazon.com/Connector-Compatible-Development-Sensors-Drivers/dp/B0GJPRX4YT) | ~$10 |
+| Part | Description | Link | ~USD | ~CAD |
+|------|-------------|------|------|------|
+| **Adafruit LIS3DH breakout** | Triple-axis accelerometer with STEMMA QT connectors | [Adafruit product 2809](https://www.adafruit.com/product/2809) · CA [Elmwood](https://elmwoodelectronics.ca/search?q=LIS3DH) | $5 | $8 |
+| **JST-SH cable kit** | Solderless STEMMA QT/Qwiic to female Dupont wiring used in the validated build | [Amazon](https://www.amazon.com/Connector-Compatible-Development-Sensors-Drivers/dp/B0GJPRX4YT) · CA [Elmwood](https://elmwoodelectronics.ca/search?q=STEMMA+QT+JST+SH+cable) | ~$10 | $2 |
 
 See the **[LIS3DH Inclinometer Setup Guide](inclinometer/README.md)** for wiring,
 mounting, calibration, startup flags, and troubleshooting.
@@ -128,20 +145,20 @@ One unit is mounted vertically (launch angle), one horizontally (club path / aim
 
 ## Power & Accessories
 
-| Part | Description | Link | ~Price |
-|------|-------------|------|--------|
-| **27W USB-C Power Supply** | Official Pi 5 power supply (5V 5A) | [Adafruit](https://www.adafruit.com/product/5814) | $14 |
-| MicroSD Card (32GB+) | For Pi OS and software | Any Class 10 | $10 |
-| USB-A to Micro-USB Cable | For OPS243 radar connection | Any | $5 |
+| Part | Description | Link | ~USD | ~CAD |
+|------|-------------|------|------|------|
+| **27W USB-C Power Supply** | Official Pi 5 power supply (5V 5A) | [Adafruit](https://www.adafruit.com/product/5814) · CA [PiShop.ca](https://www.pishop.ca/product/raspberry-pi-27w-usb-c-power-supply-black-us/) | $14 | $17 |
+| MicroSD Card (32GB+) | For Pi OS and software | Any Class 10 · CA [PiShop.ca](https://www.pishop.ca/product-category/raspberry-pi/sd-cards/) | $10 | $29 |
+| USB-A to Micro-USB Cable | For OPS243 radar connection | Any | $5 | $8 |
 
 ## Optional
 
-| Part | Description | Link | ~Price |
-|------|-------------|------|--------|
-| Tripod Mount | For positioning the unit | 1/4"-20 mount | $10 |
-| **Geekworm X1202 UPS HAT** | Rechargeable Pi 5 power using four matching flat-top 18650 Li-ion cells. Cells are not included | [Geekworm](https://geekworm.com/products/x1202) | ~$48 + cells |
-| **Geekworm X1206 UPS HAT** | Larger rechargeable Pi 5 power option using four matching 21700 Li-ion cells, advertised up to 20,000mAh total. Cells are not included | [Geekworm](https://geekworm.com/products/x1206) | Varies + cells |
-| **InnoMaker OV9281 global-shutter camera** | High-speed monochrome camera for experimental vision work. Camera software is not enabled in the production kiosk path | [Amazon](https://www.amazon.com/dp/B09WTP5GZH?th=1) | ~$30 |
+| Part | Description | Link | ~USD | ~CAD |
+|------|-------------|------|------|------|
+| Tripod Mount | For positioning the unit | 1/4"-20 mount | $10 | $14 |
+| **Geekworm X1202 UPS HAT** | Rechargeable Pi 5 power using four matching flat-top 18650 Li-ion cells. Cells are not included | [Geekworm](https://geekworm.com/products/x1202) | ~$48 + cells | ~$66 + cells |
+| **Geekworm X1206 UPS HAT** | Larger rechargeable Pi 5 power option using four matching 21700 Li-ion cells, advertised up to 20,000mAh total. Cells are not included | [Geekworm](https://geekworm.com/products/x1206) | Varies + cells | Varies + cells |
+| **InnoMaker OV9281 global-shutter camera** | High-speed monochrome camera for experimental vision work. Camera software is not enabled in the production kiosk path | [Amazon](https://www.amazon.com/dp/B09WTP5GZH?th=1) | ~$30 | ~$41 |
 
 See [Camera and YOLO Experiments](yolo-performance-tuning.md) before buying the
 camera; the standard setup does not install its optional software dependencies.
@@ -150,21 +167,68 @@ camera; the standard setup does not install its optional software dependencies.
 
 ## Cost Summary
 
-| Category | ~Price |
-|----------|--------|
-| Core (OPS243, Pi 5, Display) | $355 |
-| Sound Trigger (SEN-14262 + resistor + wires) | $18 |
-| Power & Accessories | $27 |
-| **Subtotal, no angle radar** | **~$400** |
-| Angle Radar (IWR6843LEVM + cable + wire) — **current** | $156 |
-| **Total with angle radar** | **~$556** |
-| Angle Radar (2× K-LD7 + FTDI adapters) — **deprecated** | $140 |
+| Category | ~USD | ~CAD |
+|----------|------|------|
+| Core (OPS243, Pi 5, Display) | $400 | $518 |
+| Sound Trigger (SEN-14262 + resistor + wires) | $18 | $29 |
+| Power & Accessories | $29 | $54 |
+| **Subtotal, no angle radar** | **~$447** | **~$601** |
+| Angle Radar (IWR6843LEVM + cable + wire) — **current** | $162 | $224 |
+| **Total with angle radar** | **~$609** | **~$825** |
+| Angle Radar (2× K-LD7 + FTDI adapters) — **deprecated** | $140 | n/a |
+
+CAD totals assume the LEVM is ordered from TI direct and exclude shipping, duty,
+brokerage, and sales tax.
 
 OpenFlight works without any angle radar: you get ball speed, club speed, smash
 factor, spin rate, and estimated carry. The angle radar adds measured launch
 angle (vertical and horizontal) and is what club path is derived from.
 
 If you are building new, buy the **IWR6843**, not the K-LD7s. It costs about the
-same as the two K-LD7s plus their FTDI adapters ($156 vs $140) and replaces both
+same as the two K-LD7s plus their FTDI adapters ($162 vs $140) and replaces both
 of them with one board. The K-LD7 path is **deprecated** and kept only so
 existing builds keep working.
+
+---
+
+## Buying in Canada
+
+Most of the build can be sourced from Canadian distributors, which avoids customs
+brokerage fees that often exceed the duty itself on low-value shipments.
+
+| Part | Canadian source | ~CAD |
+|------|-----------------|------|
+| Raspberry Pi 5 (4GB) | [PiShop.ca](https://www.pishop.ca/product/raspberry-pi-5-4gb/) | $153.95 |
+| 27W USB-C PSU | [PiShop.ca](https://www.pishop.ca/product/raspberry-pi-27w-usb-c-power-supply-black-us/) | $16.95 |
+| microSD 32GB (official, blank) | [PiShop.ca](https://www.pishop.ca/product-category/raspberry-pi/sd-cards/) | $28.95 |
+| SparkFun SEN-14262 | [DigiKey.ca](https://www.digikey.ca/en/products/detail/sparkfun-electronics/14262/7725299) | $20.76 |
+| Adafruit LIS3DH (optional) | [Elmwood Electronics](https://elmwoodelectronics.ca/search?q=LIS3DH) | $7.99 |
+| STEMMA QT / JST-SH cable (optional) | [Elmwood Electronics](https://elmwoodelectronics.ca/search?q=STEMMA+QT+JST+SH+cable) | $1.99 |
+| 7" 1024x600 IPS touchscreen | [Amazon.ca](https://www.amazon.ca/dp/B0CRRB1GFN) (equivalent, not the identical HMTECH unit) | ~$55.64 |
+
+Two parts have **no Canadian distributor** and must be imported:
+
+- **OPS243-A**: order direct from [OmniPreSense](https://omnipresense.com/product/ops243-doppler-radar-sensor/)
+  ($224 USD). As of 2026-08-22 it is listed **"Available on backorder"**, so order this
+  first: it is both the long pole and the single most expensive item.
+- **IWR6843LEVM**: order direct from [TI](https://www.ti.com/tool/IWR6843LEVM)
+  ($156.45 USD). TI ships to Canada. Do **not** buy it from DigiKey Canada at
+  $297.83 CAD unless you need it same-week.
+
+### Notes for Canadian orders
+
+- **Amazon `.com` ASINs do not map to Amazon.ca.** Every Amazon link in this document
+  is a `.com` listing, and the two that were checked both resolve to a different product
+  on the Canadian store: the display link lands on an 800x480 MIPI DSI panel rather than
+  a 1024x600 unit, and the hub link lands on a bus-powered hub. Match on
+  *specification*, not on the linked listing.
+- **DigiKey Canada** ships free on orders over $100 CAD and clears customs itself, so
+  batching the SEN-14262 with other DigiKey parts is usually worth it.
+- **Elmwood Electronics** (Toronto) stocks most Adafruit and SparkFun parts domestically
+  and is materially cheaper than importing them: the STEMMA QT cable is $1.99 CAD there
+  versus a ~$10 USD Amazon kit.
+- Prices captured **2026-08-22**; converted figures use the Bank of Canada daily rate of
+  **1.3760 USD/CAD (2026-08-21)**.
+
+The deprecated K-LD7 table is intentionally left in USD only, since those parts should
+not be bought for new builds.


### PR DESCRIPTION
While pricing out an actual build from Canada I ended up re-checking every line in `docs/PARTS.md` against its vendor. A few numbers had drifted and two of the Amazon links are misleading outside the US, so this PR fixes the pricing and adds Canadian sourcing.

### Price corrections (captured 2026-08-22 from vendor sites)

| Item | Doc said | Vendor says |
|---|---|---|
| OPS243-A | $249 | **$224** (and currently *"Available on backorder"*) |
| IWR6843LEVM | $150 | **$156.45** at TI |

The **Cost Summary did not reconcile with its own tables**. Core was listed at $355 while the three core rows summed to $425 at the old prices, and Power & Accessories at $27 against $29. Corrected USD total is **~$609**, not ~$556. Every category row now sums to its line items (I checked this programmatically).

### Canadian sourcing

Added a `~CAD` column to each table plus a **Buying in Canada** section. Most of the build is stocked domestically:

- **PiShop.ca** for the Pi 5 ($153.95), 27W PSU ($16.95), microSD ($28.95)
- **DigiKey Canada** for the SEN-14262 ($20.76, free shipping over $100 CAD)
- **Elmwood Electronics** for the LIS3DH ($7.99) and the STEMMA QT cable ($1.99, versus the ~$10 USD Amazon kit)

Two parts have no Canadian distributor and must be imported. Worth flagging: **order the LEVM from TI direct**, since DigiKey Canada lists the same board at **$297.83 CAD** against roughly $215 CAD landed from TI.

### Two link gotchas

Amazon `.com` ASINs do not carry over to Amazon.ca, and both of the ones I checked resolve to a *different product* there:

- The display link lands on an 800x480 MIPI DSI panel rather than a 1024x600 unit.
- The Layout B hub link lands on a **bus-powered** hub. That one is worth a warning on its own merits: Layout B exists precisely because the Pi cannot supply both radars, so a bus-powered hub fails to solve the problem it is there for. I added a caution note.

### Notes

- CAD values are Canadian distributor list prices where one stocks the part, otherwise the USD price converted at the Bank of Canada daily rate of **1.3760 (2026-08-21)**. Converted figures are marked `~` and exclude shipping, duty, brokerage and tax.
- The deprecated K-LD7 table is deliberately left USD-only, since those parts should not be bought for new builds.
- Docs-only change; no code or tests touched.

Happy to drop the CAD column and keep just the price corrections if you would rather not carry regional pricing in the main BOM.