### PR TITLE
feat(camera): add automatic high-speed exposure control

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Automatic OV9281 exposure control.** High-speed camera capture now measures
+  the impact area every five seconds, restores the last known-good setting at
+  startup, and selects a shutter/gain combination that preserves club contrast
+  without excessive clipping or motion blur. Large lighting changes re-enter
+  fast convergence while smaller changes require confirmation. Camera-derived
+  shot analysis is withheld when lighting is unsuitable, but radar processing
+  and shot display continue normally with an operator-facing lighting warning.
 - **Instrument-panel kiosk UI.** The dashboard is a tabbed shell (Live, Stats,
   Shots, Camera, Players, Debug) instead of the previous stacked shot and stats
   views. Tap a Live metric to pin it top-left while keeping all ten metrics

--- a/docs/camera/README.md
+++ b/docs/camera/README.md
@@ -210,9 +210,10 @@ entire usable area of a compact sensor crop.
 ## Camera Tab Controls
 
 When `--camera-capture` is enabled, the Camera tab keeps the preview visible
-beside an operator-control column. Exposure and analogue gain apply to the
-running Picamera2 pipeline without stopping the rolling buffer. The horizontal
-and vertical alignment controls move the preview guide only.
+beside an operator-control column. Exposure and analogue gain are selected
+automatically. The tab shows the current shutter, gain, impact-area brightness,
+contrast, motion-blur risk, and whether camera-assisted analysis is eligible.
+There is no manual exposure override in the UI.
 
 With the OpenFlight driver and the fixed `320x200` capture mode, **View up** and
 **View down** move the real sensor window in safe 10-pixel steps. Each move
@@ -224,13 +225,43 @@ direction printed on the button.
 
 Resolution, requested frame rate, and pre/post-trigger timing are shown as
 read-only capture provenance. Changing those values requires a controlled
-camera restart and is intentionally not part of the first live-control pass.
-The UI clamps exposure below the configured frame period.
+camera restart and is intentionally not part of the live-control path.
 
-## Exposure Calibration
+## Automatic Exposure
 
-Lighting varies too much for one universal exposure. Calibrate in the actual
-hitting environment:
+Lighting varies too much for one universal exposure. OpenFlight measures the
+center-lower impact region and selects from camera settings validated to fit
+inside the configured frame period.
+
+At startup, the controller begins with the last good setting saved for the same
+resolution and frame rate. If that setting is not usable, it can jump several
+steps and recheck after `300 ms`, rather than waiting through one five-second
+step at a time. It makes at most three fast startup adjustments.
+
+After startup, the controller:
+
+- Samples the latest stable frame every five seconds.
+- Requires two consecutive bad samples before changing a setting.
+- Moves only one validated step during normal operation.
+- Waits ten seconds after a steady-state adjustment.
+- Defers changes while a triggered post-impact camera tail is being collected.
+- Recovers automatically when lighting improves.
+
+The last good setting is stored at:
+
+```text
+~/.config/openflight/camera-exposure.json
+```
+
+If the available lighting cannot produce a usable image, OpenFlight does not
+stop the camera. Preview and raw frame capture continue, but camera-assisted
+horizontal launch, Club Path, and Attack Angle are withheld for that shot.
+Horizontal launch falls back to the IWR6843 path. The Camera tab reports
+**Lighting needed** and **Radar fallback active** so the operator can add or
+redirect light without restarting the session.
+
+The standalone calibration sweep remains useful when diagnosing an unusual
+lighting installation:
 
 ```bash
 cd ~/openflight
@@ -245,9 +276,9 @@ uv run --no-project --python /usr/bin/python3 \
   --settle-ms 150
 ```
 
-Outdoor testing favored approximately `500 us / gain 2`. Indoor testing may
-require more analogue gain, but excessive gain reduces clubhead edge quality.
-Prefer adding light to the hitting area over raising gain indefinitely.
+Prefer adding light to the hitting area over relying on long shutter times or
+high gain. Both can reduce clubhead edge quality even when the preview appears
+bright enough.
 
 ## Standalone Trigger Test
 
@@ -285,8 +316,6 @@ scripts/start-kiosk.sh \
   --camera-capture-fps 450 \
   --camera-capture-pre-ms 150 \
   --camera-capture-post-ms 50 \
-  --camera-capture-exposure-us 500 \
-  --camera-capture-gain 15 \
   --camera-capture-rotate-180 \
   --session-location home
 ```
@@ -306,7 +335,8 @@ Camera captures are written under:
 Each capture contains:
 
 - `frames.npz`: grayscale frames and per-frame timing/control metadata.
-- `metadata.json`: delivered cadence, frame gaps, brightness, timing, and settings.
+- `metadata.json`: delivered cadence, frame gaps, brightness, timing, settings,
+  and the capture-time automatic-exposure decision.
 - `first.pgm`: first buffered frame.
 - `trigger.pgm`: frame nearest the hardware trigger.
 - `last.pgm`: final post-trigger frame.
@@ -344,14 +374,16 @@ restored the stock driver. Re-run the high-speed driver installer and reboot.
 
 ### Frames are dark
 
-Use the exposure calibration script in the real hitting environment. Verify
-that the lens cap is removed and that light reaches the clubhead path, not just
-the stationary ball.
+Verify that the lens cap is removed and that light reaches the clubhead path,
+not just the stationary ball. If the Camera tab remains on **Lighting needed**
+at the brightest validated setting, add or redirect light. Preview and raw
+capture continue while radar-only measurements remain active.
 
 ### Highlights are solid white
 
-Reduce exposure first, then gain. Clipped ball and club pixels cannot provide
-reliable centroids even when the image looks bright enough to a person.
+Redirect intense light away from reflective surfaces and the ball. The
+automatic controller will move darker, but clipped ball and club pixels cannot
+provide reliable centroids even when the image looks bright enough to a person.
 
 ### Frame gaps increase
 

--- a/src/openflight/camera/auto_exposure.py
+++ b/src/openflight/camera/auto_exposure.py
@@ -1,0 +1,396 @@
+"""Deterministic exposure selection for the high-speed OV9281 camera."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+import numpy as np
+
+ExposureQualityStatus = Literal[
+    "good",
+    "marginal",
+    "too_dark",
+    "too_bright",
+    "unavailable",
+]
+ExposureRecommendation = Literal["brighter", "darker", "hold"]
+AutoExposureStatus = Literal[
+    "calibrating",
+    "ready",
+    "adjusting",
+    "lighting_required",
+    "unavailable",
+]
+
+
+@dataclass(frozen=True)
+class ExposureStep:
+    """One validated manual exposure/gain pair in increasing brightness order."""
+
+    exposure_us: int
+    gain: float
+    label: str | None = None
+
+    @property
+    def signal(self) -> float:
+        """Approximate relative image signal used for startup targeting."""
+        return self.exposure_us * self.gain
+
+    def to_dict(self) -> dict:
+        """Serialize the step for API consumers."""
+        return asdict(self)
+
+
+EXPOSURE_STEPS = (
+    ExposureStep(100, 2.0),
+    ExposureStep(150, 3.0),
+    ExposureStep(200, 3.0),
+    ExposureStep(250, 4.0, "Outdoor sun"),
+    ExposureStep(300, 5.0),
+    ExposureStep(350, 6.0, "Outdoor shade"),
+    ExposureStep(400, 8.0),
+    ExposureStep(450, 10.0, "Evening"),
+    ExposureStep(500, 12.0, "Indoor bright"),
+    ExposureStep(500, 15.0),
+    ExposureStep(650, 15.0, "Indoor dark"),
+    ExposureStep(800, 18.0),
+    ExposureStep(1000, 20.0, "Night"),
+    ExposureStep(1250, 16.0, "Facility dark"),
+)
+
+
+@dataclass(frozen=True)
+class ExposureObservation:
+    """Brightness and contrast measurements from the impact-zone ROI."""
+
+    sample_available: bool
+    status: ExposureQualityStatus
+    recommendation: ExposureRecommendation
+    message: str
+    p10: float | None = None
+    median: float | None = None
+    p90: float | None = None
+    contrast: float | None = None
+    clipped_pct: float | None = None
+    dark_pct: float | None = None
+
+    @property
+    def acceptable(self) -> bool:
+        """Whether camera-derived metrics may use frames with this exposure."""
+        return self.status in {"good", "marginal"}
+
+    def to_dict(self) -> dict:
+        """Serialize the observation for logs and the operator UI."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AutoExposureDecision:
+    """One side-effect-free controller decision."""
+
+    status: AutoExposureStatus
+    analysis_eligible: bool
+    message: str
+    observation: ExposureObservation
+    target: ExposureStep | None = None
+    motion_blur_risk: Literal["low", "elevated", "high"] = "low"
+
+    @property
+    def should_apply(self) -> bool:
+        """Whether the runtime should apply a new camera setting."""
+        return self.target is not None
+
+    def to_dict(self) -> dict:
+        """Serialize the decision for status and logging."""
+        payload = {
+            "status": self.status,
+            "analysis_eligible": self.analysis_eligible,
+            "message": self.message,
+            "motion_blur_risk": self.motion_blur_risk,
+            "observation": self.observation.to_dict(),
+        }
+        payload["target"] = self.target.to_dict() if self.target else None
+        return payload
+
+
+def exposure_steps_for_fps(fps: float) -> tuple[ExposureStep, ...]:
+    """Return ladder entries that fit inside the requested frame period."""
+    if fps <= 0:
+        raise ValueError("camera FPS must be positive")
+    frame_period_us = round(1_000_000 / fps)
+    steps = tuple(step for step in EXPOSURE_STEPS if step.exposure_us < frame_period_us)
+    if not steps:
+        raise ValueError(f"no exposure steps fit inside the {frame_period_us}us frame period")
+    return steps
+
+
+def measure_exposure(image: np.ndarray) -> ExposureObservation:
+    """Rate exposure in the center-lower hitting zone of one grayscale frame."""
+    pixels = np.asarray(image)
+    if pixels.ndim != 2 or not pixels.size:
+        return ExposureObservation(
+            sample_available=False,
+            status="unavailable",
+            recommendation="hold",
+            message="Waiting for a camera frame",
+        )
+
+    height, width = pixels.shape
+    region = pixels[
+        round(height * 0.45) : round(height * 0.9),
+        round(width * 0.2) : round(width * 0.8),
+    ]
+    if not region.size:
+        return ExposureObservation(
+            sample_available=False,
+            status="unavailable",
+            recommendation="hold",
+            message="Impact-area exposure region is unavailable",
+        )
+
+    p10, median, p90 = (float(np.percentile(region, value)) for value in (10, 50, 90))
+    clipped_pct = float(np.mean(region >= 250) * 100.0)
+    dark_pct = float(np.mean(region <= 12) * 100.0)
+    contrast = p90 - p10
+
+    if clipped_pct >= 8.0 or median >= 205.0:
+        status: ExposureQualityStatus = "too_bright"
+        recommendation: ExposureRecommendation = "darker"
+        message = "Impact area is clipping; reducing exposure"
+    elif p90 < 75.0 or median < 28.0 or contrast < 30.0:
+        status = "too_dark"
+        recommendation = "brighter"
+        if p90 <= 12.0 and dark_pct >= 90.0:
+            message = "Camera view is nearly black; check lighting and the lens cover"
+        else:
+            message = "Club contrast is low; increasing exposure"
+    elif clipped_pct <= 2.0 and 45.0 <= median <= 180.0 and p90 >= 100.0:
+        status = "good"
+        recommendation = "hold"
+        message = "Impact-area exposure and contrast look good"
+    else:
+        status = "marginal"
+        recommendation = "darker" if clipped_pct > 2.0 or median > 180.0 else "brighter"
+        message = f"Exposure is usable; monitoring for a {recommendation} adjustment"
+
+    return ExposureObservation(
+        sample_available=True,
+        status=status,
+        recommendation=recommendation,
+        message=message,
+        p10=round(p10, 1),
+        median=round(median, 1),
+        p90=round(p90, 1),
+        contrast=round(contrast, 1),
+        clipped_pct=round(clipped_pct, 2),
+        dark_pct=round(dark_pct, 2),
+    )
+
+
+def motion_blur_risk(exposure_us: int) -> Literal["low", "elevated", "high"]:
+    """Describe the clubhead blur risk introduced by shutter duration."""
+    if exposure_us > 800:
+        return "high"
+    if exposure_us > 500:
+        return "elevated"
+    return "low"
+
+
+class AutoExposurePolicy:
+    """Choose startup jumps and conservative steady-state adjustments."""
+
+    def __init__(
+        self,
+        *,
+        fps: float,
+        startup_max_adjustments: int = 3,
+        steady_confirmations: int = 2,
+    ):
+        if startup_max_adjustments < 1:
+            raise ValueError("startup_max_adjustments must be positive")
+        if steady_confirmations < 1:
+            raise ValueError("steady_confirmations must be positive")
+        self.steps = exposure_steps_for_fps(fps)
+        self.startup_max_adjustments = startup_max_adjustments
+        self.steady_confirmations = steady_confirmations
+        self._startup = True
+        self._startup_adjustments = 0
+        self._pending_recommendation: ExposureRecommendation = "hold"
+        self._pending_count = 0
+
+    def reset(self) -> None:
+        """Restart fast convergence after a material scene change."""
+        self._startup = True
+        self._startup_adjustments = 0
+        self._pending_recommendation = "hold"
+        self._pending_count = 0
+
+    def evaluate(
+        self,
+        observation: ExposureObservation,
+        *,
+        exposure_us: int,
+        gain: float,
+    ) -> AutoExposureDecision:
+        """Return the next camera-control decision without applying it."""
+        current_index = self._nearest_step_index(exposure_us, gain)
+        current_step = self.steps[current_index]
+        risk = motion_blur_risk(current_step.exposure_us)
+
+        if not observation.sample_available:
+            return AutoExposureDecision(
+                status="unavailable",
+                analysis_eligible=False,
+                message=observation.message,
+                observation=observation,
+                motion_blur_risk=risk,
+            )
+
+        if observation.acceptable:
+            self._startup = False
+            self._startup_adjustments = 0
+            self._pending_recommendation = "hold"
+            self._pending_count = 0
+            return AutoExposureDecision(
+                status="ready",
+                analysis_eligible=True,
+                message=observation.message,
+                observation=observation,
+                motion_blur_risk=risk,
+            )
+
+        if self._startup:
+            return self._startup_decision(observation, current_index)
+        return self._steady_decision(observation, current_index)
+
+    def _startup_decision(
+        self,
+        observation: ExposureObservation,
+        current_index: int,
+    ) -> AutoExposureDecision:
+        current = self.steps[current_index]
+        risk = motion_blur_risk(current.exposure_us)
+        if self._startup_adjustments >= self.startup_max_adjustments:
+            return AutoExposureDecision(
+                status="lighting_required",
+                analysis_eligible=False,
+                message=self._lighting_message(observation),
+                observation=observation,
+                motion_blur_risk=risk,
+            )
+
+        target_index = self._startup_target_index(observation, current_index)
+        if target_index == current_index:
+            return AutoExposureDecision(
+                status="lighting_required",
+                analysis_eligible=False,
+                message=self._lighting_message(observation),
+                observation=observation,
+                motion_blur_risk=risk,
+            )
+
+        self._startup_adjustments += 1
+        target = self.steps[target_index]
+        return AutoExposureDecision(
+            status="adjusting",
+            analysis_eligible=False,
+            message=(
+                "Calibrating camera exposure "
+                f"({self._startup_adjustments}/{self.startup_max_adjustments})"
+            ),
+            observation=observation,
+            target=target,
+            motion_blur_risk=motion_blur_risk(target.exposure_us),
+        )
+
+    def _steady_decision(
+        self,
+        observation: ExposureObservation,
+        current_index: int,
+    ) -> AutoExposureDecision:
+        if observation.recommendation != self._pending_recommendation:
+            self._pending_recommendation = observation.recommendation
+            self._pending_count = 1
+        else:
+            self._pending_count += 1
+
+        current = self.steps[current_index]
+        risk = motion_blur_risk(current.exposure_us)
+        if self._pending_count < self.steady_confirmations:
+            return AutoExposureDecision(
+                status="calibrating",
+                analysis_eligible=False,
+                message="Confirming the lighting change before adjusting",
+                observation=observation,
+                motion_blur_risk=risk,
+            )
+
+        direction = 1 if observation.recommendation == "brighter" else -1
+        target_index = max(0, min(len(self.steps) - 1, current_index + direction))
+        self._pending_count = 0
+        self._pending_recommendation = "hold"
+        if target_index == current_index:
+            return AutoExposureDecision(
+                status="lighting_required",
+                analysis_eligible=False,
+                message=self._lighting_message(observation),
+                observation=observation,
+                motion_blur_risk=risk,
+            )
+
+        target = self.steps[target_index]
+        return AutoExposureDecision(
+            status="adjusting",
+            analysis_eligible=False,
+            message=f"Adjusting camera {observation.recommendation}",
+            observation=observation,
+            target=target,
+            motion_blur_risk=motion_blur_risk(target.exposure_us),
+        )
+
+    def _startup_target_index(
+        self,
+        observation: ExposureObservation,
+        current_index: int,
+    ) -> int:
+        current = self.steps[current_index]
+        median = max(float(observation.median or 1.0), 1.0)
+        target_signal = current.signal * max(0.125, min(8.0, 110.0 / median))
+        target_index = min(
+            range(len(self.steps)),
+            key=lambda index: abs(math.log(self.steps[index].signal / target_signal)),
+        )
+        if observation.recommendation == "brighter":
+            return (
+                max(current_index + 1, target_index)
+                if current_index < len(self.steps) - 1
+                else current_index
+            )
+        if observation.recommendation == "darker":
+            return min(current_index - 1, target_index) if current_index > 0 else current_index
+        return current_index
+
+    def _nearest_step_index(self, exposure_us: int, gain: float) -> int:
+        exact_index = next(
+            (
+                index
+                for index, step in enumerate(self.steps)
+                if step.exposure_us == exposure_us and math.isclose(step.gain, gain)
+            ),
+            None,
+        )
+        if exact_index is not None:
+            return exact_index
+        signal = max(float(exposure_us) * float(gain), 1.0)
+        return min(
+            range(len(self.steps)),
+            key=lambda index: abs(math.log(self.steps[index].signal / signal)),
+        )
+
+    @staticmethod
+    def _lighting_message(observation: ExposureObservation) -> str:
+        if observation.status == "too_dark":
+            return "Camera lighting is insufficient; add or redirect light toward the ball"
+        return "Camera view is overexposed; reduce or redirect light near the ball"

--- a/src/openflight/camera/auto_exposure.py
+++ b/src/openflight/camera/auto_exposure.py
@@ -215,6 +215,11 @@ class AutoExposurePolicy:
         self.steps = exposure_steps_for_fps(fps)
         self.startup_max_adjustments = startup_max_adjustments
         self.steady_confirmations = steady_confirmations
+        self._fast_reacquire_armed = False
+        self._reset_startup_state()
+
+    def _reset_startup_state(self) -> None:
+        """Enter startup convergence without rearming scene-change detection."""
         self._startup = True
         self._startup_adjustments = 0
         self._pending_recommendation: ExposureRecommendation = "hold"
@@ -222,10 +227,8 @@ class AutoExposurePolicy:
 
     def reset(self) -> None:
         """Restart fast convergence after a material scene change."""
-        self._startup = True
-        self._startup_adjustments = 0
-        self._pending_recommendation = "hold"
-        self._pending_count = 0
+        self._reset_startup_state()
+        self._fast_reacquire_armed = False
 
     @property
     def startup(self) -> bool:
@@ -258,6 +261,7 @@ class AutoExposurePolicy:
             self._startup_adjustments = 0
             self._pending_recommendation = "hold"
             self._pending_count = 0
+            self._fast_reacquire_armed = True
             return AutoExposureDecision(
                 status="ready",
                 analysis_eligible=True,
@@ -268,7 +272,23 @@ class AutoExposurePolicy:
 
         if self._startup:
             return self._startup_decision(observation, current_index)
+        if self._fast_reacquire_armed and self._is_material_change(
+            observation,
+            current_index,
+        ):
+            self._reset_startup_state()
+            self._fast_reacquire_armed = False
+            return self._startup_decision(observation, current_index)
         return self._steady_decision(observation, current_index)
+
+    def _is_material_change(
+        self,
+        observation: ExposureObservation,
+        current_index: int,
+    ) -> bool:
+        """Return whether the measured scene needs a multi-step correction."""
+        target_index = self._startup_target_index(observation, current_index)
+        return abs(target_index - current_index) >= 2
 
     def _startup_decision(
         self,

--- a/src/openflight/camera/auto_exposure.py
+++ b/src/openflight/camera/auto_exposure.py
@@ -227,6 +227,11 @@ class AutoExposurePolicy:
         self._pending_recommendation = "hold"
         self._pending_count = 0
 
+    @property
+    def startup(self) -> bool:
+        """Whether the policy is still using fast startup convergence."""
+        return self._startup
+
     def evaluate(
         self,
         observation: ExposureObservation,
@@ -273,6 +278,7 @@ class AutoExposurePolicy:
         current = self.steps[current_index]
         risk = motion_blur_risk(current.exposure_us)
         if self._startup_adjustments >= self.startup_max_adjustments:
+            self._startup = False
             return AutoExposureDecision(
                 status="lighting_required",
                 analysis_eligible=False,
@@ -283,6 +289,7 @@ class AutoExposurePolicy:
 
         target_index = self._startup_target_index(observation, current_index)
         if target_index == current_index:
+            self._startup = False
             return AutoExposureDecision(
                 status="lighting_required",
                 analysis_eligible=False,

--- a/src/openflight/camera/capture_runtime.py
+++ b/src/openflight/camera/capture_runtime.py
@@ -552,7 +552,6 @@ class CameraCaptureRuntime:
     def _auto_exposure_loop(self) -> None:
         delay_s = 0.0
         while self._running and not self._auto_exposure_stop.wait(delay_s):
-            startup = self._auto_exposure_policy.startup
             try:
                 decision = self._run_auto_exposure_cycle()
             except Exception:  # pylint: disable=broad-exception-caught
@@ -562,7 +561,7 @@ class CameraCaptureRuntime:
 
             if decision is None:
                 delay_s = 0.1
-            elif decision.should_apply and startup:
+            elif decision.should_apply and self._auto_exposure_policy.startup:
                 delay_s = AUTO_EXPOSURE_STARTUP_SETTLE_S
             elif decision.should_apply:
                 delay_s = AUTO_EXPOSURE_ADJUSTMENT_COOLDOWN_S

--- a/src/openflight/camera/capture_runtime.py
+++ b/src/openflight/camera/capture_runtime.py
@@ -16,6 +16,13 @@ from typing import Callable, Literal
 
 import numpy as np
 
+from openflight.camera.auto_exposure import (
+    AutoExposureDecision,
+    AutoExposurePolicy,
+    ExposureObservation,
+    measure_exposure,
+    motion_blur_risk,
+)
 from openflight.camera.triggered_buffer import (
     CameraFrame,
     TriggeredCapture,
@@ -32,6 +39,9 @@ CameraCaptureStream = Literal["raw", "main-y"]
 
 RASPBERRY_PI_DIST_PACKAGES = Path("/usr/lib/python3/dist-packages")
 OV9281_VERTICAL_OFFSET_PATH = Path("/sys/module/ov9282/parameters/strip_y_offset")
+AUTO_EXPOSURE_SAMPLE_INTERVAL_S = 5.0
+AUTO_EXPOSURE_STARTUP_SETTLE_S = 0.3
+AUTO_EXPOSURE_ADJUSTMENT_COOLDOWN_S = 10.0
 
 
 def vertical_crop_limits(width: int, height: int) -> dict[str, int] | None:
@@ -60,6 +70,7 @@ class CameraCaptureSettings:
     scaler_crop: tuple[int, int, int, int] | None = None
     gpio_pin: int = 17
     match_tolerance_s: float = 0.75
+    auto_exposure: bool = True
 
     @property
     def pre_frames(self) -> int:
@@ -152,6 +163,25 @@ class CameraCaptureRuntime:
         self._trigger_epochs: queue.Queue[float] = queue.Queue()
         self._camera_control_lock = threading.Lock()
         self._reconfigure_lock = threading.Lock()
+        self._auto_exposure_policy = AutoExposurePolicy(fps=self.settings.fps)
+        self._auto_exposure_stop = threading.Event()
+        self._auto_exposure_worker: threading.Thread | None = None
+        self._auto_exposure_lock = threading.Lock()
+        self._auto_exposure_decision = AutoExposureDecision(
+            status="unavailable",
+            analysis_eligible=not self.settings.auto_exposure,
+            message="Waiting for automatic exposure calibration",
+            observation=ExposureObservation(
+                sample_available=False,
+                status="unavailable",
+                recommendation="hold",
+                message="Waiting for a camera frame",
+            ),
+            motion_blur_risk=motion_blur_risk(self.settings.exposure_us),
+        )
+        self._auto_exposure_last_check_epoch: float | None = None
+        self._auto_exposure_last_adjustment_epoch: float | None = None
+        self._auto_exposure_capture_deferred = False
 
     def start(self) -> None:
         """Start the camera and, optionally, the GPIO edge listener."""
@@ -193,6 +223,8 @@ class CameraCaptureRuntime:
         try:
             self._camera.start()
             self._wait_for_prebuffer()
+            if self.settings.auto_exposure:
+                self._start_auto_exposure()
             if self._use_gpio_trigger:
                 self._start_gpio_trigger()
         except Exception:
@@ -211,6 +243,10 @@ class CameraCaptureRuntime:
     def stop(self) -> None:
         """Stop camera capture and release hardware resources."""
         self._running = False
+        self._auto_exposure_stop.set()
+        if self._auto_exposure_worker is not None:
+            self._auto_exposure_worker.join(timeout=3.0)
+            self._auto_exposure_worker = None
         if self._button is not None:
             self._button.close()
             self._button = None
@@ -265,53 +301,32 @@ class CameraCaptureRuntime:
     def exposure_quality(self) -> dict:
         """Rate exposure in the center-lower hitting zone of the latest frame."""
         frame = self._ring.latest_frame
-        if frame is None:
-            return {
-                "sample_available": False,
-                "status": "unavailable",
-                "recommendation": "hold",
-                "message": "Waiting for a camera frame",
-            }
+        image = frame.image if frame is not None else np.asarray([])
+        return measure_exposure(image).to_dict()
 
-        image = np.asarray(frame.image)
-        height, width = image.shape
-        region = image[
-            round(height * 0.45) : round(height * 0.9),
-            round(width * 0.2) : round(width * 0.8),
-        ]
-        p10, median, p90 = (float(np.percentile(region, value)) for value in (10, 50, 90))
-        clipped_pct = float(np.mean(region >= 250) * 100.0)
-        dark_pct = float(np.mean(region <= 12) * 100.0)
-        contrast = p90 - p10
+    @property
+    def camera_analysis_eligible(self) -> bool:
+        """Whether current lighting permits camera-derived shot metrics."""
+        if not self.settings.auto_exposure:
+            return True
+        with self._auto_exposure_lock:
+            return self._auto_exposure_decision.analysis_eligible
 
-        if clipped_pct >= 8.0 or median >= 205.0:
-            status = "too_bright"
-            recommendation = "darker"
-            message = "Impact area is clipping; move one step darker"
-        elif p90 < 75.0 or median < 28.0 or contrast < 30.0:
-            status = "too_dark"
-            recommendation = "brighter"
-            message = "Club contrast is low; move one step brighter"
-        elif clipped_pct <= 2.0 and 45.0 <= median <= 180.0 and p90 >= 100.0:
-            status = "good"
-            recommendation = "hold"
-            message = "Impact-area exposure and contrast look good"
-        else:
-            status = "marginal"
-            recommendation = "darker" if clipped_pct > 2.0 or median > 180.0 else "brighter"
-            message = f"Usable, but try one step {recommendation}"
-
-        return {
-            "sample_available": True,
-            "status": status,
-            "recommendation": recommendation,
-            "message": message,
-            "median": round(median, 1),
-            "p90": round(p90, 1),
-            "contrast": round(contrast, 1),
-            "clipped_pct": round(clipped_pct, 2),
-            "dark_pct": round(dark_pct, 2),
-        }
+    def auto_exposure_status(self) -> dict:
+        """Return controller state for diagnostics and the operator UI."""
+        with self._auto_exposure_lock:
+            payload = self._auto_exposure_decision.to_dict()
+            payload.update(
+                {
+                    "enabled": self.settings.auto_exposure,
+                    "capture_deferred": self._auto_exposure_capture_deferred,
+                    "last_check_timestamp": self._auto_exposure_last_check_epoch,
+                    "last_adjustment_timestamp": self._auto_exposure_last_adjustment_epoch,
+                }
+            )
+        payload["exposure_us"] = self.settings.exposure_us
+        payload["gain"] = self.settings.gain
+        return payload
 
     def update_image_controls(self, *, exposure_us: int, gain: float) -> dict:
         """Apply exposure and gain without stopping the rolling buffer."""
@@ -426,6 +441,7 @@ class CameraCaptureRuntime:
         self._ring = TriggeredFrameBuffer(self.settings.pre_frames, self.settings.post_frames)
         self._ready = queue.Queue()
         self._trigger_epochs = queue.Queue()
+        self._auto_exposure_policy.reset()
 
     def status(self) -> dict:
         """Return lightweight state for the operator UI."""
@@ -435,6 +451,7 @@ class CameraCaptureRuntime:
             "armed": self._running and buffered_frames >= self.settings.pre_frames,
             "buffered_frames": buffered_frames,
             "required_pre_frames": self.settings.pre_frames,
+            "auto_exposure": self.auto_exposure_status(),
         }
 
     def notify_trigger(self, timestamp: float | None = None) -> bool:
@@ -511,6 +528,77 @@ class CameraCaptureRuntime:
                 "camera produced only "
                 f"{self._ring.buffered_frames}/{self.settings.pre_frames} pre-trigger frames"
             )
+
+    def _start_auto_exposure(self) -> None:
+        """Start non-blocking exposure calibration and monitoring."""
+        self._auto_exposure_policy.reset()
+        self._auto_exposure_stop.clear()
+        self._auto_exposure_worker = threading.Thread(
+            target=self._auto_exposure_loop,
+            name="camera-auto-exposure",
+            daemon=True,
+        )
+        self._auto_exposure_worker.start()
+
+    def _auto_exposure_loop(self) -> None:
+        delay_s = 0.0
+        while self._running and not self._auto_exposure_stop.wait(delay_s):
+            startup = self._auto_exposure_policy.startup
+            try:
+                decision = self._run_auto_exposure_cycle()
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.warning("[CAMERA] Automatic exposure check failed", exc_info=True)
+                delay_s = AUTO_EXPOSURE_SAMPLE_INTERVAL_S
+                continue
+
+            if decision is None:
+                delay_s = 0.1
+            elif decision.should_apply and startup:
+                delay_s = AUTO_EXPOSURE_STARTUP_SETTLE_S
+            elif decision.should_apply:
+                delay_s = AUTO_EXPOSURE_ADJUSTMENT_COOLDOWN_S
+            else:
+                delay_s = AUTO_EXPOSURE_SAMPLE_INTERVAL_S
+
+    def _run_auto_exposure_cycle(self) -> AutoExposureDecision | None:
+        """Measure one stable frame and apply the policy's requested control step."""
+        if self._ring.capture_busy:
+            with self._auto_exposure_lock:
+                self._auto_exposure_capture_deferred = True
+            return None
+
+        frame = self._ring.latest_frame
+        observation = measure_exposure(
+            frame.image if frame is not None else np.asarray([]),
+        )
+        decision = self._auto_exposure_policy.evaluate(
+            observation,
+            exposure_us=self.settings.exposure_us,
+            gain=self.settings.gain,
+        )
+        checked_at = time.time()
+        if decision.should_apply:
+            self.update_image_controls(
+                exposure_us=decision.target.exposure_us,
+                gain=decision.target.gain,
+            )
+            logger.info(
+                "[CAMERA] Auto exposure: %s -> %dus gain %.1f (%s)",
+                observation.status,
+                decision.target.exposure_us,
+                decision.target.gain,
+                decision.message,
+            )
+        elif decision.status == "lighting_required":
+            logger.warning("[CAMERA] %s", decision.message)
+
+        with self._auto_exposure_lock:
+            self._auto_exposure_decision = decision
+            self._auto_exposure_capture_deferred = False
+            self._auto_exposure_last_check_epoch = checked_at
+            if decision.should_apply:
+                self._auto_exposure_last_adjustment_epoch = checked_at
+        return decision
 
     def _on_frame(self, request) -> None:
         try:

--- a/src/openflight/camera/capture_runtime.py
+++ b/src/openflight/camera/capture_runtime.py
@@ -171,6 +171,7 @@ class CameraCaptureRuntime:
         self._trigger_epochs: queue.Queue[float] = queue.Queue()
         self._trigger_auto_exposure: queue.Queue[dict] = queue.Queue()
         self._camera_control_lock = threading.Lock()
+        self._trigger_exposure_lock = threading.Lock()
         self._reconfigure_lock = threading.Lock()
         self._auto_exposure_policy = AutoExposurePolicy(fps=self.settings.fps)
         self._auto_exposure_stop = threading.Event()
@@ -469,13 +470,14 @@ class CameraCaptureRuntime:
         if not self._running:
             return False
         trigger_epoch = time.time() if timestamp is None else float(timestamp)
-        accepted = self._ring.trigger(time.monotonic_ns())
-        if not accepted:
-            logger.debug("[CAMERA] Ignoring trigger edge while capture is busy")
-            return False
-        self._trigger_epochs.put(trigger_epoch)
-        self._trigger_auto_exposure.put(self.auto_exposure_status())
-        return True
+        with self._trigger_exposure_lock:
+            accepted = self._ring.trigger(time.monotonic_ns())
+            if not accepted:
+                logger.debug("[CAMERA] Ignoring trigger edge while capture is busy")
+                return False
+            self._trigger_epochs.put(trigger_epoch)
+            self._trigger_auto_exposure.put(self.auto_exposure_status())
+            return True
 
     def capture_for_shot(
         self,
@@ -569,42 +571,43 @@ class CameraCaptureRuntime:
 
     def _run_auto_exposure_cycle(self) -> AutoExposureDecision | None:
         """Measure one stable frame and apply the policy's requested control step."""
-        if self._ring.capture_busy:
-            with self._auto_exposure_lock:
-                self._auto_exposure_capture_deferred = True
-            return None
+        with self._trigger_exposure_lock:
+            if self._ring.capture_busy:
+                with self._auto_exposure_lock:
+                    self._auto_exposure_capture_deferred = True
+                return None
 
-        frame = self._ring.latest_frame
-        observation = measure_exposure(
-            frame.image if frame is not None else np.asarray([]),
-        )
-        decision = self._auto_exposure_policy.evaluate(
-            observation,
-            exposure_us=self.settings.exposure_us,
-            gain=self.settings.gain,
-        )
-        checked_at = time.time()
-        if decision.should_apply:
-            self.update_image_controls(
-                exposure_us=decision.target.exposure_us,
-                gain=decision.target.gain,
+            frame = self._ring.latest_frame
+            observation = measure_exposure(
+                frame.image if frame is not None else np.asarray([]),
             )
-            logger.info(
-                "[CAMERA] Auto exposure: %s -> %dus gain %.1f (%s)",
-                observation.status,
-                decision.target.exposure_us,
-                decision.target.gain,
-                decision.message,
+            decision = self._auto_exposure_policy.evaluate(
+                observation,
+                exposure_us=self.settings.exposure_us,
+                gain=self.settings.gain,
             )
-        elif decision.status == "lighting_required":
-            logger.warning("[CAMERA] %s", decision.message)
-
-        with self._auto_exposure_lock:
-            self._auto_exposure_decision = decision
-            self._auto_exposure_capture_deferred = False
-            self._auto_exposure_last_check_epoch = checked_at
             if decision.should_apply:
-                self._auto_exposure_last_adjustment_epoch = checked_at
+                self.update_image_controls(
+                    exposure_us=decision.target.exposure_us,
+                    gain=decision.target.gain,
+                )
+                logger.info(
+                    "[CAMERA] Auto exposure: %s -> %dus gain %.1f (%s)",
+                    observation.status,
+                    decision.target.exposure_us,
+                    decision.target.gain,
+                    decision.message,
+                )
+            elif decision.status == "lighting_required":
+                logger.warning("[CAMERA] %s", decision.message)
+
+            checked_at = time.time()
+            with self._auto_exposure_lock:
+                self._auto_exposure_decision = decision
+                self._auto_exposure_capture_deferred = False
+                self._auto_exposure_last_check_epoch = checked_at
+                if decision.should_apply:
+                    self._auto_exposure_last_adjustment_epoch = checked_at
         if decision.status == "ready" and observation.status == "good":
             self._persist_auto_exposure_controls()
         return decision

--- a/src/openflight/camera/capture_runtime.py
+++ b/src/openflight/camera/capture_runtime.py
@@ -71,6 +71,7 @@ class CameraCaptureSettings:
     gpio_pin: int = 17
     match_tolerance_s: float = 0.75
     auto_exposure: bool = True
+    auto_exposure_state_path: Path | None = None
 
     @property
     def pre_frames(self) -> int:
@@ -151,6 +152,13 @@ class CameraCaptureRuntime:
         self._button_factory = button_factory
         self._use_gpio_trigger = use_gpio_trigger
         self._vertical_offset_path = Path(vertical_offset_path)
+        self._auto_exposure_state_path = (
+            Path(self.settings.auto_exposure_state_path).expanduser()
+            if self.settings.auto_exposure_state_path is not None
+            else None
+        )
+        self._last_persisted_controls: tuple[int, float] | None = None
+        self._restore_auto_exposure_controls()
         self._camera = None
         self._button = None
         self._ring = TriggeredFrameBuffer(self.settings.pre_frames, self.settings.post_frames)
@@ -161,6 +169,7 @@ class CameraCaptureRuntime:
         self._captures: list[SavedCameraCapture] = []
         self._condition = threading.Condition()
         self._trigger_epochs: queue.Queue[float] = queue.Queue()
+        self._trigger_auto_exposure: queue.Queue[dict] = queue.Queue()
         self._camera_control_lock = threading.Lock()
         self._reconfigure_lock = threading.Lock()
         self._auto_exposure_policy = AutoExposurePolicy(fps=self.settings.fps)
@@ -441,6 +450,7 @@ class CameraCaptureRuntime:
         self._ring = TriggeredFrameBuffer(self.settings.pre_frames, self.settings.post_frames)
         self._ready = queue.Queue()
         self._trigger_epochs = queue.Queue()
+        self._trigger_auto_exposure = queue.Queue()
         self._auto_exposure_policy.reset()
 
     def status(self) -> dict:
@@ -459,15 +469,12 @@ class CameraCaptureRuntime:
         if not self._running:
             return False
         trigger_epoch = time.time() if timestamp is None else float(timestamp)
-        self._trigger_epochs.put(trigger_epoch)
         accepted = self._ring.trigger(time.monotonic_ns())
         if not accepted:
-            try:
-                self._trigger_epochs.get_nowait()
-            except queue.Empty:
-                pass
             logger.debug("[CAMERA] Ignoring trigger edge while capture is busy")
             return False
+        self._trigger_epochs.put(trigger_epoch)
+        self._trigger_auto_exposure.put(self.auto_exposure_status())
         return True
 
     def capture_for_shot(
@@ -598,7 +605,63 @@ class CameraCaptureRuntime:
             self._auto_exposure_last_check_epoch = checked_at
             if decision.should_apply:
                 self._auto_exposure_last_adjustment_epoch = checked_at
+        if decision.status == "ready" and observation.status == "good":
+            self._persist_auto_exposure_controls()
         return decision
+
+    def _restore_auto_exposure_controls(self) -> None:
+        """Use the last good setting as the next startup seed for this mode."""
+        path = self._auto_exposure_state_path
+        if not self.settings.auto_exposure or path is None or not path.exists():
+            return
+        try:
+            saved = json.loads(path.read_text(encoding="utf-8"))
+            same_mode = (
+                saved.get("version") == 1
+                and int(saved["width"]) == self.settings.width
+                and int(saved["height"]) == self.settings.height
+                and math.isclose(float(saved["fps"]), self.settings.fps, rel_tol=0.001)
+            )
+            exposure_us = int(saved["exposure_us"])
+            gain = float(saved["gain"])
+            frame_period_us = round(1_000_000 / self.settings.fps)
+            if same_mode and 0 < exposure_us < frame_period_us and gain > 0:
+                self.settings = replace(
+                    self.settings,
+                    exposure_us=exposure_us,
+                    gain=gain,
+                )
+                self._last_persisted_controls = (exposure_us, gain)
+                logger.info(
+                    "[CAMERA] Restored auto exposure seed: %dus gain %.1f",
+                    exposure_us,
+                    gain,
+                )
+        except (KeyError, TypeError, ValueError, OSError, json.JSONDecodeError):
+            logger.warning("[CAMERA] Ignoring invalid auto exposure state: %s", path)
+
+    def _persist_auto_exposure_controls(self) -> None:
+        """Atomically remember a validated setting without delaying capture."""
+        path = self._auto_exposure_state_path
+        controls = (self.settings.exposure_us, self.settings.gain)
+        if path is None or controls == self._last_persisted_controls:
+            return
+        payload = {
+            "version": 1,
+            "width": self.settings.width,
+            "height": self.settings.height,
+            "fps": self.settings.fps,
+            "exposure_us": controls[0],
+            "gain": controls[1],
+        }
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            temporary = path.with_suffix(f"{path.suffix}.tmp")
+            temporary.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+            temporary.replace(path)
+            self._last_persisted_controls = controls
+        except OSError:
+            logger.warning("[CAMERA] Could not persist auto exposure state", exc_info=True)
 
     def _on_frame(self, request) -> None:
         try:
@@ -640,10 +703,20 @@ class CameraCaptureRuntime:
             if capture is None:
                 break
             trigger_epoch = self._trigger_epochs.get() if not self._trigger_epochs.empty() else 0.0
+            auto_exposure = (
+                self._trigger_auto_exposure.get()
+                if not self._trigger_auto_exposure.empty()
+                else None
+            )
             self._sequence += 1
             sequence = self._sequence
             try:
-                saved = self._save_capture(sequence, trigger_epoch, capture)
+                saved = self._save_capture(
+                    sequence,
+                    trigger_epoch,
+                    capture,
+                    auto_exposure=auto_exposure,
+                )
             except Exception as exc:  # pylint: disable=broad-except
                 logger.warning("[CAMERA] Capture #%d save failed: %s", sequence, exc, exc_info=True)
                 saved = SavedCameraCapture(
@@ -663,6 +736,8 @@ class CameraCaptureRuntime:
         sequence: int,
         trigger_epoch: float,
         capture: TriggeredCapture,
+        *,
+        auto_exposure: dict | None = None,
     ) -> SavedCameraCapture:
         timestamp = datetime.fromtimestamp(trigger_epoch or time.time()).strftime(
             "%Y%m%d_%H%M%S_%f"
@@ -733,7 +808,9 @@ class CameraCaptureRuntime:
                     "mirror_horizontal": self.settings.mirror_horizontal,
                     "roll_correction_deg": self.settings.roll_correction_deg,
                     "scaler_crop": self.settings.scaler_crop,
+                    "auto_exposure": self.settings.auto_exposure,
                 },
+                "auto_exposure": auto_exposure or self.auto_exposure_status(),
             }
         )
         (shot_dir / "metadata.json").write_text(json.dumps(summary, indent=2) + "\n")

--- a/src/openflight/camera/triggered_buffer.py
+++ b/src/openflight/camera/triggered_buffer.py
@@ -62,6 +62,12 @@ class TriggeredFrameBuffer:
             return len(self._pre)
 
     @property
+    def capture_busy(self) -> bool:
+        """Whether a triggered post-impact tail is still being collected."""
+        with self._condition:
+            return self._capturing
+
+    @property
     def latest_frame(self) -> Optional[CameraFrame]:
         """Most recent frame available without disturbing capture state."""
         with self._condition:

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -1127,6 +1127,9 @@ def init_camera_capture(
             roll_correction_deg=roll_correction_deg,
             scaler_crop=scaler_crop,
             gpio_pin=gpio_pin,
+            auto_exposure_state_path=(
+                Path.home() / ".config" / "openflight" / "camera-exposure.json"
+            ),
         )
         camera_capture_runtime = CameraCaptureRuntime(
             output_dir=output_dir,
@@ -1134,6 +1137,7 @@ def init_camera_capture(
             use_gpio_trigger=use_gpio_trigger,
         )
         camera_capture_runtime.start()
+        settings = camera_capture_runtime.settings
         from openflight.camera.club_delivery import (  # noqa: PLC0415
             ReferenceBallTracker,
         )
@@ -1154,6 +1158,7 @@ def init_camera_capture(
             "post_frames": settings.post_frames,
             "exposure_us": settings.exposure_us,
             "gain": settings.gain,
+            "auto_exposure_enabled": settings.auto_exposure,
             "stream": settings.stream,
             "rotate_180": settings.rotate_180,
             "mirror_horizontal": settings.mirror_horizontal,
@@ -1568,10 +1573,12 @@ def camera_capture_preview():
 
 @app.route("/api/camera/exposure-quality")
 def camera_capture_exposure_quality():
-    """Exposure guidance derived from the latest raw impact-zone pixels."""
+    """Automatic exposure state derived from the latest impact-zone pixels."""
     if camera_capture_runtime is None:
         return jsonify({"sample_available": False, "status": "unavailable"}), 404
-    return jsonify(camera_capture_runtime.exposure_quality())
+    quality = camera_capture_runtime.exposure_quality()
+    quality["auto_exposure"] = camera_capture_runtime.auto_exposure_status()
+    return jsonify(quality)
 
 
 def _camera_capture_settings_payload() -> dict:
@@ -1583,6 +1590,16 @@ def _camera_capture_settings_payload() -> dict:
     if camera_capture_runtime is not None:
         payload.update(camera_capture_runtime.status())
         payload.update(camera_capture_runtime.vertical_crop_status())
+        payload["exposure_us"] = getattr(
+            camera_capture_runtime.settings,
+            "exposure_us",
+            payload.get("exposure_us"),
+        )
+        payload["gain"] = getattr(
+            camera_capture_runtime.settings,
+            "gain",
+            payload.get("gain"),
+        )
         frame_period_us = round(1_000_000 / camera_capture_runtime.settings.fps)
         payload["max_exposure_us"] = frame_period_us - 1
     return payload
@@ -1611,8 +1628,8 @@ def handle_set_camera_capture_settings(data):
         return
 
     try:
-        exposure_us = int(data.get("exposure_us", camera_capture_config["exposure_us"]))
-        gain = float(data.get("gain", camera_capture_config["gain"]))
+        if "exposure_us" in data or "gain" in data:
+            raise ValueError("Camera exposure and gain are managed automatically")
         alignment_x_pct = float(
             data.get("alignment_x_pct", camera_capture_config.get("alignment_x_pct", 50.0))
         )
@@ -1630,13 +1647,8 @@ def handle_set_camera_capture_settings(data):
                 int(data["vertical_offset_px"])
             )
 
-        applied = camera_capture_runtime.update_image_controls(
-            exposure_us=exposure_us,
-            gain=gain,
-        )
         camera_capture_config.update(
             {
-                **applied,
                 **crop_update,
                 "alignment_x_pct": alignment_x_pct,
                 "alignment_y_pct": alignment_y_pct,
@@ -2885,9 +2897,7 @@ def _fuse_camera_ball_flight(
                                     camera_capture_config.get("roll_correction_deg", 0.0)
                                 ),
                                 horizontal_pixel_sign=(
-                                    -1.0
-                                    if camera_capture_config.get("mirror_horizontal")
-                                    else 1.0
+                                    -1.0 if camera_capture_config.get("mirror_horizontal") else 1.0
                                 ),
                                 image_width_px=int(camera_capture_config["width"]),
                                 image_height_px=int(camera_capture_config["height"]),
@@ -2941,6 +2951,35 @@ def _fuse_camera_ball_flight(
 
 def _fuse_camera_measurements(shot: Shot, camera_capture) -> None:
     """Decode one camera clip and share it across all live estimators."""
+    captured_auto_exposure = (
+        camera_capture.metadata.get("auto_exposure")
+        if camera_capture is not None
+        and isinstance(getattr(camera_capture, "metadata", None), dict)
+        else None
+    )
+    analysis_eligible = (
+        bool(captured_auto_exposure.get("analysis_eligible"))
+        if isinstance(captured_auto_exposure, dict)
+        else (
+            camera_capture_runtime.camera_analysis_eligible
+            if camera_capture_runtime is not None
+            else True
+        )
+    )
+    if not analysis_eligible:
+        shot.experimental_camera_horizontal_status = "rejected_lighting_quality"
+        shot.experimental_camera_horizontal_deg = None
+        shot.experimental_camera_horizontal_confidence = None
+        shot.experimental_camera_iwr_delta_deg = None
+        shot.experimental_fused_attack_angle_deg = None
+        shot.experimental_fused_club_path_deg = None
+        shot.experimental_fused_status = "rejected_lighting_quality"
+        shot.experimental_fused_attack_angle_confidence = "withheld"
+        shot.experimental_fused_club_path_confidence = "withheld"
+        logger.warning(
+            "[SERVER] Camera analysis withheld for lighting quality; using radar fallback"
+        )
+        return
     camera_archive = _load_camera_capture_archive(camera_capture)
     _fuse_camera_ball_flight(shot, camera_capture, camera_archive)
     _fuse_camera_club_delivery(shot, camera_capture, camera_archive)

--- a/tests/test_camera_auto_exposure.py
+++ b/tests/test_camera_auto_exposure.py
@@ -157,6 +157,35 @@ def test_startup_attempt_limit_requires_lighting_change():
     assert not failed.should_apply
 
 
+def test_lighting_failure_can_recover_with_steady_state_adjustment():
+    policy = AutoExposurePolicy(fps=488.0, startup_max_adjustments=1)
+    dark = observation("too_dark", "brighter", median=18.0, p90=40.0)
+    first = policy.evaluate(dark, exposure_us=250, gain=4.0)
+    failed = policy.evaluate(
+        dark,
+        exposure_us=first.target.exposure_us,
+        gain=first.target.gain,
+    )
+    bright = observation("too_bright", "darker", median=240.0, p90=255.0)
+
+    confirming = policy.evaluate(
+        bright,
+        exposure_us=first.target.exposure_us,
+        gain=first.target.gain,
+    )
+    recovered = policy.evaluate(
+        bright,
+        exposure_us=first.target.exposure_us,
+        gain=first.target.gain,
+    )
+
+    assert failed.status == "lighting_required"
+    assert policy.startup is False
+    assert confirming.status == "calibrating"
+    assert recovered.should_apply
+    assert recovered.target.signal < first.target.signal
+
+
 @pytest.mark.parametrize(
     ("exposure_us", "expected"),
     [(500, "low"), (650, "elevated"), (1000, "high")],

--- a/tests/test_camera_auto_exposure.py
+++ b/tests/test_camera_auto_exposure.py
@@ -108,16 +108,32 @@ def test_acceptable_startup_observation_marks_analysis_ready():
 
 def test_steady_state_requires_confirmation_and_moves_one_step():
     policy = AutoExposurePolicy(fps=488.0, steady_confirmations=2)
-    policy.evaluate(observation("good", "hold"), exposure_us=500, gain=12.0)
-    bad = observation("too_dark", "brighter", median=20.0, p90=50.0)
+    policy.evaluate(observation("good", "hold"), exposure_us=650, gain=15.0)
+    bad = observation("too_dark", "brighter", median=70.0, p90=74.0)
 
-    first = policy.evaluate(bad, exposure_us=500, gain=12.0)
-    second = policy.evaluate(bad, exposure_us=500, gain=12.0)
+    first = policy.evaluate(bad, exposure_us=650, gain=15.0)
+    second = policy.evaluate(bad, exposure_us=650, gain=15.0)
 
     assert first.status == "calibrating"
     assert not first.should_apply
     assert second.status == "adjusting"
-    assert second.target == EXPOSURE_STEPS[9]
+    assert second.target == EXPOSURE_STEPS[11]
+
+
+def test_material_steady_state_change_reenters_fast_convergence():
+    policy = AutoExposurePolicy(fps=488.0, steady_confirmations=2)
+    policy.evaluate(observation("good", "hold"), exposure_us=500, gain=12.0)
+
+    decision = policy.evaluate(
+        observation("too_dark", "brighter", median=18.0, p90=40.0),
+        exposure_us=500,
+        gain=12.0,
+    )
+
+    assert decision.status == "adjusting"
+    assert decision.should_apply
+    assert decision.target.signal > EXPOSURE_STEPS[9].signal
+    assert policy.startup is True
 
 
 def test_ladder_limit_requires_lighting_but_recovers_automatically():

--- a/tests/test_camera_auto_exposure.py
+++ b/tests/test_camera_auto_exposure.py
@@ -1,0 +1,165 @@
+"""Tests for deterministic high-speed camera auto exposure."""
+
+import numpy as np
+import pytest
+
+from openflight.camera.auto_exposure import (
+    EXPOSURE_STEPS,
+    AutoExposurePolicy,
+    ExposureObservation,
+    exposure_steps_for_fps,
+    measure_exposure,
+    motion_blur_risk,
+)
+
+
+def observation(status, recommendation, *, median=50.0, p90=100.0):
+    """Build one deterministic policy observation."""
+    return ExposureObservation(
+        sample_available=True,
+        status=status,
+        recommendation=recommendation,
+        message=status,
+        p10=10.0,
+        median=median,
+        p90=p90,
+        contrast=p90 - 10.0,
+        clipped_pct=0.0,
+        dark_pct=0.0,
+    )
+
+
+def test_exposure_ladder_is_monotonic_and_respects_frame_period():
+    assert [step.signal for step in EXPOSURE_STEPS] == sorted(
+        step.signal for step in EXPOSURE_STEPS
+    )
+    assert exposure_steps_for_fps(488.0) == EXPOSURE_STEPS
+    assert max(step.exposure_us for step in exposure_steps_for_fps(1000.0)) < 1000
+    with pytest.raises(ValueError, match="positive"):
+        exposure_steps_for_fps(0)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(18, "too_dark"), (110, "good"), (252, "too_bright")],
+)
+def test_measure_exposure_classifies_impact_zone(value, expected):
+    image = np.full((200, 320), value, dtype=np.uint8)
+    if expected == "good":
+        image[100:175, 90:230] = np.tile(
+            np.linspace(45, 185, 140, dtype=np.uint8),
+            (75, 1),
+        )
+
+    result = measure_exposure(image)
+
+    assert result.status == expected
+    assert result.sample_available is True
+
+
+def test_measure_exposure_flags_nearly_black_view():
+    result = measure_exposure(np.zeros((200, 320), dtype=np.uint8))
+
+    assert result.status == "too_dark"
+    assert "lens cover" in result.message
+
+
+def test_startup_dark_scene_jumps_more_than_one_step():
+    policy = AutoExposurePolicy(fps=488.0)
+
+    decision = policy.evaluate(
+        observation("too_dark", "brighter", median=18.0, p90=40.0),
+        exposure_us=250,
+        gain=4.0,
+    )
+
+    assert decision.status == "adjusting"
+    assert decision.target is not None
+    assert decision.target.signal > EXPOSURE_STEPS[4].signal
+    assert decision.analysis_eligible is False
+
+
+def test_startup_bright_scene_jumps_darker():
+    policy = AutoExposurePolicy(fps=488.0)
+
+    decision = policy.evaluate(
+        observation("too_bright", "darker", median=240.0, p90=255.0),
+        exposure_us=800,
+        gain=18.0,
+    )
+
+    assert decision.target is not None
+    assert decision.target.signal < 800 * 18
+
+
+def test_acceptable_startup_observation_marks_analysis_ready():
+    policy = AutoExposurePolicy(fps=488.0)
+
+    decision = policy.evaluate(
+        observation("good", "hold", median=100.0),
+        exposure_us=500,
+        gain=12.0,
+    )
+
+    assert decision.status == "ready"
+    assert decision.analysis_eligible is True
+    assert not decision.should_apply
+
+
+def test_steady_state_requires_confirmation_and_moves_one_step():
+    policy = AutoExposurePolicy(fps=488.0, steady_confirmations=2)
+    policy.evaluate(observation("good", "hold"), exposure_us=500, gain=12.0)
+    bad = observation("too_dark", "brighter", median=20.0, p90=50.0)
+
+    first = policy.evaluate(bad, exposure_us=500, gain=12.0)
+    second = policy.evaluate(bad, exposure_us=500, gain=12.0)
+
+    assert first.status == "calibrating"
+    assert not first.should_apply
+    assert second.status == "adjusting"
+    assert second.target == EXPOSURE_STEPS[9]
+
+
+def test_ladder_limit_requires_lighting_but_recovers_automatically():
+    policy = AutoExposurePolicy(fps=488.0)
+    darkest = EXPOSURE_STEPS[-1]
+
+    failed = policy.evaluate(
+        observation("too_dark", "brighter", median=10.0, p90=20.0),
+        exposure_us=darkest.exposure_us,
+        gain=darkest.gain,
+    )
+    recovered = policy.evaluate(
+        observation("marginal", "brighter", median=40.0, p90=95.0),
+        exposure_us=darkest.exposure_us,
+        gain=darkest.gain,
+    )
+
+    assert failed.status == "lighting_required"
+    assert failed.analysis_eligible is False
+    assert "add or redirect light" in failed.message
+    assert recovered.status == "ready"
+    assert recovered.analysis_eligible is True
+
+
+def test_startup_attempt_limit_requires_lighting_change():
+    policy = AutoExposurePolicy(fps=488.0, startup_max_adjustments=1)
+    dark = observation("too_dark", "brighter", median=18.0, p90=40.0)
+    first = policy.evaluate(dark, exposure_us=250, gain=4.0)
+
+    failed = policy.evaluate(
+        dark,
+        exposure_us=first.target.exposure_us,
+        gain=first.target.gain,
+    )
+
+    assert failed.status == "lighting_required"
+    assert not failed.should_apply
+
+
+@pytest.mark.parametrize(
+    ("exposure_us", "expected"),
+    [(500, "low"), (650, "elevated"), (1000, "high")],
+)
+def test_motion_blur_risk(exposure_us, expected):
+    assert motion_blur_risk(exposure_us) == expected

--- a/tests/test_camera_triggered_buffer.py
+++ b/tests/test_camera_triggered_buffer.py
@@ -308,6 +308,56 @@ def test_auto_exposure_defers_control_change_during_trigger_tail(tmp_path):
     assert runtime.auto_exposure_status()["capture_deferred"] is True
 
 
+def test_trigger_waits_for_in_progress_auto_exposure_update(tmp_path):
+    controls_started = threading.Event()
+    allow_controls = threading.Event()
+    trigger_finished = threading.Event()
+
+    class BlockingCamera:
+        @staticmethod
+        def set_controls(_controls):
+            controls_started.set()
+            assert allow_controls.wait(timeout=1.0)
+
+    runtime = CameraCaptureRuntime(
+        output_dir=tmp_path,
+        settings=CameraCaptureSettings(
+            fps=488.0,
+            pre_ms=1.0,
+            post_ms=10.0,
+            exposure_us=250,
+            gain=4.0,
+        ),
+    )
+    runtime._camera = BlockingCamera()
+    runtime._running = True
+    runtime._ring.add_frame(
+        CameraFrame(
+            image=np.full((200, 320), 18, dtype=np.uint8),
+            sensor_timestamp_ns=1,
+            host_timestamp_ns=2,
+            exposure_us=250,
+            analogue_gain=4.0,
+        )
+    )
+    exposure_thread = threading.Thread(target=runtime._run_auto_exposure_cycle)
+    trigger_thread = threading.Thread(
+        target=lambda: (runtime.notify_trigger(), trigger_finished.set()),
+    )
+
+    exposure_thread.start()
+    assert controls_started.wait(timeout=1.0)
+    trigger_thread.start()
+    assert not trigger_finished.wait(timeout=0.05)
+    allow_controls.set()
+    exposure_thread.join(timeout=1.0)
+    trigger_thread.join(timeout=1.0)
+
+    assert trigger_finished.is_set()
+    trigger_state = runtime._trigger_auto_exposure.get_nowait()
+    assert trigger_state["exposure_us"] == runtime.settings.exposure_us
+
+
 def test_auto_exposure_acceptable_frame_enables_camera_analysis(tmp_path):
     runtime = CameraCaptureRuntime(
         output_dir=tmp_path,

--- a/tests/test_camera_triggered_buffer.py
+++ b/tests/test_camera_triggered_buffer.py
@@ -1,5 +1,6 @@
 """Tests for the high-speed camera trigger ring."""
 
+import json
 import threading
 
 import numpy as np
@@ -335,6 +336,108 @@ def test_auto_exposure_acceptable_frame_enables_camera_analysis(tmp_path):
     assert decision.status == "ready"
     assert runtime.camera_analysis_eligible is True
     assert runtime.auto_exposure_status()["observation"]["status"] == "good"
+
+
+def test_auto_exposure_restores_last_good_controls_for_same_camera_mode(tmp_path):
+    state_path = tmp_path / "camera-exposure.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "width": 320,
+                "height": 200,
+                "fps": 488.0,
+                "exposure_us": 650,
+                "gain": 15.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runtime = CameraCaptureRuntime(
+        output_dir=tmp_path,
+        settings=CameraCaptureSettings(
+            width=320,
+            height=200,
+            fps=488.0,
+            exposure_us=250,
+            gain=4.0,
+            auto_exposure_state_path=state_path,
+        ),
+    )
+
+    assert runtime.settings.exposure_us == 650
+    assert runtime.settings.gain == 15.0
+
+
+def test_auto_exposure_ignores_saved_controls_from_different_mode(tmp_path):
+    state_path = tmp_path / "camera-exposure.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "width": 640,
+                "height": 400,
+                "fps": 300.0,
+                "exposure_us": 1000,
+                "gain": 20.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runtime = CameraCaptureRuntime(
+        output_dir=tmp_path,
+        settings=CameraCaptureSettings(
+            width=320,
+            height=200,
+            fps=488.0,
+            exposure_us=250,
+            gain=4.0,
+            auto_exposure_state_path=state_path,
+        ),
+    )
+
+    assert runtime.settings.exposure_us == 250
+    assert runtime.settings.gain == 4.0
+
+
+def test_auto_exposure_persists_good_controls(tmp_path):
+    state_path = tmp_path / "camera-exposure.json"
+    runtime = CameraCaptureRuntime(
+        output_dir=tmp_path,
+        settings=CameraCaptureSettings(
+            width=320,
+            height=200,
+            fps=488.0,
+            exposure_us=500,
+            gain=12.0,
+            auto_exposure_state_path=state_path,
+        ),
+    )
+    runtime._camera = object()
+    runtime._running = True
+    image = np.full((200, 320), 110, dtype=np.uint8)
+    image[100:175, 90:230] = np.tile(
+        np.linspace(45, 185, 140, dtype=np.uint8),
+        (75, 1),
+    )
+    runtime._ring.add_frame(
+        CameraFrame(
+            image=image,
+            sensor_timestamp_ns=1,
+            host_timestamp_ns=2,
+            exposure_us=500,
+            analogue_gain=12.0,
+        )
+    )
+
+    runtime._run_auto_exposure_cycle()
+
+    saved = json.loads(state_path.read_text(encoding="utf-8"))
+    assert saved["exposure_us"] == 500
+    assert saved["gain"] == 12.0
+    assert saved["width"] == 320
 
 
 def test_preview_roll_correction_levels_sloped_line_without_modifying_raw_frame(tmp_path):

--- a/tests/test_camera_triggered_buffer.py
+++ b/tests/test_camera_triggered_buffer.py
@@ -58,12 +58,16 @@ def test_ring_exposes_latest_frame_during_capture():
 
     assert ring.latest_frame is not None
     assert ring.latest_frame.image[0, 0] == 2
+    assert ring.capture_busy is False
 
     assert ring.trigger()
+    assert ring.capture_busy is True
     ring.add_frame(make_frame(3))
 
     assert ring.latest_frame is not None
     assert ring.latest_frame.image[0, 0] == 3
+    ring.add_frame(make_frame(4))
+    assert ring.capture_busy is False
 
 
 def test_ring_rejects_overlapping_trigger():
@@ -230,6 +234,107 @@ def test_live_image_controls_update_camera_without_restarting(tmp_path):
     assert result == {"exposure_us": 750, "gain": 3.5}
     assert runtime.settings.exposure_us == 750
     assert runtime.settings.gain == 3.5
+
+
+def test_auto_exposure_startup_jumps_to_brighter_setting(tmp_path):
+    class FakeCamera:
+        def __init__(self):
+            self.controls = []
+
+        def set_controls(self, controls):
+            self.controls.append(controls)
+
+    runtime = CameraCaptureRuntime(
+        output_dir=tmp_path,
+        settings=CameraCaptureSettings(fps=488.0, exposure_us=250, gain=4.0),
+    )
+    runtime._camera = FakeCamera()
+    runtime._running = True
+    runtime._ring.add_frame(
+        CameraFrame(
+            image=np.full((200, 320), 18, dtype=np.uint8),
+            sensor_timestamp_ns=1,
+            host_timestamp_ns=2,
+            exposure_us=250,
+            analogue_gain=4.0,
+        )
+    )
+
+    decision = runtime._run_auto_exposure_cycle()
+
+    assert decision is not None
+    assert decision.status == "adjusting"
+    assert runtime._camera.controls
+    assert runtime.settings.exposure_us > 250
+    assert runtime.auto_exposure_status()["analysis_eligible"] is False
+
+
+def test_auto_exposure_defers_control_change_during_trigger_tail(tmp_path):
+    class FakeCamera:
+        def __init__(self):
+            self.controls = []
+
+        def set_controls(self, controls):
+            self.controls.append(controls)
+
+    runtime = CameraCaptureRuntime(
+        output_dir=tmp_path,
+        settings=CameraCaptureSettings(
+            fps=488.0,
+            pre_ms=1.0,
+            post_ms=10.0,
+            exposure_us=250,
+            gain=4.0,
+        ),
+    )
+    runtime._camera = FakeCamera()
+    runtime._running = True
+    runtime._ring.add_frame(
+        CameraFrame(
+            image=np.full((200, 320), 18, dtype=np.uint8),
+            sensor_timestamp_ns=1,
+            host_timestamp_ns=2,
+            exposure_us=250,
+            analogue_gain=4.0,
+        )
+    )
+    assert runtime._ring.trigger()
+
+    decision = runtime._run_auto_exposure_cycle()
+
+    assert decision is None
+    assert runtime._camera.controls == []
+    assert runtime.auto_exposure_status()["capture_deferred"] is True
+
+
+def test_auto_exposure_acceptable_frame_enables_camera_analysis(tmp_path):
+    runtime = CameraCaptureRuntime(
+        output_dir=tmp_path,
+        settings=CameraCaptureSettings(fps=488.0, exposure_us=500, gain=12.0),
+    )
+    runtime._camera = object()
+    runtime._running = True
+    image = np.full((200, 320), 110, dtype=np.uint8)
+    image[100:175, 90:230] = np.tile(
+        np.linspace(45, 185, 140, dtype=np.uint8),
+        (75, 1),
+    )
+    runtime._ring.add_frame(
+        CameraFrame(
+            image=image,
+            sensor_timestamp_ns=1,
+            host_timestamp_ns=2,
+            exposure_us=500,
+            analogue_gain=12.0,
+        )
+    )
+
+    decision = runtime._run_auto_exposure_cycle()
+
+    assert decision is not None
+    assert decision.status == "ready"
+    assert runtime.camera_analysis_eligible is True
+    assert runtime.auto_exposure_status()["observation"]["status"] == "good"
 
 
 def test_preview_roll_correction_levels_sloped_line_without_modifying_raw_frame(tmp_path):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,17 +38,24 @@ class TestCameraCaptureSettings:
             "status": "good",
             "recommendation": "hold",
         }
-        runtime = SimpleNamespace(exposure_quality=lambda: expected)
+        auto_exposure = {
+            "enabled": True,
+            "status": "ready",
+            "analysis_eligible": True,
+        }
+        runtime = SimpleNamespace(
+            exposure_quality=lambda: dict(expected),
+            auto_exposure_status=lambda: auto_exposure,
+        )
         monkeypatch.setattr(server_module, "camera_capture_runtime", runtime)
 
         response = server_module.app.test_client().get("/api/camera/exposure-quality")
 
         assert response.status_code == 200
-        assert response.get_json() == expected
+        assert response.get_json() == {**expected, "auto_exposure": auto_exposure}
 
-    def test_update_applies_controls_and_alignment(self, monkeypatch):
+    def test_update_applies_alignment_without_manual_exposure(self, monkeypatch):
         emitted = []
-        applied = []
 
         class FakeRuntime:
             settings = SimpleNamespace(fps=600.0)
@@ -61,11 +68,6 @@ class TestCameraCaptureSettings:
                     "buffered_frames": 90,
                     "required_pre_frames": 90,
                 }
-
-            @staticmethod
-            def update_image_controls(*, exposure_us, gain):
-                applied.append((exposure_us, gain))
-                return {"exposure_us": exposure_us, "gain": gain}
 
             @staticmethod
             def vertical_crop_status():
@@ -95,20 +97,44 @@ class TestCameraCaptureSettings:
 
         server_module.handle_set_camera_capture_settings(
             {
-                "exposure_us": 650,
-                "gain": 3.0,
                 "alignment_x_pct": 47,
                 "alignment_y_pct": 58,
             }
         )
 
-        assert applied == [(650, 3.0)]
         assert config["alignment_x_pct"] == 47.0
         assert config["alignment_y_pct"] == 58.0
         assert emitted[-1][0] == "camera_capture_settings"
         assert emitted[-1][1]["max_exposure_us"] == 1666
         assert emitted[-1][1]["raw_crop_adjustable"] is True
         assert emitted[-1][1]["vertical_offset_px"] == -10
+
+    def test_update_rejects_manual_exposure_override(self, monkeypatch):
+        emitted = []
+        runtime = SimpleNamespace(
+            settings=SimpleNamespace(fps=488.0),
+            status=lambda: {"running": True, "armed": True},
+        )
+        monkeypatch.setattr(server_module, "camera_capture_runtime", runtime)
+        monkeypatch.setattr(
+            server_module,
+            "camera_capture_config",
+            {"exposure_us": 500, "gain": 12.0},
+        )
+        monkeypatch.setattr(
+            server_module.socketio,
+            "emit",
+            lambda event, payload: emitted.append((event, payload)),
+        )
+
+        server_module.handle_set_camera_capture_settings({"exposure_us": 650})
+
+        assert emitted == [
+            (
+                "camera_capture_settings_error",
+                {"error": "Camera exposure and gain are managed automatically"},
+            )
+        ]
 
     def test_update_moves_real_sensor_crop(self, monkeypatch):
         emitted = []
@@ -1462,6 +1488,51 @@ class TestShotToDict:
         assert len(fused_archives) == 2
         assert fused_archives[0] is fused_archives[1]
         assert fused_archives[0]["frames"].shape == (8, 4, 4)
+
+    def test_live_camera_fusion_withholds_dark_frames_and_preserves_iwr(self, monkeypatch):
+        runtime = SimpleNamespace(camera_analysis_eligible=False)
+        monkeypatch.setattr(server_module, "camera_capture_runtime", runtime)
+        monkeypatch.setattr(
+            server_module,
+            "_load_camera_capture_archive",
+            lambda _capture: pytest.fail("dark camera frames should not be decoded"),
+        )
+        shot = Shot(
+            ball_speed_mph=110.0,
+            timestamp=datetime.now(),
+            launch_angle_horizontal=-1.8,
+            launch_angle_horizontal_confidence=0.8,
+            launch_angle_horizontal_source="radar",
+            iwr6843_horizontal_deg=-1.8,
+            iwr6843_horizontal_confidence=0.8,
+        )
+
+        server_module._fuse_camera_measurements(shot, SimpleNamespace(valid=True))
+
+        assert shot.launch_angle_horizontal == -1.8
+        assert shot.launch_angle_horizontal_source == "radar"
+        assert shot.experimental_camera_horizontal_status == "rejected_lighting_quality"
+        assert shot.experimental_fused_status == "rejected_lighting_quality"
+        assert shot.experimental_fused_attack_angle_deg is None
+        assert shot.experimental_fused_club_path_deg is None
+
+    def test_camera_fusion_uses_capture_time_exposure_state(self, monkeypatch):
+        runtime = SimpleNamespace(camera_analysis_eligible=True)
+        monkeypatch.setattr(server_module, "camera_capture_runtime", runtime)
+        monkeypatch.setattr(
+            server_module,
+            "_load_camera_capture_archive",
+            lambda _capture: pytest.fail("ineligible capture should not be decoded"),
+        )
+        shot = Shot(ball_speed_mph=110.0, timestamp=datetime.now())
+        capture = SimpleNamespace(
+            valid=True,
+            metadata={"auto_exposure": {"analysis_eligible": False}},
+        )
+
+        server_module._fuse_camera_measurements(shot, capture)
+
+        assert shot.experimental_fused_status == "rejected_lighting_quality"
 
     def test_angle_source_none_by_default(self):
         """Shot without angle source should have None."""

--- a/ui/src/components/CameraFeed.css
+++ b/ui/src/components/CameraFeed.css
@@ -322,104 +322,121 @@
   text-transform: none;
 }
 
-.camera-settings__profiles {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 7px;
-}
-
-.camera-settings__profile {
-  min-height: 52px;
-  padding: 8px;
-  border: 1px solid rgba(245, 240, 230, 0.12);
+.camera-settings__auto-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: 10px;
+  border: 1px solid rgba(251, 191, 36, 0.25);
   border-radius: var(--radius-sm);
-  background: rgba(245, 240, 230, 0.035);
-  color: var(--text-secondary);
-  text-align: left;
-  cursor: pointer;
+  background: rgba(251, 191, 36, 0.06);
 }
 
-.camera-settings__profile strong,
-.camera-settings__profile span {
+.camera-settings__auto-status > div,
+.camera-settings__auto-status strong,
+.camera-settings__auto-status span {
   display: block;
 }
 
-.camera-settings__profile strong {
+.camera-settings__auto-status strong {
+  color: var(--color-warning);
+  font-size: 0.72rem;
+}
+
+.camera-settings__auto-status span {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 0.6rem;
+  line-height: 1.35;
+}
+
+.camera-settings__auto-status--ready {
+  border-color: rgba(74, 222, 128, 0.32);
+  background: rgba(74, 222, 128, 0.07);
+}
+
+.camera-settings__auto-status--ready strong {
+  color: var(--color-success);
+}
+
+.camera-settings__auto-status--lighting_required {
+  border-color: rgba(248, 113, 113, 0.36);
+  background: rgba(248, 113, 113, 0.08);
+}
+
+.camera-settings__auto-status--lighting_required strong {
+  color: var(--color-danger);
+}
+
+.camera-settings__auto-dot {
+  flex: 0 0 auto;
+  width: 9px;
+  height: 9px;
+  margin: 0 !important;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 10px currentColor;
+}
+
+.camera-settings__exposure-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+  margin: 0;
+}
+
+.camera-settings__exposure-metrics div {
+  padding: 8px;
+  border-radius: var(--radius-sm);
+  background: rgba(245, 240, 230, 0.035);
+}
+
+.camera-settings__exposure-metrics dt {
+  color: var(--text-muted);
+  font-size: 0.56rem;
+  text-transform: uppercase;
+}
+
+.camera-settings__exposure-metrics dd {
+  margin: 3px 0 0;
   color: var(--color-cream);
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.camera-settings__analysis-state {
+  padding: 9px 10px;
+  border-left: 3px solid var(--color-warning);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  background: rgba(251, 191, 36, 0.06);
+}
+
+.camera-settings__analysis-state strong,
+.camera-settings__analysis-state span {
+  display: block;
+}
+
+.camera-settings__analysis-state strong {
+  color: var(--color-warning);
   font-size: 0.68rem;
 }
 
-.camera-settings__profile span {
+.camera-settings__analysis-state span {
   margin-top: 3px;
   color: var(--text-muted);
-  font-size: 0.56rem;
+  font-size: 0.58rem;
+  line-height: 1.4;
 }
 
-.camera-settings__profile--active {
-  border-color: rgba(74, 222, 128, 0.52);
-  background: rgba(74, 222, 128, 0.12);
+.camera-settings__analysis-state--ready {
+  border-left-color: var(--color-success);
+  background: rgba(74, 222, 128, 0.055);
 }
 
-.camera-settings__profile--active strong,
-.camera-settings__profile--active span {
+.camera-settings__analysis-state--ready strong {
   color: var(--color-success);
-}
-
-.camera-settings__profile:disabled {
-  cursor: default;
-  opacity: 0.5;
-}
-
-.camera-settings__brightness-stepper {
-  display: grid;
-  grid-template-columns: minmax(72px, 1fr) minmax(105px, 1.25fr) minmax(72px, 1fr);
-  align-items: stretch;
-  gap: 7px;
-}
-
-.camera-settings__brightness-stepper button {
-  min-height: 46px;
-  padding: 7px;
-  border: 1px solid rgba(74, 222, 128, 0.35);
-  border-radius: var(--radius-sm);
-  background: rgba(74, 222, 128, 0.09);
-  color: var(--color-success);
-  font-size: 0.66rem;
-  font-weight: 700;
-  cursor: pointer;
-  touch-action: manipulation;
-}
-
-.camera-settings__brightness-stepper button:disabled {
-  border-color: rgba(245, 240, 230, 0.08);
-  background: rgba(245, 240, 230, 0.025);
-  color: var(--text-muted);
-  cursor: default;
-  opacity: 0.55;
-}
-
-.camera-settings__brightness-stepper output {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-width: 0;
-  padding: 6px;
-  border-radius: var(--radius-sm);
-  background: rgba(245, 240, 230, 0.045);
-  text-align: center;
-}
-
-.camera-settings__brightness-stepper strong {
-  color: var(--color-cream);
-  font-size: 0.64rem;
-}
-
-.camera-settings__brightness-stepper span {
-  margin-top: 3px;
-  color: var(--text-muted);
-  font-size: 0.55rem;
-  font-variant-numeric: tabular-nums;
 }
 
 .camera-settings__view-controls {

--- a/ui/src/components/CameraFeed.test.tsx
+++ b/ui/src/components/CameraFeed.test.tsx
@@ -35,6 +35,21 @@ const captureSettings: CameraCaptureSettings = {
   vertical_offset_min_px: -70,
   vertical_offset_max_px: 70,
   vertical_offset_step_px: 10,
+  auto_exposure: {
+    enabled: true,
+    status: 'ready',
+    analysis_eligible: true,
+    message: 'Impact-area exposure and contrast look good',
+    motion_blur_risk: 'low',
+    exposure_us: 500,
+    gain: 12,
+    observation: {
+      sample_available: true,
+      status: 'good',
+      median: 108,
+      contrast: 94,
+    },
+  },
 };
 
 describe('CameraFeed', () => {
@@ -57,21 +72,16 @@ describe('CameraFeed', () => {
 
     expect(html).toContain('camera-feed__workspace');
     expect(html).toContain('Camera setup');
-    expect(html).toContain('Environment profile');
-    expect(html).toContain('Exposure check');
+    expect(html).toContain('Automatic exposure');
+    expect(html).toContain('Auto exposure');
     expect(html).toContain('camera-feed__exposure-quality');
-    expect(html).toContain('Darker');
-    expect(html).toContain('Brighter');
-    expect(html).toContain('Outdoor sun');
-    expect(html).toContain('250<!-- --> µs · <!-- -->4<!-- -->×');
-    expect(html).toContain('Outdoor shade');
-    expect(html).toContain('Evening');
-    expect(html).toContain('Indoor bright');
-    expect(html).toContain('Indoor dark');
-    expect(html).toContain('Night');
-    expect(html).toContain('1000<!-- --> µs · <!-- -->20<!-- -->×');
-    expect(html).toContain('Facility dark');
-    expect(html).toContain('1250<!-- --> µs · <!-- -->16<!-- -->×');
+    expect(html).toContain('Camera analysis active');
+    expect(html).toContain('Impact median');
+    expect(html).toContain('Motion blur risk');
+    expect(html).toContain('500<!-- --> µs');
+    expect(html).not.toContain('Environment profile');
+    expect(html).not.toContain('Darker');
+    expect(html).not.toContain('Brighter');
     expect(html).toContain('Ball placement guide');
     expect(html).toContain('50% across · 78% down');
     expect(html).not.toContain('type="range"');
@@ -82,6 +92,32 @@ describe('CameraFeed', () => {
     expect(html).toContain('-20 px');
     expect(html).toContain('320 × 200');
     expect(html).toContain('600 fps');
+    expect(html).toContain('Armed');
+  });
+
+  it('explains lighting failure without disabling capture', () => {
+    const html = renderToString(
+      <CameraFeed
+        cameraStatus={cameraStatus}
+        captureSettings={{
+          ...captureSettings,
+          auto_exposure: {
+            ...captureSettings.auto_exposure!,
+            status: 'lighting_required',
+            analysis_eligible: false,
+            message: 'Camera lighting is insufficient; add or redirect light toward the ball',
+          },
+        }}
+        captureSettingsError={null}
+        onToggleCamera={vi.fn()}
+        onToggleStream={vi.fn()}
+        onUpdateCaptureSettings={vi.fn()}
+      />
+    );
+
+    expect(html).toContain('Lighting needed');
+    expect(html).toContain('Radar fallback active');
+    expect(html).toContain('Preview and raw clips continue recording');
     expect(html).toContain('Armed');
   });
 });

--- a/ui/src/components/CameraFeed.tsx
+++ b/ui/src/components/CameraFeed.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type CSSProperties } from 'react';
 import { useCameraPointerDragScroll } from '../hooks/useCameraPointerDragScroll';
-import type { CameraCaptureSettings, CameraStatus } from '../stores/useCameraStore';
+import type { CameraAutoExposureStatus, CameraCaptureSettings, CameraStatus } from '../stores/useCameraStore';
 import { verticalViewTargets } from '../utils/cameraView';
 import { getServerOrigin } from '../utils/serverOrigin';
 import './CameraFeed.css';
@@ -16,6 +16,7 @@ interface CameraFeedProps {
 
 interface CaptureSettingsPanelProps {
   settings: CameraCaptureSettings;
+  exposureQuality: ExposureQuality | null;
   error: string | null;
   onUpdate: (settings: Partial<CameraCaptureSettings>) => void;
 }
@@ -36,50 +37,18 @@ interface ExposureQuality {
   message?: string;
   clipped_pct?: number;
   contrast?: number;
+  auto_exposure?: CameraAutoExposureStatus;
 }
 
-const BRIGHTNESS_STEPS = [
-  { exposureUs: 100, gain: 2 },
-  { exposureUs: 150, gain: 3 },
-  { exposureUs: 200, gain: 3 },
-  { id: 'outdoor-sun', label: 'Outdoor sun', exposureUs: 250, gain: 4 },
-  { exposureUs: 300, gain: 5 },
-  { id: 'outdoor-shade', label: 'Outdoor shade', exposureUs: 350, gain: 6 },
-  { exposureUs: 400, gain: 8 },
-  { id: 'evening', label: 'Evening', exposureUs: 450, gain: 10 },
-  { id: 'indoor-bright', label: 'Indoor bright', exposureUs: 500, gain: 12 },
-  { exposureUs: 500, gain: 15 },
-  { id: 'indoor-dark', label: 'Indoor dark', exposureUs: 650, gain: 15 },
-  { exposureUs: 800, gain: 18 },
-  { id: 'night', label: 'Night', exposureUs: 1000, gain: 20 },
-  { id: 'facility-dark', label: 'Facility dark', exposureUs: 1250, gain: 16 },
-] as const;
+const AUTO_EXPOSURE_LABELS: Record<CameraAutoExposureStatus['status'], string> = {
+  calibrating: 'Checking',
+  ready: 'Ready',
+  adjusting: 'Adjusting',
+  lighting_required: 'Lighting needed',
+  unavailable: 'Waiting',
+};
 
-const CAMERA_PROFILES = BRIGHTNESS_STEPS.filter((step) => 'id' in step);
-
-function brightnessStepIndex(settings: CameraCaptureSettings): number {
-  const exact = BRIGHTNESS_STEPS.findIndex(
-    (step) => step.exposureUs === settings.exposure_us && step.gain === settings.gain
-  );
-  if (exact >= 0) return exact;
-  const currentSignal = Math.max(1, (settings.exposure_us ?? 250) * (settings.gain ?? 4));
-  return BRIGHTNESS_STEPS.reduce((best, step, index) => {
-    const distance = Math.abs(Math.log(step.exposureUs * step.gain) - Math.log(currentSignal));
-    const bestStep = BRIGHTNESS_STEPS[best];
-    const bestDistance = Math.abs(Math.log(bestStep.exposureUs * bestStep.gain) - Math.log(currentSignal));
-    return distance < bestDistance ? index : best;
-  }, 0);
-}
-
-function brightnessStepLabel(index: number): string {
-  const named = BRIGHTNESS_STEPS.map((step, stepIndex) => ('label' in step ? { ...step, stepIndex } : null))
-    .filter((step): step is NonNullable<typeof step> => step !== null)
-    .reduce((best, step) => (Math.abs(step.stepIndex - index) < Math.abs(best.stepIndex - index) ? step : best));
-  const delta = index - named.stepIndex;
-  return `${named.label}${delta === 0 ? '' : ` ${delta > 0 ? '+' : ''}${delta}`}`;
-}
-
-function CaptureSettingsPanel({ settings, error, onUpdate }: CaptureSettingsPanelProps) {
+function CaptureSettingsPanel({ settings, exposureQuality, error, onUpdate }: CaptureSettingsPanelProps) {
   const verticalOffset = settings.vertical_offset_px ?? 0;
   const verticalMin = settings.vertical_offset_min_px ?? verticalOffset;
   const verticalMax = settings.vertical_offset_max_px ?? verticalOffset;
@@ -87,11 +56,11 @@ function CaptureSettingsPanel({ settings, error, onUpdate }: CaptureSettingsPane
   const viewTargets = verticalViewTargets(verticalOffset, verticalStep, settings.rotate_180 ?? false);
   const viewUpOffset = viewTargets.up;
   const viewDownOffset = viewTargets.down;
-  const brightnessIndex = brightnessStepIndex(settings);
-  const setBrightnessStep = (index: number) => {
-    const step = BRIGHTNESS_STEPS[index];
-    onUpdate({ exposure_us: step.exposureUs, gain: step.gain });
-  };
+  const autoExposure = exposureQuality?.auto_exposure ?? settings.auto_exposure;
+  const exposureObservation = autoExposure?.observation;
+  const exposureStatus = autoExposure?.capture_deferred
+    ? 'Capturing shot'
+    : AUTO_EXPOSURE_LABELS[autoExposure?.status ?? 'unavailable'];
 
   return (
     <aside className="camera-settings">
@@ -135,52 +104,49 @@ function CaptureSettingsPanel({ settings, error, onUpdate }: CaptureSettingsPane
 
         <section className="camera-settings__section">
           <div className="camera-settings__section-title">
-            <span>Environment profile</span>
-            <small>applies live</small>
+            <span>Automatic exposure</span>
+            <small>checks every 5 seconds</small>
           </div>
-          <div className="camera-settings__profiles">
-            {CAMERA_PROFILES.map((profile) => {
-              const isActive = settings.exposure_us === profile.exposureUs && settings.gain === profile.gain;
-              return (
-                <button
-                  key={profile.id}
-                  type="button"
-                  className={`camera-settings__profile ${isActive ? 'camera-settings__profile--active' : ''}`}
-                  disabled={!settings.available}
-                  onClick={() => onUpdate({ exposure_us: profile.exposureUs, gain: profile.gain })}
-                >
-                  <strong>{profile.label}</strong>
-                  <span>
-                    {profile.exposureUs} µs · {profile.gain}×
-                  </span>
-                </button>
-              );
-            })}
+          <div
+            className={`camera-settings__auto-status camera-settings__auto-status--${autoExposure?.status ?? 'unavailable'}`}
+          >
+            <div>
+              <strong>{exposureStatus}</strong>
+              <span>{autoExposure?.message ?? 'Waiting for the first camera check'}</span>
+            </div>
+            <span className="camera-settings__auto-dot" aria-hidden="true" />
           </div>
-          <div className="camera-settings__brightness-stepper">
-            <button
-              type="button"
-              disabled={!settings.available || brightnessIndex === 0}
-              onClick={() => setBrightnessStep(brightnessIndex - 1)}
-            >
-              Darker −
-            </button>
-            <output>
-              <strong>{brightnessStepLabel(brightnessIndex)}</strong>
-              <span>
-                {BRIGHTNESS_STEPS[brightnessIndex].exposureUs} µs · {BRIGHTNESS_STEPS[brightnessIndex].gain}×
-              </span>
-            </output>
-            <button
-              type="button"
-              disabled={!settings.available || brightnessIndex === BRIGHTNESS_STEPS.length - 1}
-              onClick={() => setBrightnessStep(brightnessIndex + 1)}
-            >
-              + Brighter
-            </button>
+          <dl className="camera-settings__exposure-metrics">
+            <div>
+              <dt>Shutter</dt>
+              <dd>{autoExposure?.exposure_us ?? settings.exposure_us ?? '—'} µs</dd>
+            </div>
+            <div>
+              <dt>Gain</dt>
+              <dd>{autoExposure?.gain ?? settings.gain ?? '—'}×</dd>
+            </div>
+            <div>
+              <dt>Impact median</dt>
+              <dd>{exposureObservation?.median ?? '—'}</dd>
+            </div>
+            <div>
+              <dt>Contrast</dt>
+              <dd>{exposureObservation?.contrast ?? exposureQuality?.contrast ?? '—'}</dd>
+            </div>
+          </dl>
+          <div
+            className={`camera-settings__analysis-state ${autoExposure?.analysis_eligible ? 'camera-settings__analysis-state--ready' : ''}`}
+          >
+            <strong>{autoExposure?.analysis_eligible ? 'Camera analysis active' : 'Radar fallback active'}</strong>
+            <span>
+              {autoExposure?.analysis_eligible
+                ? 'Camera-assisted aim, club path, and attack angle are eligible.'
+                : 'Preview and raw clips continue recording; camera-derived metrics are withheld.'}
+            </span>
           </div>
           <p className="camera-settings__note">
-            Brighter profiles keep the club sharper. Night prioritizes flashlight visibility and may add motion blur.
+            Motion blur risk: <strong>{autoExposure?.motion_blur_risk ?? 'checking'}</strong>. Add or redirect light if
+            the camera reaches its limit.
           </p>
         </section>
 
@@ -317,7 +283,8 @@ export function CameraFeed({
               className={`camera-feed__exposure-quality camera-feed__exposure-quality--${exposureQuality?.status ?? 'checking'}`}
               title={exposureQuality?.message ?? 'Analyzing the impact area'}
             >
-              Exposure check: {exposureQuality ? exposureQuality.status.replace('_', ' ') : 'checking'}
+              Auto exposure:{' '}
+              {exposureQuality?.auto_exposure ? AUTO_EXPOSURE_LABELS[exposureQuality.auto_exposure.status] : 'checking'}
             </span>
             {lastUpdated && <span className="camera-feed__timestamp">preview {lastUpdated.toLocaleTimeString()}</span>}
           </div>
@@ -364,6 +331,7 @@ export function CameraFeed({
           </div>
           <CaptureSettingsPanel
             settings={captureSettings}
+            exposureQuality={exposureQuality}
             error={captureSettingsError}
             onUpdate={onUpdateCaptureSettings}
           />

--- a/ui/src/stores/useCameraStore.ts
+++ b/ui/src/stores/useCameraStore.ts
@@ -36,6 +36,29 @@ export interface CameraCaptureSettings {
   vertical_offset_min_px?: number;
   vertical_offset_max_px?: number;
   vertical_offset_step_px?: number;
+  auto_exposure?: CameraAutoExposureStatus;
+}
+
+export interface CameraAutoExposureStatus {
+  enabled: boolean;
+  status: 'calibrating' | 'ready' | 'adjusting' | 'lighting_required' | 'unavailable';
+  analysis_eligible: boolean;
+  message: string;
+  motion_blur_risk: 'low' | 'elevated' | 'high';
+  capture_deferred?: boolean;
+  exposure_us?: number;
+  gain?: number;
+  observation?: {
+    sample_available: boolean;
+    status: 'good' | 'too_dark' | 'too_bright' | 'marginal' | 'unavailable';
+    recommendation?: 'brighter' | 'darker' | 'hold';
+    message?: string;
+    median?: number | null;
+    p90?: number | null;
+    contrast?: number | null;
+    clipped_pct?: number | null;
+    dark_pct?: number | null;
+  };
 }
 
 interface CameraState {


### PR DESCRIPTION
## What does this PR do?

Adds automatic exposure control for OV9281 high-speed camera capture.

- Measures the center-lower impact region using brightness percentiles, contrast, clipping, and darkness.
- Selects an FPS-safe shutter/gain combination from a bounded exposure ladder.
- Uses fast startup convergence, conservative steady-state corrections, and fast reacquisition after a material lighting change.
- Persists and restores the last known-good setting for each camera mode.
- Serializes exposure changes with sound-trigger capture and defers changes while a post-trigger capture is active.
- Withholds camera-derived horizontal launch, club path, and angle of attack when lighting is unsuitable while preserving radar processing and shot display.
- Replaces manual environment profiles with live camera readiness, exposure, motion-blur, and lighting feedback in the Camera tab.

## Why was this required?

Manual exposure presets were fragile across outdoor sun, shade, evening, indoor bays, and dark facilities. A preset could leave impact frames clipped or too dark, require repeated operator adjustment after a large lighting change, or allow camera-derived metrics from unusable frames.

This change makes camera readiness explicit and automatically adapts capture controls without interrupting the launch monitor. If the available light cannot produce a trustworthy image, OpenFlight warns the operator and falls back to radar-derived metrics rather than suppressing the shot.

## Automated tests

- Added policy tests for ROI measurement, lighting classifications, the monotonic FPS-safe exposure ladder, startup jumps, steady-state confirmation, material-change reacquisition, ladder limits, recovery, and motion-blur warnings.
- Added runtime tests for control validation/application, trigger-tail deferral, trigger/control serialization, state persistence/restoration, analysis eligibility, and status/metadata propagation.
- Added server/API tests for exposure status and camera-analysis gating.
- Updated UI tests for automatic readiness, exposure details, operator warnings, and removal of manual profiles.
- `make test`: **1,560 passed, 10 skipped**.
- `make lint`: Ruff passed, Pylint **9.49/10**, and ESLint passed.
- `cd ui && npm run build`: passed.

## Manual (human) testing

Tested on a Raspberry Pi 5 with a real OV9281 camera at 320x200 and 488 fps, with OPS243 and IWR6843 hardware enabled.

- Confirmed the camera rolling buffer remained armed at 74 pre-trigger and 25 post-trigger frames.
- Verified startup restored the last known-good controls and converged without manual profile selection.
- Verified the Camera tab reported automatic exposure readiness and displayed live shutter, gain, impact median, contrast, motion-blur, and analysis eligibility.
- Observed automatic adaptation across materially different lighting during hardware testing. The final fast-reacquisition state transitions were also covered by deterministic policy/runtime tests.
- Confirmed unsuitable lighting withheld camera analysis without disabling radar processing or preventing shots from appearing.
- Restarted the complete stack and confirmed camera, OPS rolling-buffer triggering, IWR capture, and the UI initialized together.

## Checklist

- [x] **Single feature/fix** — this PR is scoped to one thing with a clear story above
- [x] **Automated tests included** — new or updated tests cover this change
- [x] **Manual testing described** — I documented what I verified by hand above
- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [x] UI builds (`cd ui && npm run build`)
- [x] UI lint passes (`cd ui && npm run lint`)
- [x] Updated docs or CHANGELOG if needed
- [x] No unrelated changes mixed in
