### PR TITLE
fix(camera): keep system Python through kiosk startup

### DIFF
--- a/scripts/start-kiosk.sh
+++ b/scripts/start-kiosk.sh
@@ -823,12 +823,15 @@ fi
 UV_SYNC_ARGS=(--quiet)
 if [ "$CAMERA_CAPTURE" = true ]; then
     # Picamera2 is supplied by Raspberry Pi OS and must remain visible inside
-    # the project environment; the camera extra supplies portable OpenCV.
+    # the project environment; the camera extra supplies portable OpenCV. Keep
+    # this selection through the final `uv run`: .python-version pins 3.11,
+    # while libcamera's native extension is built for the OS Python ABI.
+    export UV_PYTHON=/usr/bin/python3
     if [ ! -x .venv/bin/python ] || ! .venv/bin/python -c "import picamera2" >/dev/null 2>&1; then
         uv venv --clear --system-site-packages --python /usr/bin/python3
     fi
     UV_SYNC_ARGS+=(--extra camera)
-    UV_PYTHON=/usr/bin/python3 uv sync "${UV_SYNC_ARGS[@]}"
+    uv sync "${UV_SYNC_ARGS[@]}"
 else
     uv sync "${UV_SYNC_ARGS[@]}"
 fi

--- a/tests/test_start_kiosk.py
+++ b/tests/test_start_kiosk.py
@@ -302,7 +302,7 @@ def test_startup_applies_kld7_latency_setup_before_server_start():
     assert setup_idx < server_start_idx
 
 
-def test_camera_capture_syncs_optional_camera_dependencies():
+def test_camera_capture_uses_system_python_for_sync_and_server_start():
     """Camera startup must keep system Python through sync and server launch."""
     from pathlib import Path
 
@@ -313,12 +313,12 @@ def test_camera_capture_syncs_optional_camera_dependencies():
     camera_branch_idx = script.index('if [ "$CAMERA_CAPTURE" = true ]; then', sync_setup_idx)
     camera_else_idx = script.index("\nelse\n", camera_branch_idx)
     export_idx = script.index("export UV_PYTHON=/usr/bin/python3", camera_branch_idx)
+    camera_sync_idx = script.index('uv sync "${UV_SYNC_ARGS[@]}"', export_idx, camera_else_idx)
     server_start_idx = script.index("uv run ${OPENFLIGHT_UV_RUN_ARGS:-} $SERVER_CMD &")
 
     assert "uv venv --clear --system-site-packages --python /usr/bin/python3" in script
     assert "UV_SYNC_ARGS+=(--extra camera)" in script
-    assert 'uv sync "${UV_SYNC_ARGS[@]}"' in script
-    assert camera_branch_idx < export_idx < camera_else_idx < server_start_idx
+    assert camera_branch_idx < export_idx < camera_sync_idx < camera_else_idx < server_start_idx
 
 
 def test_shutdown_requests_server_cleanup_before_forcing_process_exit():

--- a/tests/test_start_kiosk.py
+++ b/tests/test_start_kiosk.py
@@ -303,16 +303,22 @@ def test_startup_applies_kld7_latency_setup_before_server_start():
 
 
 def test_camera_capture_syncs_optional_camera_dependencies():
-    """Camera startup must preserve OpenCV when uv repairs the environment."""
+    """Camera startup must keep system Python through sync and server launch."""
     from pathlib import Path
 
     repo_root = Path(__file__).resolve().parents[1]
     script = (repo_root / "scripts/start-kiosk.sh").read_text(encoding="utf-8")
 
-    assert 'if [ "$CAMERA_CAPTURE" = true ]; then' in script
+    sync_setup_idx = script.index("UV_SYNC_ARGS=(--quiet)")
+    camera_branch_idx = script.index('if [ "$CAMERA_CAPTURE" = true ]; then', sync_setup_idx)
+    camera_else_idx = script.index("\nelse\n", camera_branch_idx)
+    export_idx = script.index("export UV_PYTHON=/usr/bin/python3", camera_branch_idx)
+    server_start_idx = script.index("uv run ${OPENFLIGHT_UV_RUN_ARGS:-} $SERVER_CMD &")
+
     assert "uv venv --clear --system-site-packages --python /usr/bin/python3" in script
     assert "UV_SYNC_ARGS+=(--extra camera)" in script
-    assert 'UV_PYTHON=/usr/bin/python3 uv sync "${UV_SYNC_ARGS[@]}"' in script
+    assert 'uv sync "${UV_SYNC_ARGS[@]}"' in script
+    assert camera_branch_idx < export_idx < camera_else_idx < server_start_idx
 
 
 def test_shutdown_requests_server_cleanup_before_forcing_process_exit():


### PR DESCRIPTION
## What does this PR do?

- Exports UV_PYTHON=/usr/bin/python3 for the complete camera-mode startup path.
- Keeps the Raspberry Pi OS system-site-packages environment ABI-compatible through dependency sync and the final server launch.
- Adds a regression test that verifies the camera branch uses the exported system Python before its own uv sync and before server startup.

## Why was this required?

Camera startup created the virtual environment with Raspberry Pi OS Python 3.13, but the interpreter selection previously applied only to uv sync. The final uv run could honor the repository Python 3.11 pin. That interpreter could see picamera2 but could not load the CPython 3.13 libcamera native extension, causing ModuleNotFoundError for libcamera._libcamera. Non-camera startup remains on the repository Python pin.

## Automated tests

- Updated tests/test_start_kiosk.py to assert export UV_PYTHON occurs before the camera-branch uv sync, its else branch, and final server launch.
- uv run pytest tests/test_start_kiosk.py -q: 31 passed.
- uv run ruff check tests/test_start_kiosk.py: passed.
- uv run ruff format --check tests/test_start_kiosk.py: passed.

## Manual (human) testing

- Ran bash -n scripts/start-kiosk.sh and confirmed the script parses successfully.
- Inspected the camera startup control flow to confirm UV_PYTHON remains exported for both uv sync and the final uv run.
- Raspberry Pi camera hardware was not available locally; final device validation remains pending on the affected Pi.

## Checklist

- [x] Single feature/fix
- [x] Automated tests included
- [x] Manual testing described
- [x] No unrelated changes mixed in